### PR TITLE
Remove toggle tint from default themes

### DIFF
--- a/Sources/Clerk/ClerkUI/Components/Auth/SignIn/SignInSetNewPasswordView.swift
+++ b/Sources/Clerk/ClerkUI/Components/Auth/SignIn/SignInSetNewPasswordView.swift
@@ -26,10 +26,6 @@ struct SignInSetNewPasswordView: View {
     var resetButtonIsDisabled: Bool {
         authState.signInNewPassword.isEmptyTrimmed || authState.signInConfirmNewPassword.isEmptyTrimmed || authState.signInNewPassword != authState.signInConfirmNewPassword
     }
-    
-    private var isDefaultTheme: Bool {
-        theme.colors.primary == ClerkTheme.Colors.defaultPrimaryColor
-    }
 
     enum Field {
         case new, confirm
@@ -83,26 +79,13 @@ struct SignInSetNewPasswordView: View {
                         }
                     }
 
-                    Group {
-                        if isDefaultTheme {
-                            Toggle("Sign out of all other devices", isOn: $signOutOfOtherDevices)
-                                .font(theme.fonts.body)
-                                .foregroundStyle(theme.colors.foreground)
-                                .padding(.horizontal, 16)
-                                .padding(.vertical, 8)
-                                .background(theme.colors.muted)
-                                .clipShape(.rect(cornerRadius: theme.design.borderRadius))
-                        } else {
-                            Toggle("Sign out of all other devices", isOn: $signOutOfOtherDevices)
-                                .font(theme.fonts.body)
-                                .foregroundStyle(theme.colors.foreground)
-                                .tint(theme.colors.primary)
-                                .padding(.horizontal, 16)
-                                .padding(.vertical, 8)
-                                .background(theme.colors.muted)
-                                .clipShape(.rect(cornerRadius: theme.design.borderRadius))
-                        }
-                    }
+                    Toggle("Sign out of all other devices", isOn: $signOutOfOtherDevices)
+                        .font(theme.fonts.body)
+                        .foregroundStyle(theme.colors.foreground)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(theme.colors.muted)
+                        .clipShape(.rect(cornerRadius: theme.design.borderRadius))
 
                     AsyncButton {
                         await setNewPassword()

--- a/Sources/Clerk/ClerkUI/Components/UserProfile/UserProfileChangePasswordView.swift
+++ b/Sources/Clerk/ClerkUI/Components/UserProfile/UserProfileChangePasswordView.swift
@@ -42,10 +42,6 @@ struct UserProfileChangePasswordView: View {
     var user: User? { clerk.user }
 
     var isAddingPassword: Bool = false
-    
-    private var isDefaultTheme: Bool {
-        theme.colors.primary == ClerkTheme.Colors.defaultPrimaryColor
-    }
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -184,20 +180,10 @@ struct UserProfileChangePasswordView: View {
     @ViewBuilder
     private var signOutOfOtherDevicesView: some View {
         VStack(spacing: 8) {
-            Group {
-                if isDefaultTheme {
-                    Toggle("Sign out of all other devices", isOn: $signOutOfOtherSessions)
-                        .font(theme.fonts.body)
-                        .foregroundStyle(theme.colors.foreground)
-                        .frame(minHeight: 22)
-                } else {
-                    Toggle("Sign out of all other devices", isOn: $signOutOfOtherSessions)
-                        .font(theme.fonts.body)
-                        .foregroundStyle(theme.colors.foreground)
-                        .tint(theme.colors.primary)
-                        .frame(minHeight: 22)
-                }
-            }
+            Toggle("Sign out of all other devices", isOn: $signOutOfOtherSessions)
+                .font(theme.fonts.body)
+                .foregroundStyle(theme.colors.foreground)
+                .frame(minHeight: 22)
 
             Text("It is recommended to sign out of all other devices which may have used your old password.", bundle: .module)
                 .font(theme.fonts.subheadline)


### PR DESCRIPTION
Remove explicit tint color from 'Sign out of all other devices' toggles to use system default.

---
<a href="https://cursor.com/background-agent?bcId=bc-badfa0b3-404c-4d3a-a3ff-e24d67da4ab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-badfa0b3-404c-4d3a-a3ff-e24d67da4ab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

