### PR TITLE
clear in flight token task on error

### DIFF
--- a/Sources/API/Models/Session.swift
+++ b/Sources/API/Models/Session.swift
@@ -281,11 +281,12 @@ actor SessionTokenFetcher {
 
         tokenTasks[cacheKey] = task
         
-        let token = try await task.value
-        
+        let result = await task.result
+
+        // clear the inProgressTask on success AND failure
         tokenTasks[cacheKey] = nil
         
-        return token
+        return try result.get()
     }
     
     /**


### PR DESCRIPTION
BUG: The in progress task was not being cleared if the `getToken` task threw an error.

This PR clears the in progress task on success AND failure.