### PR TITLE
Make buttons fill container width in SocialButtonLayout

### DIFF
--- a/Sources/ClerkKitUI/Common/SocialButtonLayout.swift
+++ b/Sources/ClerkKitUI/Common/SocialButtonLayout.swift
@@ -32,7 +32,9 @@ struct SocialButtonLayout: Layout {
     let itemsPerRow = maxFittingItemCount(containerWidth: containerWidth)
     let rowHeight = subviews.first?.sizeThatFits(.unspecified).height ?? 0
     let rowCount = Int(ceil(Double(subviews.count) / Double(itemsPerRow)))
-    let useMaxWidth = subviews.count <= itemsPerRow
+
+    // Calculate button width based on full row (fills container width)
+    let buttonWidth = (containerWidth - CGFloat(itemsPerRow - 1) * spacing) / CGFloat(itemsPerRow)
 
     for row in 0 ..< rowCount {
       let startIndex = row * itemsPerRow
@@ -40,14 +42,9 @@ struct SocialButtonLayout: Layout {
       let rowSubviews = subviews[startIndex ..< endIndex]
       let itemCount = rowSubviews.count
 
-      let buttonWidth: CGFloat = if useMaxWidth {
-        (containerWidth - CGFloat(itemCount - 1) * spacing) / CGFloat(itemCount)
-      } else {
-        minItemWidth
-      }
-
       let totalRowWidth = CGFloat(itemCount) * buttonWidth + CGFloat(itemCount - 1) * spacing
 
+      // Center partial rows, full rows naturally fill width
       let xOffset: CGFloat = switch alignment {
       case .leading:
         0


### PR DESCRIPTION
Before (Social buttons don't line up with leading and trailing edge of other views)
<img width="520" height="987" alt="Screenshot 2026-01-22 at 3 57 32 PM" src="https://github.com/user-attachments/assets/5dc01f2c-81bd-4e3a-81f7-666fc98a24d0" />

After (Social buttons now line up with leading and trailing edge of other views)
<img width="520" height="987" alt="Screenshot 2026-01-22 at 3 56 31 PM" src="https://github.com/user-attachments/assets/26997080-13ca-4af6-859c-5417159bde6f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved social button layout consistency by standardizing button sizing and alignment across all rows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->