### PR TITLE
Add vercel as oauth provider

### DIFF
--- a/Sources/Clerk/Models/OAuthProvider.swift
+++ b/Sources/Clerk/Models/OAuthProvider.swift
@@ -36,6 +36,7 @@ public enum OAuthProvider: CaseIterable, Codable, Sendable, Equatable, Identifia
     case slack
     case linear
     case huggingFace
+    case vercel
     case custom(_ strategy: String)
 
     // **
@@ -70,7 +71,8 @@ public enum OAuthProvider: CaseIterable, Codable, Sendable, Equatable, Identifia
             .box,
             .slack,
             .linear,
-            .huggingFace
+            .huggingFace,
+            .vercel
         ]
     }
 
@@ -315,6 +317,12 @@ public enum OAuthProvider: CaseIterable, Codable, Sendable, Equatable, Identifia
                 provider: "huggingface",
                 strategy: "oauth_huggingface",
                 name: "Hugging Face"
+            )
+        case .vercel:
+            return .init(
+                provider: "vercel",
+                strategy: "oauth_vercel",
+                name: "Vercel"
             )
         }
     }


### PR DESCRIPTION
This pull request adds support for the Vercel OAuth provider to the `OAuthProvider` enum in the authentication models. The changes ensure that Vercel is now recognized as a valid OAuth provider throughout the codebase.

New OAuth provider support:

* Added `.vercel` case to the `OAuthProvider` enum.
* Included `.vercel` in the `allCases` array so it is recognized as a supported provider.
* Implemented the `.vercel` case in the provider details mapping, returning the correct provider information for Vercel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vercel as an available OAuth provider for user authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->