### PR TITLE
Add string title init for custom profile rows

### DIFF
--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileCustomRow.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileCustomRow.swift
@@ -35,6 +35,30 @@ public struct UserProfileCustomRow<Route: Hashable> {
     self.icon = icon
     self.placement = placement
   }
+
+  /// Creates a custom row for ``UserProfileView`` using a plain string title.
+  ///
+  /// Rows that share the same placement are displayed in the order they appear in the
+  /// array passed to ``UserProfileView/userProfileRows(_:)``.
+  ///
+  /// - Parameters:
+  ///   - route: The route that should be pushed when the row is tapped.
+  ///   - title: The row title.
+  ///   - icon: The icon displayed for the row.
+  ///   - placement: The insertion point relative to Clerk's built-in rows.
+  public init(
+    route: Route,
+    title: String,
+    icon: UserProfileRowIcon,
+    placement: UserProfileCustomRowPlacement = .sectionEnd(.profile)
+  ) {
+    self.init(
+      route: route,
+      title: LocalizedStringKey(title),
+      icon: icon,
+      placement: placement
+    )
+  }
 }
 
 /// The icon displayed by a user profile row.


### PR DESCRIPTION
Introduce a convenience initializer for
`UserProfileCustomRow` that accepts a plain `String` title and converts it to `LocalizedStringKey`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new initializer variant that accepts String parameters for user profile customization, providing improved API convenience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->