### PR TITLE
Add oauth2 identity provider methods to ios sdk

### DIFF
--- a/Sources/Clerk/Models/OAuth2IdentityProviderService.swift
+++ b/Sources/Clerk/Models/OAuth2IdentityProviderService.swift
@@ -1,0 +1,65 @@
+//
+//  OAuth2IdentityProviderService.swift
+//  Clerk
+//
+//  Created by Cursor on 11/4/25.
+//
+
+import FactoryKit
+import Foundation
+import Get
+
+extension Container {
+
+    var oauth2IdentityProviderService: Factory<OAuth2IdentityProviderService> {
+        self { OAuth2IdentityProviderService() }
+    }
+
+}
+
+/// Service for interacting with Clerk's OAuth2 Identity Provider Frontend API endpoints.
+struct OAuth2IdentityProviderService {
+
+    /// Obtain an OAuth 2.0 token for a configured Identity Provider connection.
+    ///
+    /// - Parameter parameters: Arbitrary token request parameters. Common keys include
+    ///   `grant_type`, `connection_id` or `provider`, `scope`, `audience`, `resource`, etc.
+    ///   Keys should be provided in snake_case as they will be URL-encoded as-is.
+    ///
+    /// - Returns: ``OAuth2TokenResponse``
+    ///
+    /// - Note: The request body is sent as `application/x-www-form-urlencoded` with `_is_native=true` appended
+    ///   as a query parameter automatically by the API client.
+    var obtainToken: @MainActor (_ parameters: [String: String]) async throws -> OAuth2TokenResponse = { parameters in
+        let request = Request<OAuth2TokenResponse>.init(
+            path: "/v1/oauth/token",
+            method: .post,
+            body: parameters
+        )
+
+        return try await Container.shared.apiClient().send(request).value
+    }
+}
+
+extension Clerk {
+
+    /// Obtain an OAuth 2.0 token from a configured OAuth2 Identity Provider connection.
+    ///
+    /// - Parameter parameters: Arbitrary token request parameters. Common keys include
+    ///   `grant_type`, `connection_id` or `provider`, `scope`, `audience`, `resource`, etc.
+    ///
+    /// - Returns: ``OAuth2TokenResponse``
+    ///
+    /// - Example:
+    /// ```swift
+    /// let token = try await clerk.obtainOAuth2Token(parameters: [
+    ///   "grant_type": "client_credentials",
+    ///   "connection_id": "con_123",
+    ///   "scope": "read:all"
+    /// ])
+    /// ```
+    @discardableResult @MainActor
+    public func obtainOAuth2Token(parameters: [String: String]) async throws -> OAuth2TokenResponse {
+        try await Container.shared.oauth2IdentityProviderService().obtainToken(parameters)
+    }
+}

--- a/Sources/Clerk/Models/OAuth2TokenResponse.swift
+++ b/Sources/Clerk/Models/OAuth2TokenResponse.swift
@@ -1,0 +1,56 @@
+//
+//  OAuth2TokenResponse.swift
+//  Clerk
+//
+//  Created by Cursor on 11/4/25.
+//
+
+import Foundation
+
+/// Standard OAuth 2.0 token response returned from Clerk's OAuth2 Identity Provider endpoint.
+///
+/// This structure models the most common fields defined by RFC 6749 and
+/// is intentionally general so it can be used with any configured OAuth2
+/// Identity Provider connection in Clerk.
+public struct OAuth2TokenResponse: Codable, Equatable, Sendable {
+
+    /// The access token issued by the authorization server.
+    public let accessToken: String
+
+    /// The type of the token issued.
+    public let tokenType: String
+
+    /// The lifetime in seconds of the access token.
+    public let expiresIn: Int?
+
+    /// A refresh token used to obtain a new access token (if issued).
+    public let refreshToken: String?
+
+    /// The scope of the access token (if different from the requested one).
+    public let scope: String?
+
+    /// If the provider returns an ID token (OIDC), it will be included here.
+    public let idToken: String?
+
+    public init(
+        accessToken: String,
+        tokenType: String,
+        expiresIn: Int? = nil,
+        refreshToken: String? = nil,
+        scope: String? = nil,
+        idToken: String? = nil
+    ) {
+        self.accessToken = accessToken
+        self.tokenType = tokenType
+        self.expiresIn = expiresIn
+        self.refreshToken = refreshToken
+        self.scope = scope
+        self.idToken = idToken
+    }
+}
+
+extension OAuth2TokenResponse {
+    static var mock: OAuth2TokenResponse {
+        .init(accessToken: "access_token", tokenType: "Bearer", expiresIn: 3600, refreshToken: "refresh_token", scope: "read:all", idToken: "id_token")
+    }
+}

--- a/Tests/OAuth2IdentityProviderTests.swift
+++ b/Tests/OAuth2IdentityProviderTests.swift
@@ -1,0 +1,56 @@
+import FactoryKit
+import Foundation
+import Mocker
+import Testing
+
+@testable import Clerk
+
+@Suite(.serialized) struct OAuth2IdentityProviderTests {
+
+  init() {
+    // Ensure mocked API client is used (auto-registered via TestUtilities)
+    Container.shared.reset(context: .test)
+  }
+
+  deinit {
+    Container.shared.reset()
+  }
+
+  @MainActor
+  @Test func testObtainTokenRequest() async throws {
+    let originalUrl = mockBaseUrl.appending(path: "/v1/oauth/token")
+
+    var requestHandled = false
+
+    var mock = Mock(
+      url: originalUrl, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: try! JSONEncoder.clerkEncoder.encode(OAuth2TokenResponse.mock)
+      ])
+
+    mock.onRequestHandler = OnRequestHandler { request in
+      #expect(request.httpMethod == "POST")
+      // Body should be URL-encoded and contain our parameters
+      if let body = request.httpBody, let bodyString = String(data: body, encoding: .utf8) {
+        #expect(bodyString.contains("grant_type=client_credentials"))
+        #expect(bodyString.contains("connection_id=con_123"))
+      } else {
+        Issue.record("Request body missing")
+      }
+
+      requestHandled = true
+    }
+
+    mock.register()
+
+    let params: [String: String] = [
+      "grant_type": "client_credentials",
+      "connection_id": "con_123",
+      "scope": "read:all"
+    ]
+
+    let token = try await Clerk.shared.obtainOAuth2Token(parameters: params)
+    #expect(token.accessToken == OAuth2TokenResponse.mock.accessToken)
+    #expect(requestHandled)
+  }
+}


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-a90d4a75-93cd-4889-a26b-267dc4dd1a64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a90d4a75-93cd-4889-a26b-267dc4dd1a64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

