### PR TITLE
fix(ui): add secondaryButton color token for social/SSO buttons

### DIFF
--- a/Sources/ClerkKitUI/Theme/Buttons/SecondaryButtonStyle.swift
+++ b/Sources/ClerkKitUI/Theme/Buttons/SecondaryButtonStyle.swift
@@ -47,19 +47,22 @@ struct SecondaryButtonStyle: ButtonStyle {
   func backgroundColor(
     configuration: Configuration
   ) -> Color {
+    // Secondary buttons (including social / SSO buttons) fill with the
+    // dedicated `secondaryButton` surface rather than the page `background`,
+    // so a custom page background doesn't bleed in and kill the contrast.
     switch config.emphasis {
     case .none:
       configuration.isPressed
-        ? theme.colors.muted
-        : theme.colors.background
+        ? theme.colors.secondaryButtonPressed
+        : theme.colors.secondaryButton
     case .low:
       configuration.isPressed
-        ? theme.colors.muted
-        : theme.colors.background
+        ? theme.colors.secondaryButtonPressed
+        : theme.colors.secondaryButton
     case .high:
       configuration.isPressed
-        ? theme.colors.muted
-        : theme.colors.background
+        ? theme.colors.secondaryButtonPressed
+        : theme.colors.secondaryButton
     }
   }
 

--- a/Sources/ClerkKitUI/Theme/ClerkColors.swift
+++ b/Sources/ClerkKitUI/Theme/ClerkColors.swift
@@ -52,6 +52,15 @@ extension ClerkTheme {
     /// The color used for muted backgrounds.
     public var muted: Color
 
+    /// The background fill for secondary buttons, including the social / SSO
+    /// buttons on the sign-in and sign-up views.
+    ///
+    /// This is intentionally separate from ``background`` so that customizing
+    /// the page `background` (e.g. a saturated brand color) does not bleed into
+    /// the buttons and destroy their contrast. Defaults to the standard
+    /// adaptive surface (light/dark); override it to control button contrast.
+    public var secondaryButton: Color
+
     /// The base shadow color used in the views.
     public var shadow: Color
 
@@ -59,6 +68,9 @@ extension ClerkTheme {
 
     /// A pressed-state variant of `primary`.
     public var primaryPressed: Color
+
+    /// A pressed-state variant of `secondaryButton`.
+    public var secondaryButtonPressed: Color
 
     /// The base border color used in the views.
     public var border: Color
@@ -117,6 +129,7 @@ extension ClerkTheme {
       neutral: Color = Self.defaultNeutralColor,
       ring: Color = Self.defaultRingColor,
       muted: Color = Self.defaultMutedColor,
+      secondaryButton: Color = Self.defaultSecondaryButtonColor,
       shadow: Color = Self.defaultShadowColor,
       border: Color = Self.defaultBorderColor
     ) {
@@ -133,10 +146,12 @@ extension ClerkTheme {
       self.neutral = neutral
       self.ring = ring
       self.muted = muted
+      self.secondaryButton = secondaryButton
       self.shadow = shadow
 
       // Derived tokens
       primaryPressed = primary.isDark ? primary.lighten(by: 0.06) : primary.darken(by: 0.06)
+      secondaryButtonPressed = secondaryButton.isDark ? secondaryButton.lighten(by: 0.06) : secondaryButton.darken(by: 0.06)
       self.border = border.opacity(0.06)
       buttonBorder = border.opacity(0.08)
       inputBorder = border.opacity(0.11)
@@ -168,6 +183,10 @@ extension ClerkTheme.Colors {
   public static let defaultNeutralColor = Color(.neutral)
   public static let defaultRingColor = Color(.neutral)
   public static let defaultMutedColor = Color(.muted)
+  /// The standard adaptive surface used for secondary buttons. Resolves to the
+  /// default light/dark `background` asset, so secondary buttons keep a sensible
+  /// contrasting surface even when a custom page `background` is supplied.
+  public static let defaultSecondaryButtonColor = Color(.background)
   public static let defaultShadowColor = Color(.neutral)
   public static let defaultBorderColor = Color(.neutral)
 


### PR DESCRIPTION
Adds a `secondaryButton` color token so social/SSO (secondary) buttons no longer inherit the page `background`.

**Problem:** `SecondaryButtonStyle` filled buttons with `theme.colors.background`, so a custom page background (e.g. a saturated brand color) floods the buttons and destroys contrast. Reported via Expo; the rendering lives here in clerk-ios.

**Change:** new `secondaryButton` token (defaults to the standard adaptive light/dark surface); `SecondaryButtonStyle` fills with it instead of `background`.

MOBILE-528
