### PR TITLE
Add image prefetching API for ClerkKitUI

### DIFF
--- a/Examples/Quickstart/Quickstart/QuickstartApp.swift
+++ b/Examples/Quickstart/Quickstart/QuickstartApp.swift
@@ -6,6 +6,7 @@
 //
 
 import ClerkKit
+import ClerkKitUI
 import SwiftUI
 
 @main
@@ -18,6 +19,7 @@ struct QuickstartApp: App {
     WindowGroup {
       ContentView()
         .environment(Clerk.shared)
+        .clerkImagePrefetching()
         .atlantisProxy()
     }
   }

--- a/Examples/WatchExampleApp/WatchExampleApp/WatchExampleApp.swift
+++ b/Examples/WatchExampleApp/WatchExampleApp/WatchExampleApp.swift
@@ -6,6 +6,7 @@
 //
 
 import ClerkKit
+import ClerkKitUI
 import SwiftUI
 
 @main
@@ -26,6 +27,7 @@ struct WatchExampleApp: App {
     WindowGroup {
       ContentView()
         .environment(Clerk.shared)
+        .clerkImagePrefetching()
         .atlantisProxy()
     }
   }

--- a/Sources/ClerkKitUI/Common/ClerkImagePrefetcher.swift
+++ b/Sources/ClerkKitUI/Common/ClerkImagePrefetcher.swift
@@ -1,0 +1,44 @@
+//
+//  ClerkImagePrefetcher.swift
+//  Clerk
+//
+
+#if os(iOS)
+
+import ClerkKit
+import Nuke
+
+/// Prefetches images used by ClerkKitUI components.
+@MainActor
+public enum ClerkImagePrefetcher {
+  private static let prefetcher = ImagePrefetcher()
+
+  /// Prefetch all images used by ClerkKitUI (OAuth icons, app logo).
+  /// Call this after Clerk environment is loaded.
+  public static func prefetchImages() {
+    guard let environment = Clerk.shared.environment else { return }
+
+    var urls: [URL] = []
+
+    // OAuth icons (light + dark variants)
+    for (_, config) in environment.userSettings.social where config.enabled {
+      if let logoUrl = config.logoUrl, !logoUrl.isEmpty {
+        if let url = URL(string: logoUrl) { urls.append(url) }
+        let darkUrl = logoUrl.replacingOccurrences(of: ".png", with: "-dark.png")
+        if let url = URL(string: darkUrl) { urls.append(url) }
+      }
+    }
+
+    // App logo
+    if let logoUrl = environment.displayConfig.logoImageUrl,
+       !logoUrl.isEmpty,
+       let url = URL(string: logoUrl)
+    {
+      urls.append(url)
+    }
+
+    prefetcher.startPrefetching(with: urls)
+  }
+}
+
+#endif

--- a/Sources/ClerkKitUI/Extensions/View+ImagePrefetching.swift
+++ b/Sources/ClerkKitUI/Extensions/View+ImagePrefetching.swift
@@ -1,0 +1,31 @@
+//
+//  View+ImagePrefetching.swift
+//  Clerk
+//
+
+#if os(iOS)
+
+import ClerkKit
+import SwiftUI
+
+private struct ClerkImagePrefetchingModifier: ViewModifier {
+  @Environment(Clerk.self) private var clerk
+
+  func body(content: Content) -> some View {
+    content
+      .task(id: clerk.environment) {
+        if clerk.environment != nil {
+          ClerkImagePrefetcher.prefetchImages()
+        }
+      }
+  }
+}
+
+public extension View {
+  /// Prefetches ClerkKitUI images when the Clerk environment loads.
+  func clerkImagePrefetching() -> some View {
+    modifier(ClerkImagePrefetchingModifier())
+  }
+}
+
+#endif


### PR DESCRIPTION
Provides `ClerkImagePrefetcher.prefetchImages()` to prefetch OAuth provider icons (including dark mode variants) and app logos from the Clerk environment. Includes a convenient `.clerkImagePrefetching()` view modifier that automatically prefetches when the environment loads.

Two usage options:
- Direct call: `ClerkImagePrefetcher.prefetchImages()`
- View modifier: `.clerkImagePrefetching()` on root view

Updated example apps to demonstrate the modifier usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)