### PR TITLE
fix: use light mode social logo if no dark mode exists

### DIFF
--- a/Sources/ClerkKitUI/Common/SocialButton.swift
+++ b/Sources/ClerkKitUI/Common/SocialButton.swift
@@ -27,6 +27,19 @@ struct SocialButton: View {
         image
           .resizable()
           .scaledToFit()
+      } else if state.error != nil, colorScheme == .dark {
+        // Dark variant failed to load, fall back to light variant
+        LazyImage(url: provider.iconImageUrl(darkMode: false)) { fallbackState in
+          if let image = fallbackState.image {
+            image
+              .resizable()
+              .scaledToFit()
+          } else {
+            Image(systemName: "globe")
+              .resizable()
+              .scaledToFit()
+          }
+        }
       } else {
         Image(systemName: "globe")
           .resizable()

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileExternalAccountRow.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileExternalAccountRow.swift
@@ -35,6 +35,21 @@ struct UserProfileExternalAccountRow: View {
                 image
                   .resizable()
                   .scaledToFit()
+              } else if state.error != nil, colorScheme == .dark {
+                // Dark variant failed to load, fall back to light variant
+                LazyImage(url: externalAccount.oauthProvider.iconImageUrl(darkMode: false)) { fallbackState in
+                  if let image = fallbackState.image {
+                    image
+                      .resizable()
+                      .scaledToFit()
+                  } else {
+                    #if DEBUG
+                    Image(systemName: "globe")
+                      .resizable()
+                      .scaledToFit()
+                    #endif
+                  }
+                }
               } else {
                 #if DEBUG
                 Image(systemName: "globe")


### PR DESCRIPTION
Should potentially close https://github.com/clerk/clerk-ios/issues/335, more info there ✌️ The dark mode logo issue is something else though.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced image loading fallback behavior for social buttons and external account icons in dark mode, improving reliability when images fail to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->