### PR TITLE
Make UserButtonPopover public

### DIFF
--- a/Sources/UI/Components/User/UserButton/UserButtonPopover.swift
+++ b/Sources/UI/Components/User/UserButton/UserButtonPopover.swift
@@ -39,7 +39,9 @@ public struct UserButtonPopover: View {
             dump(error)
         }
     }
-        
+
+    public init() {}
+
     public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: .zero) {

--- a/Sources/UI/Components/User/UserButton/UserButtonPopover.swift
+++ b/Sources/UI/Components/User/UserButton/UserButtonPopover.swift
@@ -9,7 +9,7 @@
 
 import SwiftUI
 
-struct UserButtonPopover: View {
+public struct UserButtonPopover: View {
     @ObservedObject private var clerk = Clerk.shared
     @EnvironmentObject private var clerkUIState: ClerkUIState
     @Environment(\.clerkTheme) private var clerkTheme
@@ -40,7 +40,7 @@ struct UserButtonPopover: View {
         }
     }
         
-    var body: some View {
+    public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: .zero) {
                 if let currentSession = clerk.session, let user = currentSession.user {


### PR DESCRIPTION
### Motivation

Currently the SDK is designed around SwiftUI's lifecycle. Making the `UserButtonPopover` public would allow UIKit applications to benefit from the UI. e.g.

```swift           
let state = ClerkUIState()
let view = UserButtonPopover().environmentObject(state)
let viewController = UIHostingController(rootView: view)
self.navigationController?.present(viewController, animated: true)
```