### PR TITLE
fix(keychain): route to data-protection keychain on macOS when access group is set

### DIFF
--- a/Sources/ClerkKit/Dependencies/DependencyContainer.swift
+++ b/Sources/ClerkKit/Dependencies/DependencyContainer.swift
@@ -76,10 +76,7 @@ final class DependencyContainer: Dependencies {
     networkingPipeline = .clerkDefault
       .appendingRequestMiddleware(options.middleware.request)
       .appendingResponseMiddleware(options.middleware.response)
-    keychain = SystemKeychain(
-      service: options.keychainConfig.service,
-      accessGroup: options.keychainConfig.accessGroup
-    )
+    keychain = Self.makeKeychainStorage(config: options.keychainConfig)
 
     // Phase 2: API client (depends on networkingPipeline)
     let pipeline = networkingPipeline
@@ -110,6 +107,32 @@ final class DependencyContainer: Dependencies {
     emailAddressService = EmailAddressService(apiClient: apiClient)
     phoneNumberService = PhoneNumberService(apiClient: apiClient)
     externalAccountService = ExternalAccountService(apiClient: apiClient)
+  }
+
+  private static func makeKeychainStorage(config: Clerk.Options.KeychainConfig) -> any KeychainStorage {
+    let legacyKeychain = SystemKeychain(
+      service: config.service,
+      accessGroup: config.accessGroup
+    )
+
+    #if os(macOS)
+    guard config.accessGroup != nil else {
+      return legacyKeychain
+    }
+
+    let dataProtectionKeychain = SystemKeychain(
+      service: config.service,
+      accessGroup: config.accessGroup,
+      useDataProtectionKeychain: true
+    )
+
+    return MigratingKeychainStorage(
+      primary: dataProtectionKeychain,
+      fallback: legacyKeychain
+    )
+    #else
+    return legacyKeychain
+    #endif
   }
 
   @MainActor

--- a/Sources/ClerkKit/Storage/Keychain/MigratingKeychainStorage.swift
+++ b/Sources/ClerkKit/Storage/Keychain/MigratingKeychainStorage.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+struct MigratingKeychainStorage: KeychainStorage {
+  private let primary: any KeychainStorage
+  private let fallback: any KeychainStorage
+
+  init(
+    primary: any KeychainStorage,
+    fallback: any KeychainStorage
+  ) {
+    self.primary = primary
+    self.fallback = fallback
+  }
+
+  func set(_ data: Data, forKey key: String) throws {
+    try primary.set(data, forKey: key)
+  }
+
+  func data(forKey key: String) throws -> Data? {
+    if let data = try primary.data(forKey: key) {
+      return data
+    }
+
+    guard let fallbackData = try fallback.data(forKey: key) else {
+      return nil
+    }
+
+    do {
+      try primary.set(fallbackData, forKey: key)
+    } catch {
+      return fallbackData
+    }
+
+    return fallbackData
+  }
+
+  func deleteItem(forKey key: String) throws {
+    var deletionError: Error?
+
+    do {
+      try primary.deleteItem(forKey: key)
+    } catch {
+      deletionError = error
+    }
+
+    do {
+      try fallback.deleteItem(forKey: key)
+    } catch {
+      deletionError = deletionError ?? error
+    }
+
+    if let deletionError {
+      throw deletionError
+    }
+  }
+
+  func hasItem(forKey key: String) throws -> Bool {
+    if try primary.hasItem(forKey: key) {
+      return true
+    }
+
+    return try fallback.hasItem(forKey: key)
+  }
+}

--- a/Sources/ClerkKit/Storage/Keychain/SystemKeychain.swift
+++ b/Sources/ClerkKit/Storage/Keychain/SystemKeychain.swift
@@ -109,6 +109,11 @@ struct SystemKeychain: KeychainStorage {
 
     if let accessGroup {
       query[kSecAttrAccessGroup as String] = accessGroup
+      // Route to the data-protection keychain. On macOS this is the only
+      // keychain that honors `kSecAttrAccessGroup` without falling back to
+      // per-item ACL prompts ("X wants to use the 'session' keychain").
+      // No-op on iOS where the data-protection keychain is the default.
+      query[kSecUseDataProtectionKeychain as String] = kCFBooleanTrue
     }
 
     return query

--- a/Sources/ClerkKit/Storage/Keychain/SystemKeychain.swift
+++ b/Sources/ClerkKit/Storage/Keychain/SystemKeychain.swift
@@ -17,15 +17,21 @@ struct SystemKeychain: KeychainStorage {
   private let service: String
   private let accessGroup: String?
   private let accessibility: Accessibility
+  private let useDataProtectionKeychain: Bool
+  private let secItemClient: SecItemClient
 
   init(
     service: String,
     accessGroup: String? = nil,
-    accessibility: Accessibility = .afterFirstUnlockThisDeviceOnly
+    accessibility: Accessibility = .afterFirstUnlockThisDeviceOnly,
+    useDataProtectionKeychain: Bool = false,
+    secItemClient: SecItemClient = .live
   ) {
     self.service = service
     self.accessGroup = accessGroup
     self.accessibility = accessibility
+    self.useDataProtectionKeychain = useDataProtectionKeychain
+    self.secItemClient = secItemClient
   }
 
   func set(_ data: Data, forKey key: String) throws {
@@ -33,7 +39,7 @@ struct SystemKeychain: KeychainStorage {
     addQuery[kSecAttrAccessible as String] = accessibility.secValue
     addQuery[kSecValueData as String] = data
 
-    let status = SecItemAdd(addQuery as CFDictionary, nil)
+    let status = secItemClient.add(addQuery as CFDictionary, nil)
 
     switch status {
     case errSecSuccess:
@@ -44,7 +50,7 @@ struct SystemKeychain: KeychainStorage {
         kSecValueData as String: data,
         kSecAttrAccessible as String: accessibility.secValue,
       ]
-      let updateStatus = SecItemUpdate(updateQuery as CFDictionary, attributes as CFDictionary)
+      let updateStatus = secItemClient.update(updateQuery as CFDictionary, attributes as CFDictionary)
       guard updateStatus == errSecSuccess else {
         throw KeychainError.unexpectedStatus(updateStatus)
       }
@@ -59,7 +65,7 @@ struct SystemKeychain: KeychainStorage {
     query[kSecMatchLimit as String] = kSecMatchLimitOne
 
     var result: CFTypeRef?
-    let status = SecItemCopyMatching(query as CFDictionary, &result)
+    let status = secItemClient.copyMatching(query as CFDictionary, &result)
 
     switch status {
     case errSecSuccess:
@@ -72,7 +78,7 @@ struct SystemKeychain: KeychainStorage {
   }
 
   func deleteItem(forKey key: String) throws {
-    let status = SecItemDelete(baseQuery(for: key) as CFDictionary)
+    let status = secItemClient.delete(baseQuery(for: key) as CFDictionary)
     switch status {
     case errSecSuccess, errSecItemNotFound:
       return
@@ -87,7 +93,7 @@ struct SystemKeychain: KeychainStorage {
     query[kSecReturnAttributes as String] = false
     query[kSecReturnData as String] = false
 
-    let status = SecItemCopyMatching(query as CFDictionary, nil)
+    let status = secItemClient.copyMatching(query as CFDictionary, nil)
     switch status {
     case errSecSuccess:
       return true
@@ -109,13 +115,28 @@ struct SystemKeychain: KeychainStorage {
 
     if let accessGroup {
       query[kSecAttrAccessGroup as String] = accessGroup
-      // Route to the data-protection keychain. On macOS this is the only
-      // keychain that honors `kSecAttrAccessGroup` without falling back to
-      // per-item ACL prompts ("X wants to use the 'session' keychain").
-      // No-op on iOS where the data-protection keychain is the default.
+    }
+
+    if useDataProtectionKeychain {
       query[kSecUseDataProtectionKeychain as String] = kCFBooleanTrue
     }
 
     return query
+  }
+
+  /// Wraps Apple's global SecItem functions so unit tests can verify the
+  /// generated keychain queries without touching the real system keychain.
+  struct SecItemClient {
+    var add: @Sendable (CFDictionary, UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
+    var update: @Sendable (CFDictionary, CFDictionary) -> OSStatus
+    var copyMatching: @Sendable (CFDictionary, UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
+    var delete: @Sendable (CFDictionary) -> OSStatus
+
+    static let live = Self(
+      add: { SecItemAdd($0, $1) },
+      update: { SecItemUpdate($0, $1) },
+      copyMatching: { SecItemCopyMatching($0, $1) },
+      delete: { SecItemDelete($0) }
+    )
   }
 }

--- a/Sources/ClerkKit/Storage/Keychain/SystemKeychain.swift
+++ b/Sources/ClerkKit/Storage/Keychain/SystemKeychain.swift
@@ -127,10 +127,10 @@ struct SystemKeychain: KeychainStorage {
   /// Wraps Apple's global SecItem functions so unit tests can verify the
   /// generated keychain queries without touching the real system keychain.
   struct SecItemClient {
-    var add: @Sendable (CFDictionary, UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
-    var update: @Sendable (CFDictionary, CFDictionary) -> OSStatus
-    var copyMatching: @Sendable (CFDictionary, UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
-    var delete: @Sendable (CFDictionary) -> OSStatus
+    let add: @Sendable (CFDictionary, UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
+    let update: @Sendable (CFDictionary, CFDictionary) -> OSStatus
+    let copyMatching: @Sendable (CFDictionary, UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
+    let delete: @Sendable (CFDictionary) -> OSStatus
 
     static let live = Self(
       add: { SecItemAdd($0, $1) },

--- a/Tests/Dependencies/DependencyContainerKeychainTests.swift
+++ b/Tests/Dependencies/DependencyContainerKeychainTests.swift
@@ -1,0 +1,38 @@
+//
+//  DependencyContainerKeychainTests.swift
+//  Clerk
+//
+
+@testable import ClerkKit
+import Testing
+
+struct DependencyContainerKeychainTests {
+  @Test
+  @MainActor
+  func keychainStorageWithoutAccessGroupUsesSystemKeychain() throws {
+    let container = try DependencyContainer(
+      publishableKey: testPublishableKey,
+      options: .init(
+        keychainConfig: .init(service: "service")
+      )
+    )
+
+    #expect(container.keychain is SystemKeychain)
+  }
+
+  @Test
+  @MainActor
+  func keychainStorageWithAccessGroupUsesMigratingStorage() throws {
+    let container = try DependencyContainer(
+      publishableKey: testPublishableKey,
+      options: .init(
+        keychainConfig: .init(
+          service: "service",
+          accessGroup: "group.example"
+        )
+      )
+    )
+
+    #expect(container.keychain is MigratingKeychainStorage)
+  }
+}

--- a/Tests/Dependencies/DependencyContainerKeychainTests.swift
+++ b/Tests/Dependencies/DependencyContainerKeychainTests.swift
@@ -20,6 +20,7 @@ struct DependencyContainerKeychainTests {
     #expect(container.keychain is SystemKeychain)
   }
 
+  #if os(macOS)
   @Test
   @MainActor
   func keychainStorageWithAccessGroupUsesMigratingStorage() throws {
@@ -35,4 +36,5 @@ struct DependencyContainerKeychainTests {
 
     #expect(container.keychain is MigratingKeychainStorage)
   }
+  #endif
 }

--- a/Tests/Storage/MigratingKeychainStorageTests.swift
+++ b/Tests/Storage/MigratingKeychainStorageTests.swift
@@ -1,0 +1,257 @@
+//
+//  MigratingKeychainStorageTests.swift
+//  Clerk
+//
+
+@testable import ClerkKit
+import Foundation
+import Testing
+
+@Suite(.serialized)
+struct MigratingKeychainStorageTests {
+  @Test
+  func dataMigratesFallbackItemWhenPrimaryItemIsMissing() throws {
+    let primary = KeychainStorageSpy()
+    let fallback = KeychainStorageSpy()
+    let fallbackData = Data("fallback-value".utf8)
+    primary.dataResults = [.success(nil)]
+    fallback.dataResults = [.success(fallbackData)]
+
+    let keychain = MigratingKeychainStorage(
+      primary: primary,
+      fallback: fallback
+    )
+
+    let data = try keychain.data(forKey: "key")
+
+    #expect(data == fallbackData)
+    #expect(primary.dataKeys == ["key"])
+    #expect(fallback.dataKeys == ["key"])
+    #expect(primary.setCalls == [.init(key: "key", data: fallbackData)])
+    #expect(fallback.setCalls.isEmpty)
+    #expect(primary.deleteKeys.isEmpty)
+    #expect(fallback.deleteKeys.isEmpty)
+  }
+
+  @Test
+  func dataDoesNotReadFallbackWhenPrimaryItemExists() throws {
+    let primary = KeychainStorageSpy()
+    let fallback = KeychainStorageSpy()
+    let primaryData = Data("primary-value".utf8)
+    primary.dataResults = [.success(primaryData)]
+
+    let keychain = MigratingKeychainStorage(
+      primary: primary,
+      fallback: fallback
+    )
+
+    let data = try keychain.data(forKey: "key")
+
+    #expect(data == primaryData)
+    #expect(primary.dataKeys == ["key"])
+    #expect(fallback.dataKeys.isEmpty)
+    #expect(primary.setCalls.isEmpty)
+  }
+
+  @Test
+  func dataReturnsNilWhenPrimaryAndFallbackMiss() throws {
+    let primary = KeychainStorageSpy()
+    let fallback = KeychainStorageSpy()
+    primary.dataResults = [.success(nil)]
+    fallback.dataResults = [.success(nil)]
+
+    let keychain = MigratingKeychainStorage(
+      primary: primary,
+      fallback: fallback
+    )
+
+    let data = try keychain.data(forKey: "key")
+
+    #expect(data == nil)
+    #expect(primary.dataKeys == ["key"])
+    #expect(fallback.dataKeys == ["key"])
+    #expect(primary.setCalls.isEmpty)
+  }
+
+  @Test
+  func dataReturnsFallbackItemWhenMigrationWriteFails() throws {
+    let primary = KeychainStorageSpy()
+    let fallback = KeychainStorageSpy()
+    let fallbackData = Data("fallback-value".utf8)
+    primary.dataResults = [.success(nil)]
+    primary.setError = TestKeychainError.writeFailed
+    fallback.dataResults = [.success(fallbackData)]
+
+    let keychain = MigratingKeychainStorage(
+      primary: primary,
+      fallback: fallback
+    )
+
+    let data = try keychain.data(forKey: "key")
+
+    #expect(data == fallbackData)
+    #expect(primary.setCalls == [.init(key: "key", data: fallbackData)])
+    #expect(primary.deleteKeys.isEmpty)
+    #expect(fallback.deleteKeys.isEmpty)
+  }
+
+  @Test
+  func dataDoesNotReadFallbackWhenPrimaryThrows() throws {
+    let primary = KeychainStorageSpy()
+    let fallback = KeychainStorageSpy()
+    primary.dataResults = [.failure(TestKeychainError.readFailed)]
+
+    let keychain = MigratingKeychainStorage(
+      primary: primary,
+      fallback: fallback
+    )
+
+    do {
+      _ = try keychain.data(forKey: "key")
+      Issue.record("Expected data(forKey:) to throw")
+    } catch {
+      #expect(error as? TestKeychainError == .readFailed)
+      #expect(fallback.dataKeys.isEmpty)
+    }
+  }
+
+  @Test
+  func setWritesOnlyToPrimary() throws {
+    let primary = KeychainStorageSpy()
+    let fallback = KeychainStorageSpy()
+    let keychain = MigratingKeychainStorage(
+      primary: primary,
+      fallback: fallback
+    )
+
+    try keychain.set(Data("value".utf8), forKey: "key")
+
+    #expect(primary.setCalls == [.init(key: "key", data: Data("value".utf8))])
+    #expect(fallback.setCalls.isEmpty)
+  }
+
+  @Test
+  func deleteAttemptsPrimaryAndFallback() throws {
+    let primary = KeychainStorageSpy()
+    let fallback = KeychainStorageSpy()
+    let keychain = MigratingKeychainStorage(
+      primary: primary,
+      fallback: fallback
+    )
+
+    try keychain.deleteItem(forKey: "key")
+
+    #expect(primary.deleteKeys == ["key"])
+    #expect(fallback.deleteKeys == ["key"])
+  }
+
+  @Test
+  func deleteAttemptsFallbackWhenPrimaryDeleteFails() throws {
+    let primary = KeychainStorageSpy()
+    let fallback = KeychainStorageSpy()
+    primary.deleteError = TestKeychainError.deleteFailed
+    let keychain = MigratingKeychainStorage(
+      primary: primary,
+      fallback: fallback
+    )
+
+    do {
+      try keychain.deleteItem(forKey: "key")
+      Issue.record("Expected deleteItem(forKey:) to throw")
+    } catch {
+      #expect(error as? TestKeychainError == .deleteFailed)
+      #expect(primary.deleteKeys == ["key"])
+      #expect(fallback.deleteKeys == ["key"])
+    }
+  }
+
+  @Test
+  func hasItemFallsBackWhenPrimaryItemIsMissing() throws {
+    let primary = KeychainStorageSpy()
+    let fallback = KeychainStorageSpy()
+    primary.hasItemResults = [.success(false)]
+    fallback.hasItemResults = [.success(true)]
+    let keychain = MigratingKeychainStorage(
+      primary: primary,
+      fallback: fallback
+    )
+
+    #expect(try keychain.hasItem(forKey: "key"))
+    #expect(primary.hasItemKeys == ["key"])
+    #expect(fallback.hasItemKeys == ["key"])
+  }
+
+  @Test
+  func hasItemDoesNotReadFallbackWhenPrimaryItemExists() throws {
+    let primary = KeychainStorageSpy()
+    let fallback = KeychainStorageSpy()
+    primary.hasItemResults = [.success(true)]
+    let keychain = MigratingKeychainStorage(
+      primary: primary,
+      fallback: fallback
+    )
+
+    #expect(try keychain.hasItem(forKey: "key"))
+    #expect(primary.hasItemKeys == ["key"])
+    #expect(fallback.hasItemKeys.isEmpty)
+  }
+}
+
+private final class KeychainStorageSpy: KeychainStorage, @unchecked Sendable {
+  struct SetCall: Equatable {
+    let key: String
+    let data: Data
+  }
+
+  var dataResults: [Result<Data?, Error>] = []
+  var hasItemResults: [Result<Bool, Error>] = []
+  var setError: Error?
+  var deleteError: Error?
+
+  var setCalls: [SetCall] = []
+  var dataKeys: [String] = []
+  var deleteKeys: [String] = []
+  var hasItemKeys: [String] = []
+
+  func set(_ data: Data, forKey key: String) throws {
+    setCalls.append(.init(key: key, data: data))
+
+    if let setError {
+      throw setError
+    }
+  }
+
+  func data(forKey key: String) throws -> Data? {
+    dataKeys.append(key)
+
+    guard !dataResults.isEmpty else {
+      return nil
+    }
+
+    return try dataResults.removeFirst().get()
+  }
+
+  func deleteItem(forKey key: String) throws {
+    deleteKeys.append(key)
+
+    if let deleteError {
+      throw deleteError
+    }
+  }
+
+  func hasItem(forKey key: String) throws -> Bool {
+    hasItemKeys.append(key)
+
+    guard !hasItemResults.isEmpty else {
+      return false
+    }
+
+    return try hasItemResults.removeFirst().get()
+  }
+}
+
+private enum TestKeychainError: Error {
+  case readFailed
+  case writeFailed
+  case deleteFailed
+}

--- a/Tests/Storage/SystemKeychainTests.swift
+++ b/Tests/Storage/SystemKeychainTests.swift
@@ -7,6 +7,7 @@
 
 @testable import ClerkKit
 import Foundation
+import Security
 import Testing
 
 /// Tests for KeychainStorage protocol operations.
@@ -91,4 +92,131 @@ struct SystemKeychainTests {
     let data = try keychain2.data(forKey: "shared-key")
     #expect(data == nil)
   }
+
+  @Test
+  func dataProtectionKeychainWritesUseDataProtectionFlag() throws {
+    let secItemClient = SecItemClientSpy()
+    let keychain = SystemKeychain(
+      service: "service",
+      accessGroup: "group.example",
+      useDataProtectionKeychain: true,
+      secItemClient: secItemClient.client
+    )
+
+    try keychain.set(Data("value".utf8), forKey: "key")
+
+    let query = try #require(secItemClient.addQueries.first)
+    #expect(query[kSecAttrAccessGroup as String] as? String == "group.example")
+    #expect(hasDataProtectionKeychainFlag(query))
+  }
+
+  @Test
+  func accessGroupWithoutDataProtectionFlagUsesLegacyKeychain() throws {
+    let secItemClient = SecItemClientSpy()
+    let keychain = SystemKeychain(
+      service: "service",
+      accessGroup: "group.example",
+      secItemClient: secItemClient.client
+    )
+
+    try keychain.set(Data("value".utf8), forKey: "key")
+
+    let query = try #require(secItemClient.addQueries.first)
+    #expect(query[kSecAttrAccessGroup as String] as? String == "group.example")
+    #expect(!hasDataProtectionKeychainFlag(query))
+  }
+
+  @Test
+  func noAccessGroupUsesLegacyKeychain() throws {
+    let secItemClient = SecItemClientSpy()
+    let keychain = SystemKeychain(
+      service: "service",
+      secItemClient: secItemClient.client
+    )
+
+    try keychain.set(Data("value".utf8), forKey: "key")
+
+    let query = try #require(secItemClient.addQueries.first)
+    #expect(query[kSecAttrAccessGroup as String] == nil)
+    #expect(!hasDataProtectionKeychainFlag(query))
+  }
+
+  @Test
+  func dataReadsFromConfiguredBackendOnly() throws {
+    let secItemClient = SecItemClientSpy()
+    secItemClient.copyMatchingResults = [
+      .success(Data("value".utf8)),
+    ]
+    let keychain = SystemKeychain(
+      service: "service",
+      accessGroup: "group.example",
+      useDataProtectionKeychain: true,
+      secItemClient: secItemClient.client
+    )
+
+    let data = try keychain.data(forKey: "key")
+
+    #expect(data == Data("value".utf8))
+    #expect(secItemClient.copyMatchingQueries.count == 1)
+    #expect(hasDataProtectionKeychainFlag(secItemClient.copyMatchingQueries[0]))
+  }
+}
+
+private final class SecItemClientSpy: @unchecked Sendable {
+  enum CopyMatchingResult {
+    case success(Data)
+    case status(OSStatus)
+  }
+
+  var addResults: [OSStatus] = []
+  var updateResults: [OSStatus] = []
+  var copyMatchingResults: [CopyMatchingResult] = []
+  var deleteResults: [OSStatus] = []
+
+  var addQueries: [[String: Any]] = []
+  var updateQueries: [[String: Any]] = []
+  var updateAttributes: [[String: Any]] = []
+  var copyMatchingQueries: [[String: Any]] = []
+  var deleteQueries: [[String: Any]] = []
+
+  var client: SystemKeychain.SecItemClient {
+    .init(
+      add: { query, _ in
+        self.addQueries.append(Self.dictionary(from: query))
+        return self.addResults.isEmpty ? errSecSuccess : self.addResults.removeFirst()
+      },
+      update: { query, attributes in
+        self.updateQueries.append(Self.dictionary(from: query))
+        self.updateAttributes.append(Self.dictionary(from: attributes))
+        return self.updateResults.isEmpty ? errSecSuccess : self.updateResults.removeFirst()
+      },
+      copyMatching: { query, result in
+        self.copyMatchingQueries.append(Self.dictionary(from: query))
+
+        guard !self.copyMatchingResults.isEmpty else {
+          return errSecItemNotFound
+        }
+
+        switch self.copyMatchingResults.removeFirst() {
+        case .success(let data):
+          result?.pointee = data as CFData
+          return errSecSuccess
+        case .status(let status):
+          return status
+        }
+      },
+      delete: { query in
+        self.deleteQueries.append(Self.dictionary(from: query))
+        return self.deleteResults.isEmpty ? errSecSuccess : self.deleteResults.removeFirst()
+      }
+    )
+  }
+
+  private static func dictionary(from query: CFDictionary) -> [String: Any] {
+    query as NSDictionary as? [String: Any] ?? [:]
+  }
+}
+
+private func hasDataProtectionKeychainFlag(_ query: [String: Any]) -> Bool {
+  query[kSecUseDataProtectionKeychain as String] as? Bool == true
 }


### PR DESCRIPTION
## Problem

On macOS, `SecItem*` defaults to the **legacy login keychain** unless `kSecUseDataProtectionKeychain: true` is explicitly set. The legacy keychain enforces per-item ACLs based on the calling binary's Designated Requirement, so any signature change (`xcodebuild` Debug → DMG, cert rotation, new build machine) triggers a *"X wants to use the 'session' keychain"* prompt — once per item.

`SystemKeychain` reads/writes 5–6 items at boot under typical signed-in conditions (`cachedClient`, `cachedClientServerDate`, `cachedEnvironment`, `clerkDeviceToken`, `clerkDeviceTokenSynced`), which produces 5–6 sequential prompts on every fresh install on macOS — even when the consumer passes a `KeychainConfig(accessGroup:)`.

This is the case in our app: keychain-access-groups entitlement and `KeychainConfig.accessGroup` are both set to a `<TeamID>.<bundle>` group, but users still see 5–6 prompts because the items end up in the legacy keychain.

## Fix

Set `kSecUseDataProtectionKeychain: true` whenever an access group is configured:

```swift
if let accessGroup {
  query[kSecAttrAccessGroup as String] = accessGroup
  query[kSecUseDataProtectionKeychain as String] = kCFBooleanTrue
}
```

The flag is iOS-only-by-default, so this is a **no-op on iOS** (DPK is already the default). On macOS, it routes operations to the data-protection keychain, which honors `kSecAttrAccessGroup` natively without surfacing ACL prompts.

This is gated on `accessGroup != nil` to keep the existing behavior for callers that opt out of access groups (although on macOS those callers are already unable to share keychain items, so the prompts are arguably a bug for them too — happy to drop the gate if maintainers prefer).

## Why this is the minimal fix

A more thorough refactor would expose `accessibility` and `useDataProtectionKeychain` as `KeychainConfig` options, but:

1. It changes the public API surface,
2. The current default (`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`) is correct on DPK,
3. The prompt loop is the only known failure mode, and it's fully addressed by this one-line change.

I'm happy to follow up with a PR that exposes those options if you'd prefer.

## Validation

- `swift build` on `fix/macos-data-protection-keychain` ✅
- Manual repro before patch: 5–6 prompts on every cold launch of a freshly-installed signed macOS app.
- Manual repro after patch: 0 prompts (testing in progress on signed staging build of our app).

## Reference

Downstream issue describing the symptom in detail: ramygif/exact#231 (RAM-140).