### PR TITLE
Generate and push HTML documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,138 @@
+name: Generate Documentation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # Allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  generate-docs:
+    runs-on: macos-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Setup Swift
+      uses: swift-actions/setup-swift@v1
+      with:
+        swift-version: '5.9'
+        
+    - name: Cache Swift packages
+      uses: actions/cache@v3
+      with:
+        path: .build
+        key: ${{ runner.os }}-swift-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-swift-
+          
+    - name: Build package
+      run: swift build
+      
+    - name: Generate documentation
+      run: |
+        # Generate documentation for the Clerk target
+        swift package generate-documentation \
+          --target Clerk \
+          --disable-indexing \
+          --transform-for-static-hosting \
+          --hosting-base-path Clerk \
+          --output-path ./docs
+          
+    - name: Setup docs directory structure
+      run: |
+        # Create a clean docs directory structure
+        mkdir -p ./docs-output
+        
+        # Copy the generated documentation
+        if [ -d "./docs" ]; then
+          cp -r ./docs/* ./docs-output/
+        fi
+        
+        # Create index.html if it doesn't exist
+        if [ ! -f "./docs-output/index.html" ]; then
+          cat > ./docs-output/index.html << 'EOF'
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>Clerk Documentation</title>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <style>
+                body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 40px; }
+                .header { text-align: center; margin-bottom: 40px; }
+                .links { display: flex; justify-content: center; gap: 20px; flex-wrap: wrap; }
+                .link { padding: 10px 20px; background: #007AFF; color: white; text-decoration: none; border-radius: 8px; }
+                .link:hover { background: #0056CC; }
+            </style>
+        </head>
+        <body>
+            <div class="header">
+                <h1>Clerk Documentation</h1>
+                <p>Swift Package Documentation</p>
+            </div>
+            <div class="links">
+                <a href="./documentation/clerk/" class="link">Browse Documentation</a>
+            </div>
+        </body>
+        </html>
+        EOF
+        fi
+        
+    - name: Deploy to docs branch
+      if: github.ref == 'refs/heads/main'
+      run: |
+        # Configure git
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        
+        # Create/checkout docs branch
+        git checkout --orphan docs || git checkout docs
+        
+        # Remove all files except docs-output
+        git rm -rf . 2>/dev/null || true
+        
+        # Copy documentation files to root
+        cp -r ./docs-output/* . 2>/dev/null || true
+        
+        # Add and commit all documentation files
+        git add .
+        
+        # Check if there are changes to commit
+        if git diff --staged --quiet; then
+          echo "No changes to commit"
+          exit 0
+        fi
+        
+        git commit -m "📚 Update documentation ($(date '+%Y-%m-%d %H:%M:%S'))"
+        
+        # Push to docs branch
+        git push origin docs --force
+        
+    - name: Comment on PR with docs link
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { owner, repo } = context.repo;
+          const prNumber = context.payload.pull_request.number;
+          
+          const comment = `📚 **Documentation Preview**
+          
+          Documentation has been generated for this PR. Once merged to main, it will be available at:
+          https://${owner}.github.io/${repo}/
+          
+          The documentation includes:
+          - API reference for the Clerk Swift package
+          - Code examples and usage guides
+          - Generated from the latest code changes`;
+          
+          await github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: prNumber,
+            body: comment
+          });

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,14 @@
-name: Generate Documentation
+THIS SHOULD BE A LINTER ERRORname: Generate Documentation
 
 on:
+  # Trigger on new releases
+  release:
+    types: [published]
+  # Trigger on new tags (alternative to release)
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    tags:
+      - 'v*.*.*'
+      - '*.*.*'
   # Allow manual trigger
   workflow_dispatch:
 

--- a/DOCS_WORKFLOW.md
+++ b/DOCS_WORKFLOW.md
@@ -1,0 +1,96 @@
+# Documentation Generation Workflow
+
+This repository now includes a GitHub Action workflow that automatically generates HTML documentation from the Swift Package Interface (SPI) and deploys it to a dedicated `docs` branch.
+
+## How It Works
+
+The workflow (`.github/workflows/docs.yml`) performs the following steps:
+
+### 1. **Triggers**
+- **Push to main**: Automatically generates and deploys documentation when code is pushed to the main branch
+- **Pull Requests**: Generates documentation for preview (but doesn't deploy)
+- **Manual Trigger**: Can be manually triggered via GitHub Actions UI
+
+### 2. **Documentation Generation**
+- Uses **Swift-DocC** (Swift Documentation Compiler) to generate HTML documentation
+- Targets the `Clerk` Swift package as specified in `.spi.yml`
+- Generates static HTML files optimized for hosting
+
+### 3. **Deployment Process**
+- Creates/updates an **orphan branch** called `docs`
+- The `docs` branch contains **only** the generated HTML documentation (no source code)
+- Pushes the latest documentation to this branch
+- Force-pushes to ensure clean state on each update
+
+### 4. **Features**
+- **Automatic indexing**: Creates a landing page with links to documentation
+- **Static hosting ready**: Documentation is optimized for static hosting (GitHub Pages, etc.)
+- **PR previews**: Comments on pull requests with documentation preview information
+- **Caching**: Uses Swift package caching for faster builds
+
+## Generated Documentation Structure
+
+The `docs` branch will contain:
+```
+docs/
+├── index.html              # Landing page
+├── documentation/
+│   └── clerk/             # Main documentation
+│       ├── index.html     # Package overview
+│       ├── classes/       # Class documentation
+│       ├── structs/       # Struct documentation
+│       ├── enums/         # Enum documentation
+│       └── protocols/     # Protocol documentation
+├── css/                   # Styling files
+├── js/                    # JavaScript files
+└── data/                  # Documentation data files
+```
+
+## Setting Up GitHub Pages (Optional)
+
+To make your documentation publicly accessible:
+
+1. Go to your repository **Settings** → **Pages**
+2. Under "Source", select **Deploy from a branch**
+3. Choose **docs** branch and **/ (root)** folder
+4. Click **Save**
+
+Your documentation will be available at: `https://[username].github.io/[repository-name]/`
+
+## Manual Workflow Execution
+
+You can manually trigger the documentation generation:
+1. Go to **Actions** tab in your repository
+2. Select **Generate Documentation** workflow
+3. Click **Run workflow**
+4. Choose the branch and click **Run workflow**
+
+## Workflow Configuration
+
+The workflow is configured to:
+- Run on **macOS** (required for Swift-DocC)
+- Use **Swift 5.9** (matches your Package.swift)
+- Cache Swift packages for faster builds
+- Only deploy to `docs` branch from `main` branch pushes
+
+## Troubleshooting
+
+### Common Issues:
+- **Build failures**: Ensure all dependencies are properly defined in `Package.swift`
+- **Missing documentation**: Add DocC comments (`///`) to your Swift code
+- **Deploy failures**: Check repository permissions for GitHub Actions
+
+### Requirements:
+- Repository must have Actions enabled
+- Branch protection rules shouldn't prevent force-pushes to `docs` branch
+- Swift package must build successfully
+
+## Customization
+
+You can customize the workflow by:
+- Modifying the `--hosting-base-path` in the documentation generation step
+- Changing the landing page content in the "Setup docs directory structure" step
+- Adjusting the PR comment template
+- Adding additional Swift-DocC flags as needed
+
+The workflow is designed to work with your existing `.spi.yml` configuration and will automatically detect and document all public APIs in your Swift package.


### PR DESCRIPTION
Add a GitHub Action to automatically generate Swift-DocC HTML documentation and push it to a dedicated `docs` branch.

---

[Slack Thread](https://clerkinc.slack.com/archives/C08SE0321GR/p1752041424007469?thread_ts=1752041424.007469&cid=C08SE0321GR)