### PR TITLE
Fix preview mock behavior and migrate to handler style

### DIFF
--- a/Sources/ClerkKit/Mocks/Clerk+Mocks.swift
+++ b/Sources/ClerkKit/Mocks/Clerk+Mocks.swift
@@ -7,41 +7,34 @@
 
 import Foundation
 
-/// Builder for configuring mock services and environment in previews and tests.
+/// Builder for configuring mock services in previews and tests.
 ///
-/// Use this builder to configure custom behaviors for service methods and environment properties.
+/// Use this builder to configure custom behaviors for service methods.
 /// You can modify handler properties directly on the default services or replace entire services.
 ///
 /// Example:
 /// ```swift
-/// // Modify handler properties directly (recommended)
-/// builder.signInService.createHandler = { _, _ in
-///   try? await Task.sleep(for: .seconds(2))
-///   return .mock
+/// Clerk.preview { builder in
+///   // Modify handler properties directly (recommended)
+///   builder.services.signInService.createHandler = { _, _ in
+///     try? await Task.sleep(for: .seconds(2))
+///     return .mock
+///   }
+///
+///   builder.services.userService.getSessionsHandler = { user in
+///     try? await Task.sleep(for: .seconds(1))
+///     return [Session.mock, Session.mock2]
+///   }
+///
+///   // Or replace entire services
+///   builder.services.clientService = MockClientService {
+///     try? await Task.sleep(for: .seconds(1))
+///     return Client.mock
+///   }
 /// }
-///
-/// builder.userService.getSessionsHandler = { user in
-///   try? await Task.sleep(for: .seconds(1))
-///   return [Session.mock, Session.mock2]
-/// }
-///
-/// // Or replace entire services
-/// builder.clientService = MockClientService {
-///   try? await Task.sleep(for: .seconds(1))
-///   return Client.mock
-/// }
-///
-/// // Load environment from JSON file (recommended for previews)
-/// let url = Bundle.main.url(forResource: "environment", withExtension: "json")!
-/// builder.environment = try! Clerk.Environment(fromFile: url)
-///
-/// // Customize client properties like sessions
-/// var client = Client.mock
-/// client.sessions = [Session.mock, Session.mock2]
-/// builder.client = client
 /// ```
 @MainActor
-package final class MockBuilder {
+package final class MockServicesBuilder {
   /// Mock client service for customizing `clerk.refreshClient()` behavior.
   /// You can modify handler properties directly or replace the entire service.
   package var clientService: MockClientService = .init()
@@ -86,169 +79,9 @@ package final class MockBuilder {
   /// You can modify handler properties directly or replace the entire service.
   package var externalAccountService: MockExternalAccountService = .init()
 
-  /// Custom mock environment for configuring environment properties.
-  /// If set, this environment will be used instead of the default `.mock` environment.
-  ///
-  /// The recommended approach is to load your environment from a JSON file:
-  /// ```swift
-  /// let url = Bundle.main.url(forResource: "environment", withExtension: "json")!
-  /// builder.environment = try! Clerk.Environment(fromFile: url)
-  /// ```
-  package var environment: Clerk.Environment?
-
-  /// Custom mock client for configuring client properties like sessions and user data.
-  /// If set, this client will be used instead of the default `.mock` client.
-  /// Assign a `Client` instance to configure it.
-  ///
-  /// Example:
-  /// ```swift
-  /// var client = Client.mock
-  /// client.sessions = [Session.mock, Session.mock2]
-  /// builder.client = client
-  /// ```
-  package var client: Client?
-
-  /// Creates a new mock builder.
+  /// Creates a new mock services builder.
   ///
   /// All services are pre-initialized with default mock implementations.
   /// You can modify handler properties directly or replace entire services in the configuration closure.
   package init() {}
-}
-
-package extension Clerk {
-  /// Configures Clerk.shared with mock services and environment.
-  ///
-  /// This function allows you to inject custom mock services (like `MockClientService`) and configure
-  /// environment properties to control behavior without making real API calls. This is useful for SwiftUI previews
-  /// and testing scenarios.
-  ///
-  /// **Important:** This function only works when compiled with DEBUG configuration. In release builds,
-  /// it returns `Clerk.shared` if already configured, or configures Clerk with an empty publishable key.
-  ///
-  /// - Parameters:
-  ///   - builder: An optional closure that receives a `MockBuilder` for configuring mock services, environment, and client.
-  ///                        If not provided, all services, environment, and client will use their default mock implementations.
-  ///
-  /// Example:
-  /// ```swift
-  /// // Use default mock services
-  /// Clerk.configureWithMocks()
-  ///
-  /// // Or customize specific service handlers
-  /// Clerk.configureWithMocks { builder in
-  ///   builder.signInService.createHandler = { _, _ in
-  ///     try? await Task.sleep(for: .seconds(2))
-  ///     return .mock
-  ///   }
-  ///
-  ///   builder.userService.getSessionsHandler = { user in
-  ///     try? await Task.sleep(for: .seconds(1))
-  ///     return [Session.mock, Session.mock2]
-  ///   }
-  /// }
-  ///
-  /// // Load environment from JSON file for previews
-  /// Clerk.configureWithMocks { builder in
-  ///   let url = Bundle.main.url(forResource: "environment", withExtension: "json")!
-  ///   builder.environment = try! Clerk.Environment(fromFile: url)
-  ///
-  ///   // Customize client
-  ///   var client = Client.mock
-  ///   client.sessions = [Session.mock, Session.mock2]
-  ///   builder.client = client
-  /// }
-  /// ```
-  ///
-  /// To reuse a mock configuration across multiple previews, create a helper function:
-  /// ```swift
-  /// @MainActor
-  /// func createPreviewClerk() -> Clerk {
-  ///   Clerk.configureWithMocks { builder in
-  ///     let url = Bundle.main.url(forResource: "environment", withExtension: "json")!
-  ///     builder.environment = try! Clerk.Environment(fromFile: url)
-  ///   }
-  /// }
-  ///
-  /// #Preview {
-  ///   MyView()
-  ///     .environment(createPreviewClerk())
-  /// }
-  /// ```
-  @MainActor
-  @discardableResult
-  static func configureWithMocks(
-    builder: ((MockBuilder) -> Void)? = nil
-  ) -> Clerk {
-    #if DEBUG
-    // Configure Clerk.shared if not already configured
-    let clerk = Clerk.configure(publishableKey: "pk_test_bW9jay5jbGVyay5hY2NvdW50cy5kZXYk")
-
-    // Create a minimal API client (won't be used if services are mocked)
-    let mockBaseURL = URL(string: "https://mock.clerk.accounts.dev")!
-    let mockAPIClient = APIClient(baseURL: mockBaseURL)
-
-    // Create mock builder
-    let mockBuilder = MockBuilder()
-
-    // Try to load ClerkEnvironment.json from bundle, fall back to .mock if it fails
-    if let url = Bundle.main.url(forResource: "ClerkEnvironment", withExtension: "json"),
-       let environment = try? Clerk.Environment(fromFile: url)
-    {
-      mockBuilder.environment = environment
-    }
-
-    builder?(mockBuilder)
-
-    // Determine which environment to use: custom from builder, or default .mock
-    let mockEnvironment = mockBuilder.environment ?? .mock
-
-    // Determine which client to use: custom from builder, or default .mock
-    let mockClient = mockBuilder.client ?? .mock
-
-    // If builder has a custom environment, update the environmentService to return it
-    let environmentService: MockEnvironmentService = if mockBuilder.environment != nil {
-      MockEnvironmentService {
-        mockEnvironment
-      }
-    } else {
-      mockBuilder.environmentService
-    }
-
-    // If builder has a custom client, update the clientService to return it
-    let clientService: MockClientService = if mockBuilder.client != nil {
-      MockClientService {
-        mockClient
-      }
-    } else {
-      mockBuilder.clientService
-    }
-
-    // Create mock dependency container with mock services
-    let container = MockDependencyContainer(
-      apiClient: mockAPIClient,
-      clientService: clientService,
-      userService: mockBuilder.userService,
-      signInService: mockBuilder.signInService,
-      signUpService: mockBuilder.signUpService,
-      sessionService: mockBuilder.sessionService,
-      passkeyService: mockBuilder.passkeyService,
-      organizationService: mockBuilder.organizationService,
-      environmentService: environmentService,
-      emailAddressService: mockBuilder.emailAddressService,
-      phoneNumberService: mockBuilder.phoneNumberService,
-      externalAccountService: mockBuilder.externalAccountService
-    )
-
-    // Replace dependencies with mock services
-    clerk.dependencies = container
-    clerk._auth = nil // Force auth to reinitialize with new mock services
-    clerk.client = mockClient
-    clerk.environment = mockEnvironment
-
-    return clerk
-    #else
-    // In release builds, return Clerk.shared
-    return Clerk.shared
-    #endif
-  }
 }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -371,55 +371,51 @@ extension UserProfileView {
 
 #Preview("Dismissable") {
   UserProfileView()
-    .clerkPreview { builder in
-      builder.clientService = MockClientService(
-        get: {
+    .environment(
+      Clerk.preview { builder in
+        builder.services.clientService.getHandler = {
           try? await Task.sleep(for: .seconds(1))
           return Client.mock
         }
-      )
 
-      builder.environmentService = MockEnvironmentService(
-        get: {
+        builder.services.environmentService.getHandler = {
           try? await Task.sleep(for: .seconds(1))
           return Clerk.Environment.mock
         }
-      )
 
-      builder.userService = MockUserService(
-        getSessions: { _ in
+        builder.services.userService.getSessionsHandler = { _ in
           try? await Task.sleep(for: .seconds(1))
           return [Session.mock, Session.mock2]
         }
-      )
-    }
+      }
+    )
+    .environment(AuthState())
+    .environment(UserProfileView.SharedState())
     .environment(\.clerkTheme, .clerk)
 }
 
 #Preview("Not dismissable") {
   UserProfileView(isDismissable: false)
-    .clerkPreview { builder in
-      builder.clientService = MockClientService(
-        get: {
+    .environment(
+      Clerk.preview { builder in
+        builder.services.clientService.getHandler = {
           try? await Task.sleep(for: .seconds(1))
           return Client.mock
         }
-      )
 
-      builder.environmentService = MockEnvironmentService(
-        get: {
+        builder.services.environmentService.getHandler = {
           try? await Task.sleep(for: .seconds(1))
           return Clerk.Environment.mock
         }
-      )
 
-      builder.userService = MockUserService(
-        getSessions: { _ in
+        builder.services.userService.getSessionsHandler = { _ in
           try? await Task.sleep(for: .seconds(1))
           return [Session.mock, Session.mock2]
         }
-      )
-    }
+      }
+    )
+    .environment(AuthState())
+    .environment(UserProfileView.SharedState())
     .environment(\.clerkTheme, .clerk)
 }
 

--- a/Sources/ClerkKitUI/Extensions/View+PreviewMocks.swift
+++ b/Sources/ClerkKitUI/Extensions/View+PreviewMocks.swift
@@ -10,10 +10,6 @@
 import ClerkKit
 import SwiftUI
 
-/// Preview test publishable key that decodes to mock.clerk.accounts.dev
-/// Used for configuring Clerk.shared in SwiftUI previews.
-private let previewTestPublishableKey = "pk_test_bW9jay5jbGVyay5hY2NvdW50cy5kZXYk"
-
 package extension View {
   /// Injects mock environment values for previews.
   ///
@@ -40,47 +36,6 @@ package extension View {
       // Configure Clerk.shared so views that access it directly don't fail
       let clerk = Clerk.preview { builder in
         builder.isSignedIn = isSignedIn
-      }
-
-      return AnyView(
-        environment(clerk)
-          .environment(AuthState())
-          .environment(UserProfileView.SharedState())
-      )
-    }
-    return AnyView(self)
-  }
-
-  /// Preview with custom mock service behaviors.
-  ///
-  /// This modifier allows you to configure mock services (like `refreshClient()`) to have custom behaviors
-  /// such as delays or custom return values. This is useful for testing loading states and async behavior.
-  ///
-  /// - Parameter configureServices: A closure that receives a `MockBuilder` for configuring mock services.
-  ///
-  /// **Important:** This modifier only works when running in SwiftUI previews. When used outside of previews,
-  /// it returns the view unchanged without applying any mock configuration.
-  ///
-  /// Usage:
-  /// ```swift
-  /// #Preview {
-  ///     MyView()
-  ///         .clerkPreview { builder in
-  ///             builder.clientService = MockClientService {
-  ///                 try? await Task.sleep(for: .seconds(1))
-  ///                 return Client.mock
-  ///             }
-  ///         }
-  /// }
-  /// ```
-  @MainActor
-  func clerkPreview(preview: @escaping (MockBuilder) -> Void) -> some View {
-    if EnvironmentDetection.isRunningInPreviews {
-      // Configure Clerk.shared with mock services (using default preview publishable key)
-      // Note: This still uses configureWithMocks internally for advanced customization
-      let clerk = Clerk.configureWithMocks { builder in
-        // Allow user's closure to override or further configure
-        preview(builder)
       }
 
       return AnyView(


### PR DESCRIPTION
Fixed regression where PreviewBuilder.client, environment, and isSignedIn no longer influenced mock services. Migrated UserProfileView previews to cleaner handler property assignment style. Removed deprecated DEBUG-only configureWithMocks API in favor of PreviewBuilder.services.