### PR TITLE
Fix `getToken` bug

### DIFF
--- a/Sources/API/Models/Session.swift
+++ b/Sources/API/Models/Session.swift
@@ -281,11 +281,9 @@ actor SessionTokenFetcher {
 
         tokenTasks[cacheKey] = task
         
-        let token = try await task.value
+        defer { tokenTasks[cacheKey] = nil }
         
-        tokenTasks[cacheKey] = nil
-        
-        return token
+        return try await task.value
     }
     
     /**


### PR DESCRIPTION
There is a bug which results in the cached token not being cleared in the event the operation fails. 
If the operation fails then all subsequent requests for the token result in the cached failure being returned each time.

This fix ensures that the cached value is always cleared upon success _and_ failure.