### PR TITLE
apple watch support

### DIFF
--- a/Sources/Clerk/Models/Clerk/Clerk.swift
+++ b/Sources/Clerk/Models/Clerk/Clerk.swift
@@ -136,7 +136,8 @@ final public class Clerk {
                 SimpleKeychain(
                     service: keychainConfig.service,
                     accessGroup: keychainConfig.accessGroup,
-                    accessibility: .afterFirstUnlockThisDeviceOnly
+                    accessibility: keychainConfig.accessibility,
+                    synchronizable: keychainConfig.synchronizable
                 )
             }
 

--- a/Sources/Clerk/Models/Clerk/Settings/KeychainConfig.swift
+++ b/Sources/Clerk/Models/Clerk/Settings/KeychainConfig.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SimpleKeychain
 
 /// A configuration object that can be passed to `Clerk.configure()` to customize keychain behavior.
 public struct KeychainConfig: Sendable {
@@ -16,15 +17,27 @@ public struct KeychainConfig: Sendable {
     /// Access group for sharing Keychain items.
     public let accessGroup: String?
 
+    /// Accessibility type the stored items will have
+    public let accessibility: Accessibility
+
+    /// Whether the items should be synchronized through iCloud
+    public let synchronizable: Bool
+
     /// Initializes a ``KeychainConfig`` instance.
     /// - Parameters:
     ///   - service: Name of the service under which to save items. Defaults to the bundle identifier.
     ///   - accessGroup: Access group for sharing Keychain items.
+    ///   - accessibility: ``Accessibility`` type the stored items will have
+    ///   - synchronizable: Whether the items should be synchronized through iCloud
     public init(
         service: String = Bundle.main.bundleIdentifier ?? "",
-        accessGroup: String? = nil
+        accessGroup: String? = nil,
+        accessibility: Accessibility = .afterFirstUnlockThisDeviceOnly,
+        synchronizable: Bool = false
     ) {
         self.service = service
         self.accessGroup = accessGroup
+        self.accessibility = accessibility
+        self.synchronizable = synchronizable
     }
 }


### PR DESCRIPTION
Support synchronizing auth state between multiple devices, including between an iPhone and an Apple Watch.  This enables an iOS app to be used to sign-in and the auth state to then be synchronized with an Apple Watch that shares the same service and app group

Here's an example for using the new feature:

```
import Clerk
import SimpleKeychain

  let settings = Clerk.Settings(
    keychainConfig: .init(
      service: keychainService,
      accessGroup: keychainAccessGroup,
      accessibility: .afterFirstUnlock,
      synchronizable: true
    ))
  clerk.configure(publishableKey: "clerk_publishable_key", settings: settings)
```