### PR TITLE
Update ios sdk api version

### DIFF
--- a/Sources/Clerk/Models/Clerk/Clerk.swift
+++ b/Sources/Clerk/Models/Clerk/Clerk.swift
@@ -387,7 +387,7 @@ extension Clerk {
                 configuration.encoder = .clerkEncoder
                 configuration.sessionConfiguration.httpAdditionalHeaders = [
                     "Content-Type": "application/x-www-form-urlencoded",
-                    "clerk-api-version": "2025-04-10",
+                    "clerk-api-version": "2025-11-10",
                     "x-ios-sdk-version": Clerk.version,
                     "x-mobile": "1"
                 ]

--- a/Tests/TestUtilities/MockAPIClient.swift
+++ b/Tests/TestUtilities/MockAPIClient.swift
@@ -25,7 +25,7 @@ extension Container: @retroactive AutoRegistering {
             configuration.sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
             configuration.sessionConfiguration.httpAdditionalHeaders = [
                 "Content-Type": "application/x-www-form-urlencoded",
-                "clerk-api-version": "2024-10-01",
+                "clerk-api-version": "2025-11-10",
                 "x-ios-sdk-version": Clerk.version,
                 "x-mobile": "1"
             ]


### PR DESCRIPTION
Update the iOS SDK to target Clerk API version 2025-11-10.

This aligns the SDK with the latest backend changes, which are billing-related and expected to be safe to update.

---
Linear Issue: [MOBILE-320](https://linear.app/clerk/issue/MOBILE-320/ios-update-api-version-to-2025-11-10)

<a href="https://cursor.com/background-agent?bcId=bc-75e55dda-c484-426a-a0d9-f4011a0821ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-75e55dda-c484-426a-a0d9-f4011a0821ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

