### PR TITLE
Sean/mobile 413 support embedding userprofileview in an existing navigation stack

### DIFF
--- a/Sources/ClerkKitUI/Components/UserButton/UserButtonAccountSwitcher.swift
+++ b/Sources/ClerkKitUI/Components/UserButton/UserButtonAccountSwitcher.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct UserButtonAccountSwitcher: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
-  @Environment(UserProfileNavigation.self) private var navigation
+  @Environment(UserProfileSheetNavigation.self) private var navigation
   @Environment(\.dismiss) private var dismiss
 
   @Binding private var contentHeight: CGFloat

--- a/Sources/ClerkKitUI/Components/UserProfile/BackupCodesView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/BackupCodesView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct BackupCodesView: View {
   @Environment(\.clerkTheme) private var theme
-  @Environment(UserProfileNavigation.self) private var navigation
+  @Environment(UserProfileSheetNavigation.self) private var navigation
   @Environment(\.dismiss) private var dismiss
 
   enum MfaType {

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddMfaView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddMfaView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct UserProfileAddMfaView: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
-  @Environment(UserProfileNavigation.self) private var navigation
+  @Environment(UserProfileSheetNavigation.self) private var navigation
   @Environment(\.dismiss) private var dismiss
 
   @State private var error: Error?

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
@@ -13,6 +13,7 @@ struct UserProfileDeleteAccountConfirmationView: View {
   @Environment(\.clerkTheme) private var theme
   @Environment(\.dismiss) private var dismiss
   @Environment(UserProfileNavigation.self) private var navigation
+  @Environment(\.userProfileRouter) private var router
 
   @State private var deleteAccount = ""
   @State private var error: Error?
@@ -96,7 +97,7 @@ extension UserProfileDeleteAccountConfirmationView {
     do {
       try await user.delete()
       dismiss()
-      navigation.popToRoot(includingSelf: clerk.user == nil)
+      router.popToRoot(clerk.user == nil)
       if clerk.auth.sessions.count > 1 {
         navigation.accountSwitcherIsPresented = true
       }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
@@ -97,7 +97,7 @@ extension UserProfileDeleteAccountConfirmationView {
     do {
       try await user.delete()
       dismiss()
-      router.popToRoot(clerk.user == nil)
+      router.popToRoot()
       if clerk.auth.sessions.count > 1 {
         navigation.accountSwitcherIsPresented = true
       }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
@@ -12,7 +12,7 @@ struct UserProfileDeleteAccountConfirmationView: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
   @Environment(\.dismiss) private var dismiss
-  @Environment(UserProfileNavigation.self) private var navigation
+  @Environment(UserProfileSheetNavigation.self) private var navigation
   @Environment(\.userProfileRouter) private var router
 
   @State private var deleteAccount = ""

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
@@ -96,9 +96,11 @@ extension UserProfileDeleteAccountConfirmationView {
 
     do {
       try await user.delete()
+      let shouldPresentAccountSwitcher = clerk.auth.sessions.count > 1
+      let shouldPopIncludingSelf = clerk.user == nil && !shouldPresentAccountSwitcher
       dismiss()
-      router.popToRoot()
-      if clerk.auth.sessions.count > 1 {
+      router.popToRoot(shouldPopIncludingSelf)
+      if shouldPresentAccountSwitcher {
         navigation.accountSwitcherIsPresented = true
       }
     } catch {

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
@@ -96,7 +96,7 @@ extension UserProfileDeleteAccountConfirmationView {
 
     do {
       try await user.delete()
-      let shouldPresentAccountSwitcher = clerk.auth.sessions.count > 1
+      let shouldPresentAccountSwitcher = !clerk.auth.sessions.isEmpty
       let shouldPopIncludingSelf = clerk.user == nil && !shouldPresentAccountSwitcher
       dismiss()
       router.popToRoot(shouldPopIncludingSelf)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
@@ -96,7 +96,7 @@ extension UserProfileDeleteAccountConfirmationView {
     do {
       try await user.delete()
       dismiss()
-      navigation.popToRoot()
+      navigation.popToRoot(includingSelf: clerk.user == nil)
       if clerk.auth.sessions.count > 1 {
         navigation.accountSwitcherIsPresented = true
       }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
@@ -96,7 +96,7 @@ extension UserProfileDeleteAccountConfirmationView {
 
     do {
       try await user.delete()
-      let shouldPresentAccountSwitcher = !clerk.auth.sessions.isEmpty
+      let shouldPresentAccountSwitcher = clerk.auth.sessions.count > 1
       let shouldPopIncludingSelf = clerk.user == nil && !shouldPresentAccountSwitcher
       dismiss()
       router.popToRoot(shouldPopIncludingSelf)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
@@ -96,7 +96,7 @@ extension UserProfileDeleteAccountConfirmationView {
     do {
       try await user.delete()
       dismiss()
-      navigation.path = NavigationPath()
+      navigation.popToRoot()
       if clerk.auth.sessions.count > 1 {
         navigation.accountSwitcherIsPresented = true
       }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddSmsView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddSmsView.swift
@@ -13,7 +13,7 @@ struct UserProfileMfaAddSmsView: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
   @Environment(\.dismiss) private var dismiss
-  @Environment(UserProfileNavigation.self) private var navigation
+  @Environment(UserProfileSheetNavigation.self) private var navigation
 
   @State private var selectedPhoneNumber: ClerkKit.PhoneNumber?
   @State private var addPhoneNumberIsPresented = false

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddTotpView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddTotpView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct UserProfileMfaAddTotpView: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
-  @Environment(UserProfileNavigation.self) private var navigation
+  @Environment(UserProfileSheetNavigation.self) private var navigation
   @Environment(\.dismiss) private var dismiss
 
   @State private var path = NavigationPath()

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaSection.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaSection.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct UserProfileMfaSection: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
-  @Environment(UserProfileNavigation.self) private var navigation
+  @Environment(UserProfileSheetNavigation.self) private var navigation
 
   @State private var addMfaHeight: CGFloat = 400
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
@@ -8,16 +8,13 @@
 import Foundation
 import SwiftUI
 
-/// Manages navigation and presentation state for the user profile flow.
+/// Manages presentation state for the user profile flow.
 ///
-/// This class handles navigation path management and sheet presentation state.
+/// This class handles sheet presentation state for the user profile.
 /// It is injected into child views via the environment.
 @MainActor
 @Observable
 final class UserProfileNavigation {
-  /// The internal navigation path for standalone `UserProfileView` usage.
-  var path = NavigationPath()
-  
   /// Whether the account switcher sheet is presented.
   var accountSwitcherIsPresented = false
   
@@ -40,18 +37,11 @@ struct UserProfileRouter: Sendable {
   let popToRoot: @MainActor @Sendable (_ includingSelf: Bool) -> Void
 }
 
-private struct UserProfileRouterKey: EnvironmentKey {
-  static let defaultValue = UserProfileRouter(
+extension EnvironmentValues {
+  @Entry var userProfileRouter = UserProfileRouter(
     push: { _ in },
     popToRoot: { _ in }
   )
-}
-
-extension EnvironmentValues {
-  var userProfileRouter: UserProfileRouter {
-    get { self[UserProfileRouterKey.self] }
-    set { self[UserProfileRouterKey.self] = newValue }
-  }
 }
 
 #endif

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
@@ -17,37 +17,37 @@ import SwiftUI
 final class UserProfileNavigation {
   /// The navigation path for the user profile flow (used when managing own NavigationStack).
   var path = NavigationPath()
-
+  
   /// An external navigation path binding provided by the parent.
   /// When set, navigation pushes are forwarded to the parent's path instead of the internal one.
   private(set) var externalPath: Binding<NavigationPath>?
-
+  
   /// The count of the external path when UserProfileView first appeared.
   /// Used to determine how many entries we pushed so `popToRoot()` only removes ours.
   private var externalPathBaseCount: Int?
-
+  
   /// Whether the account switcher sheet is presented.
   var accountSwitcherIsPresented = false
-
+  
   /// Whether the auth view sheet is presented.
   var authViewIsPresented = false
-
+  
   /// Whether the MFA type chooser sheet is presented.
   var chooseMfaTypeIsPresented = false
-
+  
   /// The currently presented MFA add view type.
   var presentedAddMfaType: UserProfileAddMfaView.PresentedView?
-
+  
   /// Creates a new UserProfileNavigation instance.
   init() {}
-
+  
   /// Configures the navigation to use an external path from a parent `NavigationStack`.
   /// When configured, navigation pushes are forwarded to the parent's path.
   func configure(externalPath: Binding<NavigationPath>) {
     self.externalPath = externalPath
     self.externalPathBaseCount = externalPath.wrappedValue.count
   }
-
+  
   /// Navigates to the specified destination.
   ///
   /// When an external navigation path is provided (embedded mode), pushes onto the parent's path.
@@ -59,15 +59,20 @@ final class UserProfileNavigation {
       path.append(destination)
     }
   }
-
+  
   /// Pops to the root of the user profile flow.
   ///
   /// In standalone mode, resets the internal navigation path.
   /// In embedded mode, removes only the entries pushed by the user profile flow,
   /// leaving the parent's pre-existing entries intact.
-  func popToRoot() {
+  ///
+  /// - Parameter includingSelf: When `true`, also removes the entry that pushed
+  ///   `UserProfileView` itself onto the parent's path. Use this when the user
+  ///   has been deleted and there are no remaining sessions to display.
+  func popToRoot(includingSelf: Bool = false) {
     if let externalPath, let baseCount = externalPathBaseCount {
-      let entriesToRemove = externalPath.wrappedValue.count - baseCount
+      let adjustedBase = includingSelf ? baseCount - 1 : baseCount
+      let entriesToRemove = externalPath.wrappedValue.count - adjustedBase
       if entriesToRemove > 0 {
         externalPath.wrappedValue.removeLast(entriesToRemove)
       }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
@@ -34,13 +34,13 @@ final class UserProfileSheetNavigation {
 /// Routing API for navigating inside `UserProfileView` and nested destinations.
 struct UserProfileRouter: Sendable {
   let push: @MainActor @Sendable (UserProfileView.Destination) -> Void
-  let popToRoot: @MainActor @Sendable () -> Void
+  let popToRoot: @MainActor @Sendable (_ includingSelf: Bool) -> Void
 }
 
 extension EnvironmentValues {
   @Entry var userProfileRouter = UserProfileRouter(
     push: { _ in },
-    popToRoot: {}
+    popToRoot: { _ in }
   )
 }
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
@@ -15,16 +15,8 @@ import SwiftUI
 @MainActor
 @Observable
 final class UserProfileNavigation {
-  /// The navigation path for the user profile flow (used when managing own NavigationStack).
+  /// The internal navigation path for standalone `UserProfileView` usage.
   var path = NavigationPath()
-  
-  /// An external navigation path binding provided by the parent.
-  /// When set, navigation pushes are forwarded to the parent's path instead of the internal one.
-  private(set) var externalPath: Binding<NavigationPath>?
-  
-  /// The count of the external path when UserProfileView first appeared.
-  /// Used to determine how many entries we pushed so `popToRoot()` only removes ours.
-  private var externalPathBaseCount: Int?
   
   /// Whether the account switcher sheet is presented.
   var accountSwitcherIsPresented = false
@@ -40,46 +32,25 @@ final class UserProfileNavigation {
   
   /// Creates a new UserProfileNavigation instance.
   init() {}
-  
-  /// Configures the navigation to use an external path from a parent `NavigationStack`.
-  /// When configured, navigation pushes are forwarded to the parent's path.
-  func configure(externalPath: Binding<NavigationPath>) {
-    self.externalPath = externalPath
-    self.externalPathBaseCount = externalPath.wrappedValue.count
-  }
-  
-  /// Navigates to the specified destination.
-  ///
-  /// When an external navigation path is provided (embedded mode), pushes onto the parent's path.
-  /// Otherwise, pushes onto the internal path (standalone mode).
-  func navigate(to destination: UserProfileView.Destination) {
-    if let externalPath {
-      externalPath.wrappedValue.append(destination)
-    } else {
-      path.append(destination)
-    }
-  }
-  
-  /// Pops to the root of the user profile flow.
-  ///
-  /// In standalone mode, resets the internal navigation path.
-  /// In embedded mode, removes only the entries pushed by the user profile flow,
-  /// leaving the parent's pre-existing entries intact.
-  ///
-  /// - Parameter includingSelf: When `true`, also removes the entry that pushed
-  ///   `UserProfileView` itself onto the parent's path. Use this when the user
-  ///   has been deleted and there are no remaining sessions to display.
-  func popToRoot(includingSelf: Bool = false) {
-    if let externalPath, let baseCount = externalPathBaseCount {
-      let adjustedBase = max(includingSelf ? baseCount - 1 : baseCount, 0)
-      let currentCount = externalPath.wrappedValue.count
-      let entriesToRemove = min(max(currentCount - adjustedBase, 0), currentCount)
-      if entriesToRemove > 0 {
-        externalPath.wrappedValue.removeLast(entriesToRemove)
-      }
-    } else {
-      path = NavigationPath()
-    }
+}
+
+/// Routing API for navigating inside `UserProfileView` and nested destinations.
+struct UserProfileRouter: Sendable {
+  let push: @MainActor @Sendable (UserProfileView.Destination) -> Void
+  let popToRoot: @MainActor @Sendable (_ includingSelf: Bool) -> Void
+}
+
+private struct UserProfileRouterKey: EnvironmentKey {
+  static let defaultValue = UserProfileRouter(
+    push: { _ in },
+    popToRoot: { _ in }
+  )
+}
+
+extension EnvironmentValues {
+  var userProfileRouter: UserProfileRouter {
+    get { self[UserProfileRouterKey.self] }
+    set { self[UserProfileRouterKey.self] = newValue }
   }
 }
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
@@ -15,8 +15,16 @@ import SwiftUI
 @MainActor
 @Observable
 final class UserProfileNavigation {
-  /// The navigation path for the user profile flow.
+  /// The navigation path for the user profile flow (used when managing own NavigationStack).
   var path = NavigationPath()
+
+  /// An external navigation path binding provided by the parent.
+  /// When set, navigation pushes are forwarded to the parent's path instead of the internal one.
+  private(set) var externalPath: Binding<NavigationPath>?
+
+  /// The count of the external path when UserProfileView first appeared.
+  /// Used to determine how many entries we pushed so `popToRoot()` only removes ours.
+  private var externalPathBaseCount: Int?
 
   /// Whether the account switcher sheet is presented.
   var accountSwitcherIsPresented = false
@@ -31,7 +39,40 @@ final class UserProfileNavigation {
   var presentedAddMfaType: UserProfileAddMfaView.PresentedView?
 
   /// Creates a new UserProfileNavigation instance.
-  init() {}
+  /// - Parameter externalPath: An optional binding to a parent's `NavigationPath`.
+  ///   When provided, navigation pushes are forwarded to the parent's path.
+  init(externalPath: Binding<NavigationPath>? = nil) {
+    self.externalPath = externalPath
+    self.externalPathBaseCount = externalPath?.wrappedValue.count
+  }
+
+  /// Navigates to the specified destination.
+  ///
+  /// When an external navigation path is provided (embedded mode), pushes onto the parent's path.
+  /// Otherwise, pushes onto the internal path (standalone mode).
+  func navigate(to destination: UserProfileView.Destination) {
+    if let externalPath {
+      externalPath.wrappedValue.append(destination)
+    } else {
+      path.append(destination)
+    }
+  }
+
+  /// Pops to the root of the user profile flow.
+  ///
+  /// In standalone mode, resets the internal navigation path.
+  /// In embedded mode, removes only the entries pushed by the user profile flow,
+  /// leaving the parent's pre-existing entries intact.
+  func popToRoot() {
+    if let externalPath, let baseCount = externalPathBaseCount {
+      let entriesToRemove = externalPath.wrappedValue.count - baseCount
+      if entriesToRemove > 0 {
+        externalPath.wrappedValue.removeLast(entriesToRemove)
+      }
+    } else {
+      path = NavigationPath()
+    }
+  }
 }
 
 #endif

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
@@ -39,11 +39,13 @@ final class UserProfileNavigation {
   var presentedAddMfaType: UserProfileAddMfaView.PresentedView?
 
   /// Creates a new UserProfileNavigation instance.
-  /// - Parameter externalPath: An optional binding to a parent's `NavigationPath`.
-  ///   When provided, navigation pushes are forwarded to the parent's path.
-  init(externalPath: Binding<NavigationPath>? = nil) {
+  init() {}
+
+  /// Configures the navigation to use an external path from a parent `NavigationStack`.
+  /// When configured, navigation pushes are forwarded to the parent's path.
+  func configure(externalPath: Binding<NavigationPath>) {
     self.externalPath = externalPath
-    self.externalPathBaseCount = externalPath?.wrappedValue.count
+    self.externalPathBaseCount = externalPath.wrappedValue.count
   }
 
   /// Navigates to the specified destination.

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
@@ -32,7 +32,7 @@ final class UserProfileSheetNavigation {
 }
 
 /// Routing API for navigating inside `UserProfileView` and nested destinations.
-struct UserProfileRouter: Sendable {
+struct UserProfileRouter {
   let push: @MainActor @Sendable (UserProfileView.Destination) -> Void
   let popToRoot: @MainActor @Sendable (_ includingSelf: Bool) -> Void
 }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
@@ -71,8 +71,9 @@ final class UserProfileNavigation {
   ///   has been deleted and there are no remaining sessions to display.
   func popToRoot(includingSelf: Bool = false) {
     if let externalPath, let baseCount = externalPathBaseCount {
-      let adjustedBase = includingSelf ? baseCount - 1 : baseCount
-      let entriesToRemove = externalPath.wrappedValue.count - adjustedBase
+      let adjustedBase = max(includingSelf ? baseCount - 1 : baseCount, 0)
+      let currentCount = externalPath.wrappedValue.count
+      let entriesToRemove = min(max(currentCount - adjustedBase, 0), currentCount)
       if entriesToRemove > 0 {
         externalPath.wrappedValue.removeLast(entriesToRemove)
       }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
@@ -1,5 +1,5 @@
 //
-//  UserProfileSheetNavigation.swift
+//  UserProfileNavigation.swift
 //  Clerk
 //
 
@@ -17,16 +17,16 @@ import SwiftUI
 final class UserProfileSheetNavigation {
   /// Whether the account switcher sheet is presented.
   var accountSwitcherIsPresented = false
-  
+
   /// Whether the auth view sheet is presented.
   var authViewIsPresented = false
-  
+
   /// Whether the MFA type chooser sheet is presented.
   var chooseMfaTypeIsPresented = false
-  
+
   /// The currently presented MFA add view type.
   var presentedAddMfaType: UserProfileAddMfaView.PresentedView?
-  
+
   /// Creates a new UserProfileSheetNavigation instance.
   init() {}
 }
@@ -34,13 +34,13 @@ final class UserProfileSheetNavigation {
 /// Routing API for navigating inside `UserProfileView` and nested destinations.
 struct UserProfileRouter: Sendable {
   let push: @MainActor @Sendable (UserProfileView.Destination) -> Void
-  let popToRoot: @MainActor @Sendable (_ includingSelf: Bool) -> Void
+  let popToRoot: @MainActor @Sendable () -> Void
 }
 
 extension EnvironmentValues {
   @Entry var userProfileRouter = UserProfileRouter(
     push: { _ in },
-    popToRoot: { _ in }
+    popToRoot: {}
   )
 }
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileNavigation.swift
@@ -1,5 +1,5 @@
 //
-//  UserProfileNavigation.swift
+//  UserProfileSheetNavigation.swift
 //  Clerk
 //
 
@@ -14,7 +14,7 @@ import SwiftUI
 /// It is injected into child views via the environment.
 @MainActor
 @Observable
-final class UserProfileNavigation {
+final class UserProfileSheetNavigation {
   /// Whether the account switcher sheet is presented.
   var accountSwitcherIsPresented = false
   
@@ -27,7 +27,7 @@ final class UserProfileNavigation {
   /// The currently presented MFA add view type.
   var presentedAddMfaType: UserProfileAddMfaView.PresentedView?
   
-  /// Creates a new UserProfileNavigation instance.
+  /// Creates a new UserProfileSheetNavigation instance.
   init() {}
 }
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileSecurityView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileSecurityView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct UserProfileSecurityView: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
-  @Environment(UserProfileNavigation.self) private var navigation
+  @Environment(UserProfileSheetNavigation.self) private var navigation
 
   @State private var error: Error?
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -471,4 +471,31 @@ extension UserProfileView {
     .environment(\.clerkTheme, .clerk)
 }
 
+#Preview("Embedded in parent NavigationStack") {
+  @Previewable @State var navigationPath = NavigationPath()
+
+  UserProfileView(isDismissable: false, navigationPath: $navigationPath)
+    .environment(
+      Clerk.preview { builder in
+        builder.services.clientService.getHandler = {
+          try? await Task.sleep(for: .seconds(1))
+          return Client.mock
+        }
+
+        builder.services.environmentService.getHandler = {
+          try? await Task.sleep(for: .seconds(1))
+          return Clerk.Environment.mock
+        }
+
+        builder.services.userService.getSessionsHandler = { _ in
+          try? await Task.sleep(for: .seconds(1))
+          return [Session.mock, Session.mock2]
+        }
+      }
+    )
+    .environment(AuthState())
+    .environment(UserProfileSheetNavigation())
+    .environment(\.clerkTheme, .clerk)
+}
+
 #endif

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -57,7 +57,6 @@ import SwiftUI
 ///
 /// ```swift
 /// struct ContentView: View {
-///   @Environment(Clerk.self) private var clerk
 ///   @State private var path = NavigationPath()
 ///
 ///   var body: some View {
@@ -69,9 +68,6 @@ import SwiftUI
 ///             UserProfileView(isDismissable: false, navigationPath: $path)
 ///           }
 ///         }
-///     }
-///     .onChange(of: clerk.user) { _, newValue in
-///       if newValue == nil { path = NavigationPath() }
 ///     }
 ///   }
 /// }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -83,6 +83,7 @@ public struct UserProfileView: View {
   @State private var updateProfileIsPresented = false
   @State private var accountSwitcherHeight: CGFloat = 400
   @State private var embeddedPushCount = 0
+  @State private var internalPath = NavigationPath()
   @State private var navigation = UserProfileNavigation()
   @State private var codeLimiter = CodeLimiter()
   @State private var error: Error?
@@ -108,7 +109,7 @@ public struct UserProfileView: View {
     if let user = clerk.user {
       Group {
         if navigationPath == nil {
-          NavigationStack(path: $navigation.path) {
+          NavigationStack(path: $internalPath) {
             profileContent(user: user)
           }
         } else {
@@ -183,7 +184,7 @@ public struct UserProfileView: View {
           navigationPath.wrappedValue.append(destination)
           embeddedPushCount += 1
         } else {
-          navigation.path.append(destination)
+          internalPath.append(destination)
         }
       },
       popToRoot: { includingSelf in
@@ -196,7 +197,7 @@ public struct UserProfileView: View {
           }
           embeddedPushCount = 0
         } else {
-          navigation.path = NavigationPath()
+          internalPath = NavigationPath()
         }
       }
     )

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -52,6 +52,30 @@ import SwiftUI
 ///   }
 /// }
 /// ```
+///
+/// Embedded in a parent `NavigationStack`:
+///
+/// ```swift
+/// struct ContentView: View {
+///   @Environment(Clerk.self) private var clerk
+///   @State private var path = NavigationPath()
+///
+///   var body: some View {
+///     NavigationStack(path: $path) {
+///       HomeView()
+///         .navigationDestination(for: AppRoute.self) { route in
+///           switch route {
+///           case .profile:
+///             UserProfileView(isDismissable: false, navigationPath: $path)
+///           }
+///         }
+///     }
+///     .onChange(of: clerk.user) { _, newValue in
+///       if newValue == nil { path = NavigationPath() }
+///     }
+///   }
+/// }
+/// ```
 public struct UserProfileView: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
@@ -61,7 +85,7 @@ public struct UserProfileView: View {
 
   @State private var updateProfileIsPresented = false
   @State private var accountSwitcherHeight: CGFloat = 400
-  @State private var navigation = UserProfileNavigation()
+  @State private var navigation: UserProfileNavigation
   @State private var codeLimiter = CodeLimiter()
   @State private var error: Error?
 
@@ -73,52 +97,24 @@ public struct UserProfileView: View {
   ///   can be used in sheets or other dismissable contexts. When `false`, no
   ///   dismiss button is shown, making it suitable for full-screen usage.
   ///   Defaults to `true`.
-  public init(isDismissable: Bool = true) {
+  ///   - navigationPath: An optional binding to a parent `NavigationPath`. When provided,
+  ///   the view skips creating its own `NavigationStack` and pushes destinations onto the
+  ///   parent's path instead. Use this when embedding `UserProfileView` inside your own
+  ///   `NavigationStack` to avoid nested navigation stacks. Defaults to `nil`.
+  public init(isDismissable: Bool = true, navigationPath: Binding<NavigationPath>? = nil) {
     self.isDismissable = isDismissable
+    _navigation = State(initialValue: .init(externalPath: navigationPath))
   }
 
   public var body: some View {
     if let user = clerk.user {
-      NavigationStack(path: $navigation.path) {
-        VStack(spacing: 0) {
-          ScrollView {
-            LazyVStack(spacing: 0) {
-              UserProfileHeaderView(
-                user: user,
-                onUpdateProfile: {
-                  updateProfileIsPresented = true
-                }
-              )
-
-              VStack(spacing: 48) {
-                profileSection
-
-                accountSection
-              }
-            }
+      Group {
+        if navigation.externalPath == nil {
+          NavigationStack(path: $navigation.path) {
+            profileContent(user: user)
           }
-          .background(theme.colors.muted)
-
-          SecuredByClerkFooter()
-        }
-        .animation(.default, value: user)
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-          ToolbarItem(placement: .principal) {
-            Text("Account", bundle: .module)
-              .font(theme.fonts.headline)
-              .fontWeight(.semibold)
-              .foregroundStyle(theme.colors.foreground)
-          }
-
-          if isDismissable {
-            ToolbarItem(placement: .topBarTrailing) {
-              DismissButton()
-            }
-          }
-        }
-        .navigationDestination(for: Destination.self) {
-          $0.view
+        } else {
+          profileContent(user: user)
         }
       }
       .tint(theme.colors.primary)
@@ -159,12 +155,61 @@ public struct UserProfileView: View {
         await clerk.telemetry.record(
           TelemetryEvents.viewDidAppear(
             "UserProfileView",
-            payload: ["isDismissable": .bool(isDismissable)]
+            payload: [
+              "isDismissable": .bool(isDismissable),
+              "isEmbedded": .bool(navigation.externalPath != nil),
+            ]
           )
         )
       }
       .environment(navigation)
       .environment(codeLimiter)
+    }
+  }
+
+  @ViewBuilder
+  private func profileContent(user: User) -> some View {
+    VStack(spacing: 0) {
+      ScrollView {
+        LazyVStack(spacing: 0) {
+          UserProfileHeaderView(
+            user: user,
+            onUpdateProfile: {
+              updateProfileIsPresented = true
+            }
+          )
+
+          VStack(spacing: 48) {
+            profileSection
+
+            accountSection
+          }
+        }
+      }
+      .background(theme.colors.muted)
+
+      SecuredByClerkFooter()
+    }
+    .animation(.default, value: user)
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItem(placement: .principal) {
+        Text("Account", bundle: .module)
+          .font(theme.fonts.headline)
+          .fontWeight(.semibold)
+          .foregroundStyle(theme.colors.foreground)
+      }
+
+      if isDismissable {
+        ToolbarItem(placement: .topBarTrailing) {
+          DismissButton()
+        }
+      }
+    }
+    .navigationDestination(for: Destination.self) { destination in
+      destination.view
+        .environment(navigation)
+        .environment(codeLimiter)
     }
   }
 }
@@ -175,11 +220,11 @@ extension UserProfileView {
   private var profileSection: some View {
     VStack(spacing: 0) {
       row(icon: "icon-profile", text: "Manage account") {
-        navigation.path.append(Destination.profileDetail)
+        navigation.path.append(.profileDetail)
       }
 
       row(icon: "icon-security", text: "Security") {
-        navigation.path.append(Destination.security)
+        navigation.navigate(to: .security)
       }
     }
     .background(theme.colors.background)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -474,28 +474,30 @@ extension UserProfileView {
 #Preview("Embedded in parent NavigationStack") {
   @Previewable @State var navigationPath = NavigationPath()
 
-  UserProfileView(isDismissable: false, navigationPath: $navigationPath)
-    .environment(
-      Clerk.preview { builder in
-        builder.services.clientService.getHandler = {
-          try? await Task.sleep(for: .seconds(1))
-          return Client.mock
-        }
+  NavigationStack(path: $navigationPath) {
+    UserProfileView(isDismissable: false, navigationPath: $navigationPath)
+      .environment(
+        Clerk.preview { builder in
+          builder.services.clientService.getHandler = {
+            try? await Task.sleep(for: .seconds(1))
+            return Client.mock
+          }
 
-        builder.services.environmentService.getHandler = {
-          try? await Task.sleep(for: .seconds(1))
-          return Clerk.Environment.mock
-        }
+          builder.services.environmentService.getHandler = {
+            try? await Task.sleep(for: .seconds(1))
+            return Clerk.Environment.mock
+          }
 
-        builder.services.userService.getSessionsHandler = { _ in
-          try? await Task.sleep(for: .seconds(1))
-          return [Session.mock, Session.mock2]
+          builder.services.userService.getSessionsHandler = { _ in
+            try? await Task.sleep(for: .seconds(1))
+            return [Session.mock, Session.mock2]
+          }
         }
-      }
-    )
-    .environment(AuthState())
-    .environment(UserProfileSheetNavigation())
-    .environment(\.clerkTheme, .clerk)
+      )
+      .environment(AuthState())
+      .environment(UserProfileSheetNavigation())
+      .environment(\.clerkTheme, .clerk)
+  }
 }
 
 #endif

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -177,8 +177,8 @@ public struct UserProfileView: View {
           internalPath.append(destination)
         }
       },
-      popToRoot: {
-        let extraRemoval = clerk.user == nil ? 1 : 0
+      popToRoot: { includingSelf in
+        let extraRemoval = includingSelf ? 1 : 0
         if let navigationPath {
           let currentCount = navigationPath.wrappedValue.count
           let entriesToRemove = min(max(currentCount - initialPathCount + extraRemoval, 0), currentCount)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -82,6 +82,7 @@ public struct UserProfileView: View {
 
   @State private var updateProfileIsPresented = false
   @State private var accountSwitcherHeight: CGFloat = 400
+  @State private var embeddedPushCount = 0
   @State private var navigation = UserProfileNavigation()
   @State private var codeLimiter = CodeLimiter()
   @State private var error: Error?
@@ -148,11 +149,17 @@ public struct UserProfileView: View {
       .task {
         _ = try? await clerk.refreshClient()
       }
-      .taskOnce {
-        if let navigationPath {
-          navigation.configure(externalPath: navigationPath)
+      .onChange(of: navigationPath?.wrappedValue.count) { oldValue, newValue in
+        guard let oldValue, let newValue else {
+          embeddedPushCount = 0
+          return
         }
 
+        if newValue < oldValue {
+          embeddedPushCount = max(embeddedPushCount - (oldValue - newValue), 0)
+        }
+      }
+      .taskOnce {
         await clerk.telemetry.record(
           TelemetryEvents.viewDidAppear(
             "UserProfileView",
@@ -165,7 +172,34 @@ public struct UserProfileView: View {
       }
       .environment(navigation)
       .environment(codeLimiter)
+      .environment(\.userProfileRouter, router)
     }
+  }
+
+  private var router: UserProfileRouter {
+    UserProfileRouter(
+      push: { destination in
+        if let navigationPath {
+          navigationPath.wrappedValue.append(destination)
+          embeddedPushCount += 1
+        } else {
+          navigation.path.append(destination)
+        }
+      },
+      popToRoot: { includingSelf in
+        if let navigationPath {
+          let currentCount = navigationPath.wrappedValue.count
+          let requestedRemovals = embeddedPushCount + (includingSelf ? 1 : 0)
+          let entriesToRemove = min(max(requestedRemovals, 0), currentCount)
+          if entriesToRemove > 0 {
+            navigationPath.wrappedValue.removeLast(entriesToRemove)
+          }
+          embeddedPushCount = 0
+        } else {
+          navigation.path = NavigationPath()
+        }
+      }
+    )
   }
 
   @ViewBuilder
@@ -211,6 +245,7 @@ public struct UserProfileView: View {
       destination.view
         .environment(navigation)
         .environment(codeLimiter)
+        .environment(\.userProfileRouter, router)
     }
   }
 }
@@ -221,11 +256,11 @@ extension UserProfileView {
   private var profileSection: some View {
     VStack(spacing: 0) {
       row(icon: "icon-profile", text: "Manage account") {
-        navigation.path.append(.profileDetail)
+        router.push(.profileDetail)
       }
 
       row(icon: "icon-security", text: "Security") {
-        navigation.navigate(to: .security)
+        router.push(.security)
       }
     }
     .background(theme.colors.background)
@@ -382,7 +417,7 @@ private struct UserProfileHeaderView: View {
 // MARK: - Destination
 
 extension UserProfileView {
-  enum Destination: Hashable {
+  enum Destination: Hashable, Sendable {
     case profileDetail
     case security
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -404,7 +404,7 @@ private struct UserProfileHeaderView: View {
 // MARK: - Destination
 
 extension UserProfileView {
-  enum Destination: Hashable, Sendable {
+  enum Destination: Hashable {
     case profileDetail
     case security
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -187,7 +187,8 @@ public struct UserProfileView: View {
           internalPath.append(destination)
         }
       },
-      popToRoot: { includingSelf in
+      popToRoot: {
+        let includingSelf = clerk.user == nil
         if let navigationPath {
           let currentCount = navigationPath.wrappedValue.count
           let requestedRemovals = embeddedPushCount + (includingSelf ? 1 : 0)
@@ -203,7 +204,6 @@ public struct UserProfileView: View {
     )
   }
 
-  @ViewBuilder
   private func profileContent(user: User) -> some View {
     VStack(spacing: 0) {
       ScrollView {

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -81,11 +81,12 @@ public struct UserProfileView: View {
   @Environment(\.clerkTheme) private var theme
   @Environment(\.dismiss) private var dismiss
 
-  let isDismissable: Bool
+  private let isDismissable: Bool
+  private let navigationPath: Binding<NavigationPath>?
 
   @State private var updateProfileIsPresented = false
   @State private var accountSwitcherHeight: CGFloat = 400
-  @State private var navigation: UserProfileNavigation
+  @State private var navigation = UserProfileNavigation()
   @State private var codeLimiter = CodeLimiter()
   @State private var error: Error?
 
@@ -103,13 +104,13 @@ public struct UserProfileView: View {
   ///   `NavigationStack` to avoid nested navigation stacks. Defaults to `nil`.
   public init(isDismissable: Bool = true, navigationPath: Binding<NavigationPath>? = nil) {
     self.isDismissable = isDismissable
-    _navigation = State(initialValue: .init(externalPath: navigationPath))
+    self.navigationPath = navigationPath
   }
 
   public var body: some View {
     if let user = clerk.user {
       Group {
-        if navigation.externalPath == nil {
+        if navigationPath == nil {
           NavigationStack(path: $navigation.path) {
             profileContent(user: user)
           }
@@ -152,12 +153,16 @@ public struct UserProfileView: View {
         _ = try? await clerk.refreshClient()
       }
       .taskOnce {
+        if let navigationPath {
+          navigation.configure(externalPath: navigationPath)
+        }
+
         await clerk.telemetry.record(
           TelemetryEvents.viewDidAppear(
             "UserProfileView",
             payload: [
               "isDismissable": .bool(isDismissable),
-              "isEmbedded": .bool(navigation.externalPath != nil),
+              "isEmbedded": .bool(navigationPath != nil),
             ]
           )
         )

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -188,14 +188,10 @@ public struct UserProfileView: View {
         }
       },
       popToRoot: {
-        let includingSelf = clerk.user == nil
+        let extraRemoval = clerk.user == nil ? 1 : 0
         if let navigationPath {
-          let currentCount = navigationPath.wrappedValue.count
-          let requestedRemovals = embeddedPushCount + (includingSelf ? 1 : 0)
-          let entriesToRemove = min(max(requestedRemovals, 0), currentCount)
-          if entriesToRemove > 0 {
-            navigationPath.wrappedValue.removeLast(entriesToRemove)
-          }
+          let entriesToRemove = min(embeddedPushCount + extraRemoval, navigationPath.wrappedValue.count)
+          navigationPath.wrappedValue.removeLast(entriesToRemove)
           embeddedPushCount = 0
         } else {
           internalPath = NavigationPath()

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -84,7 +84,7 @@ public struct UserProfileView: View {
   @State private var accountSwitcherHeight: CGFloat = 400
   @State private var embeddedPushCount = 0
   @State private var internalPath = NavigationPath()
-  @State private var navigation = UserProfileNavigation()
+  @State private var navigation = UserProfileSheetNavigation()
   @State private var codeLimiter = CodeLimiter()
   @State private var error: Error?
 
@@ -456,7 +456,7 @@ extension UserProfileView {
       }
     )
     .environment(AuthState())
-    .environment(UserProfileNavigation())
+    .environment(UserProfileSheetNavigation())
     .environment(\.clerkTheme, .clerk)
 }
 
@@ -481,7 +481,7 @@ extension UserProfileView {
       }
     )
     .environment(AuthState())
-    .environment(UserProfileNavigation())
+    .environment(UserProfileSheetNavigation())
     .environment(\.clerkTheme, .clerk)
 }
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -82,7 +82,7 @@ public struct UserProfileView: View {
 
   @State private var updateProfileIsPresented = false
   @State private var accountSwitcherHeight: CGFloat = 400
-  @State private var embeddedPushCount = 0
+  @State private var initialPathCount: Int
   @State private var internalPath = NavigationPath()
   @State private var navigation = UserProfileSheetNavigation()
   @State private var codeLimiter = CodeLimiter()
@@ -103,6 +103,7 @@ public struct UserProfileView: View {
   public init(isDismissable: Bool = true, navigationPath: Binding<NavigationPath>? = nil) {
     self.isDismissable = isDismissable
     self.navigationPath = navigationPath
+    _initialPathCount = State(initialValue: navigationPath?.wrappedValue.count ?? 0)
   }
 
   public var body: some View {
@@ -150,16 +151,6 @@ public struct UserProfileView: View {
       .task {
         _ = try? await clerk.refreshClient()
       }
-      .onChange(of: navigationPath?.wrappedValue.count) { oldValue, newValue in
-        guard let oldValue, let newValue else {
-          embeddedPushCount = 0
-          return
-        }
-
-        if newValue < oldValue {
-          embeddedPushCount = max(embeddedPushCount - (oldValue - newValue), 0)
-        }
-      }
       .taskOnce {
         await clerk.telemetry.record(
           TelemetryEvents.viewDidAppear(
@@ -182,7 +173,6 @@ public struct UserProfileView: View {
       push: { destination in
         if let navigationPath {
           navigationPath.wrappedValue.append(destination)
-          embeddedPushCount += 1
         } else {
           internalPath.append(destination)
         }
@@ -190,9 +180,9 @@ public struct UserProfileView: View {
       popToRoot: {
         let extraRemoval = clerk.user == nil ? 1 : 0
         if let navigationPath {
-          let entriesToRemove = min(embeddedPushCount + extraRemoval, navigationPath.wrappedValue.count)
+          let currentCount = navigationPath.wrappedValue.count
+          let entriesToRemove = min(max(currentCount - initialPathCount + extraRemoval, 0), currentCount)
           navigationPath.wrappedValue.removeLast(entriesToRemove)
-          embeddedPushCount = 0
         } else {
           internalPath = NavigationPath()
         }

--- a/Sources/ClerkKitUI/Extensions/View+PreviewMocks.swift
+++ b/Sources/ClerkKitUI/Extensions/View+PreviewMocks.swift
@@ -18,7 +18,7 @@ extension View {
   /// - `AuthState()` for `@Environment(AuthState.self)`
   /// - `AuthNavigation()` for `@Environment(AuthNavigation.self)`
   /// - `CodeLimiter()` for `@Environment(CodeLimiter.self)`
-  /// - `UserProfileNavigation()` for `@Environment(UserProfileNavigation.self)`
+  /// - `UserProfileSheetNavigation()` for `@Environment(UserProfileSheetNavigation.self)`
   ///
   /// Note: `ClerkTheme` has a default value and doesn't need to be injected.
   ///
@@ -45,7 +45,7 @@ extension View {
           .environment(AuthState())
           .environment(AuthNavigation())
           .environment(CodeLimiter())
-          .environment(UserProfileNavigation())
+          .environment(UserProfileSheetNavigation())
       )
     }
     return AnyView(self)

--- a/Tests/Domains/User/UserServiceTests.swift
+++ b/Tests/Domains/User/UserServiceTests.swift
@@ -554,8 +554,12 @@ struct UserServiceTests {
 
   @Test
   func deleteSyncsRemainingSessionsFromResponse() async throws {
+    Mocker.removeAll()
+    defer { Mocker.removeAll() }
+
     let requestHandled = LockIsolated(false)
     let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/me")!
+    Clerk.shared.client = .mock
 
     var mock = try Mock(
       url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
@@ -578,6 +582,9 @@ struct UserServiceTests {
 
   @Test
   func deleteSyncsSignedOutClientWhenNoSessionsRemain() async throws {
+    Mocker.removeAll()
+    defer { Mocker.removeAll() }
+
     let requestHandled = LockIsolated(false)
     let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/me")!
     Clerk.shared.client = .mock

--- a/Tests/Domains/User/UserServiceTests.swift
+++ b/Tests/Domains/User/UserServiceTests.swift
@@ -553,13 +553,9 @@ struct UserServiceTests {
   }
 
   @Test
-  func deleteSyncsRemainingSessionsFromResponse() async throws {
-    Mocker.removeAll()
-    defer { Mocker.removeAll() }
-
+  func deleteUsesDeleteEndpoint() async throws {
     let requestHandled = LockIsolated(false)
     let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/me")!
-    Clerk.shared.client = .mock
 
     var mock = try Mock(
       url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
@@ -576,35 +572,5 @@ struct UserServiceTests {
 
     _ = try await Clerk.shared.dependencies.userService.delete()
     #expect(requestHandled.value)
-    #expect(Clerk.shared.client?.sessions.count == Client.mock.sessions.count)
-    #expect(Clerk.shared.user != nil)
-  }
-
-  @Test
-  func deleteSyncsSignedOutClientWhenNoSessionsRemain() async throws {
-    Mocker.removeAll()
-    defer { Mocker.removeAll() }
-
-    let requestHandled = LockIsolated(false)
-    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/me")!
-    Clerk.shared.client = .mock
-
-    var mock = try Mock(
-      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
-      data: [
-        .delete: JSONEncoder.clerkEncoder.encode(ClientResponse<DeletedObject>(response: .mock, client: .mockSignedOut)),
-      ]
-    )
-
-    mock.onRequestHandler = OnRequestHandler { request in
-      #expect(request.httpMethod == "DELETE")
-      requestHandled.setValue(true)
-    }
-    mock.register()
-
-    _ = try await Clerk.shared.dependencies.userService.delete()
-    #expect(requestHandled.value)
-    #expect(Clerk.shared.client?.sessions.isEmpty == true)
-    #expect(Clerk.shared.user == nil)
   }
 }

--- a/Tests/Domains/User/UserServiceTests.swift
+++ b/Tests/Domains/User/UserServiceTests.swift
@@ -553,14 +553,14 @@ struct UserServiceTests {
   }
 
   @Test
-  func testDelete() async throws {
+  func deleteSyncsRemainingSessionsFromResponse() async throws {
     let requestHandled = LockIsolated(false)
     let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/me")!
 
     var mock = try Mock(
       url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
       data: [
-        .delete: JSONEncoder.clerkEncoder.encode(ClientResponse<DeletedObject>(response: .mock, client: nil)),
+        .delete: JSONEncoder.clerkEncoder.encode(ClientResponse<DeletedObject>(response: .mock, client: .mock)),
       ]
     )
 
@@ -572,5 +572,32 @@ struct UserServiceTests {
 
     _ = try await Clerk.shared.dependencies.userService.delete()
     #expect(requestHandled.value)
+    #expect(Clerk.shared.client?.sessions.count == Client.mock.sessions.count)
+    #expect(Clerk.shared.user != nil)
+  }
+
+  @Test
+  func deleteSyncsSignedOutClientWhenNoSessionsRemain() async throws {
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/me")!
+    Clerk.shared.client = .mock
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .delete: JSONEncoder.clerkEncoder.encode(ClientResponse<DeletedObject>(response: .mock, client: .mockSignedOut)),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { request in
+      #expect(request.httpMethod == "DELETE")
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    _ = try await Clerk.shared.dependencies.userService.delete()
+    #expect(requestHandled.value)
+    #expect(Clerk.shared.client?.sessions.isEmpty == true)
+    #expect(Clerk.shared.user == nil)
   }
 }

--- a/Tests/Middleware/ClerkClientSyncResponseMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkClientSyncResponseMiddlewareTests.swift
@@ -79,6 +79,52 @@ struct ClerkClientSyncResponseMiddlewareTests {
     #expect(clerk.client?.id == existingClient.id)
   }
 
+  @Test
+  func validateAppliesRemainingSessionsClientFromDeleteResponse() async throws {
+    configureClerkForTesting()
+    let clerk = Clerk()
+    clerk.client = .mockSignedOut
+    let middleware = ClerkClientSyncResponseMiddleware(clerkProvider: { clerk })
+
+    let data = try JSONEncoder.clerkEncoder.encode(ClientResponse<DeletedObject>(response: .mock, client: .mock))
+    let url = try #require(URL(string: "https://example.com/v1/me"))
+    let response = try #require(HTTPURLResponse(
+      url: url,
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: nil
+    ))
+    let request = URLRequest(url: url)
+
+    try await middleware.validate(response, data: data, for: request)
+
+    #expect(clerk.client?.sessions.count == Client.mock.sessions.count)
+    #expect(clerk.user != nil)
+  }
+
+  @Test
+  func validateAppliesSignedOutClientFromDeleteResponseWhenNoSessionsRemain() async throws {
+    configureClerkForTesting()
+    let clerk = Clerk()
+    clerk.client = .mock
+    let middleware = ClerkClientSyncResponseMiddleware(clerkProvider: { clerk })
+
+    let data = try JSONEncoder.clerkEncoder.encode(ClientResponse<DeletedObject>(response: .mock, client: .mockSignedOut))
+    let url = try #require(URL(string: "https://example.com/v1/me"))
+    let response = try #require(HTTPURLResponse(
+      url: url,
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: nil
+    ))
+    let request = URLRequest(url: url)
+
+    try await middleware.validate(response, data: data, for: request)
+
+    #expect(clerk.client?.sessions.isEmpty == true)
+    #expect(clerk.user == nil)
+  }
+
   private func client(id: String, updatedAt: Date) -> Client {
     var client = Client.mockSignedOut
     client.id = id


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Profile navigation moved from a path/stack model to sheet-based presentations with a new router; profile screen can embed into a parent navigation stack.
* **Behavior**
  * Delete-account flow now reliably returns to root or presents account switcher as needed.
  * MFA and security flows now present via sheets for a more consistent user experience.
* **Tests**
  * Expanded and added deletion tests to verify session and user sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->