### PR TITLE
Persist auth start identifier mode

### DIFF
--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -21,7 +21,6 @@ struct AuthStartView: View {
 
   // MARK: - State
 
-  @SceneStorage("phoneNumberFieldIsActive") private var phoneNumberFieldIsActive = false
   @State private var fieldError: Error?
   @State private var generalError: Error?
   @State private var lastUsedAuth: LastUsedAuth?
@@ -41,6 +40,10 @@ struct AuthStartView: View {
   var phoneNumberIsEnabled: Bool {
     clerk.environment?.enabledFirstFactorAttributes
       .contains("phone_number") ?? false
+  }
+
+  var phoneNumberFieldIsActive: Bool {
+    authState.authStartPhoneNumberFieldIsActive
   }
 
   var showIdentifierField: Bool {
@@ -181,9 +184,9 @@ struct AuthStartView: View {
         lastUsedAuth = LastUsedAuth(environment: Clerk.shared.environment)
       }
       if authState.hasInitialValues {
-        phoneNumberFieldIsActive = shouldStartOnPhoneNumber
+        authState.authStartPhoneNumberFieldIsActive = shouldStartOnPhoneNumber
       } else if shouldStartOnPhoneNumber {
-        phoneNumberFieldIsActive = true
+        authState.authStartPhoneNumberFieldIsActive = true
       }
     }
   }
@@ -264,7 +267,7 @@ extension AuthStartView {
   private var identifierSwitcherButton: some View {
     Button {
       withAnimation(.default.speed(2)) {
-        phoneNumberFieldIsActive.toggle()
+        authState.authStartPhoneNumberFieldIsActive.toggle()
       }
     } label: {
       Text(identifierSwitcherString, bundle: .module)

--- a/Sources/ClerkKitUI/Components/Auth/AuthState.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthState.swift
@@ -38,6 +38,7 @@ final class AuthState {
     self.userDefaults = userDefaults
     authStartIdentifier = userDefaults.string(forKey: Self.identifierStorageKey) ?? ""
     authStartPhoneNumber = userDefaults.string(forKey: Self.phoneNumberStorageKey) ?? ""
+    authStartPhoneNumberFieldIsActive = userDefaults.bool(forKey: Self.phoneNumberFieldIsActiveStorageKey)
     configure(config)
   }
 
@@ -68,6 +69,14 @@ final class AuthState {
     }
   }
 
+  var authStartPhoneNumberFieldIsActive = false {
+    didSet {
+      if persistsIdentifiers {
+        userDefaults.set(authStartPhoneNumberFieldIsActive, forKey: Self.phoneNumberFieldIsActiveStorageKey)
+      }
+    }
+  }
+
   /// Applies auth flow configuration values.
   func configure(_ config: AuthConfig) {
     persistsIdentifiers = config.persistsIdentifiers
@@ -77,6 +86,7 @@ final class AuthState {
     if !config.persistsIdentifiers {
       userDefaults.removeObject(forKey: Self.identifierStorageKey)
       userDefaults.removeObject(forKey: Self.phoneNumberStorageKey)
+      userDefaults.removeObject(forKey: Self.phoneNumberFieldIsActiveStorageKey)
       LastUsedAuth.clearStoredIdentifierType(userDefaults: userDefaults)
     }
 
@@ -91,6 +101,7 @@ final class AuthState {
     } else if !config.persistsIdentifiers {
       authStartIdentifier = ""
       authStartPhoneNumber = ""
+      authStartPhoneNumberFieldIsActive = false
     }
   }
 
@@ -118,6 +129,7 @@ final class AuthState {
 extension AuthState {
   static let identifierStorageKey = "authStartIdentifier"
   static let phoneNumberStorageKey = "authStartPhoneNumber"
+  static let phoneNumberFieldIsActiveStorageKey = "authStartPhoneNumberFieldIsActive"
 }
 
 #endif

--- a/Sources/ClerkKitUI/Components/Auth/AuthState.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthState.swift
@@ -92,9 +92,11 @@ final class AuthState {
 
     if let identifier = config.initialIdentifier {
       if identifier.looksLikePhoneNumber {
+        authStartPhoneNumberFieldIsActive = true
         authStartPhoneNumber = identifier
         authStartIdentifier = ""
       } else {
+        authStartPhoneNumberFieldIsActive = false
         authStartIdentifier = identifier
         authStartPhoneNumber = ""
       }

--- a/Tests/UI/AuthStateConfigurationTests.swift
+++ b/Tests/UI/AuthStateConfigurationTests.swift
@@ -12,11 +12,13 @@ struct AuthStateConfigurationTests {
     let defaults = makeUserDefaults()
     defaults.set("stored@example.com", forKey: AuthState.identifierStorageKey)
     defaults.set("15555550100", forKey: AuthState.phoneNumberStorageKey)
+    defaults.set(true, forKey: AuthState.phoneNumberFieldIsActiveStorageKey)
 
     let authState = AuthState(userDefaults: defaults)
 
     #expect(authState.authStartIdentifier == "stored@example.com")
     #expect(authState.authStartPhoneNumber == "15555550100")
+    #expect(authState.authStartPhoneNumberFieldIsActive)
   }
 
   @Test
@@ -26,9 +28,11 @@ struct AuthStateConfigurationTests {
 
     authState.authStartIdentifier = "edited@example.com"
     authState.authStartPhoneNumber = "16666660123"
+    authState.authStartPhoneNumberFieldIsActive = true
 
     #expect(defaults.string(forKey: AuthState.identifierStorageKey) == "edited@example.com")
     #expect(defaults.string(forKey: AuthState.phoneNumberStorageKey) == "16666660123")
+    #expect(defaults.bool(forKey: AuthState.phoneNumberFieldIsActiveStorageKey))
   }
 
   @Test
@@ -67,6 +71,7 @@ struct AuthStateConfigurationTests {
     let defaults = makeUserDefaults()
     defaults.set("stored@example.com", forKey: AuthState.identifierStorageKey)
     defaults.set("15555550100", forKey: AuthState.phoneNumberStorageKey)
+    defaults.set(true, forKey: AuthState.phoneNumberFieldIsActiveStorageKey)
     LastUsedAuth.storeIdentifierType(.email, userDefaults: defaults)
 
     let authState = AuthState(userDefaults: defaults)
@@ -76,8 +81,10 @@ struct AuthStateConfigurationTests {
 
     #expect(authState.authStartIdentifier.isEmpty)
     #expect(authState.authStartPhoneNumber.isEmpty)
+    #expect(!authState.authStartPhoneNumberFieldIsActive)
     #expect(defaults.string(forKey: AuthState.identifierStorageKey) == nil)
     #expect(defaults.string(forKey: AuthState.phoneNumberStorageKey) == nil)
+    #expect(defaults.object(forKey: AuthState.phoneNumberFieldIsActiveStorageKey) == nil)
     #expect(LastUsedAuth.retrieveStoredIdentifierType(userDefaults: defaults) == nil)
   }
 
@@ -91,9 +98,11 @@ struct AuthStateConfigurationTests {
 
     authState.authStartIdentifier = "new@example.com"
     authState.authStartPhoneNumber = "19999990123"
+    authState.authStartPhoneNumberFieldIsActive = true
 
     #expect(defaults.string(forKey: AuthState.identifierStorageKey) == nil)
     #expect(defaults.string(forKey: AuthState.phoneNumberStorageKey) == nil)
+    #expect(defaults.object(forKey: AuthState.phoneNumberFieldIsActiveStorageKey) == nil)
   }
 
   @Test
@@ -101,6 +110,7 @@ struct AuthStateConfigurationTests {
     let defaults = makeUserDefaults()
     defaults.set("stored@example.com", forKey: AuthState.identifierStorageKey)
     defaults.set("15555550100", forKey: AuthState.phoneNumberStorageKey)
+    defaults.set(true, forKey: AuthState.phoneNumberFieldIsActiveStorageKey)
     LastUsedAuth.storeIdentifierType(.phone, userDefaults: defaults)
 
     let authState = AuthState(userDefaults: defaults)
@@ -113,6 +123,7 @@ struct AuthStateConfigurationTests {
     #expect(authState.authStartPhoneNumber.isEmpty)
     #expect(defaults.string(forKey: AuthState.identifierStorageKey) == nil)
     #expect(defaults.string(forKey: AuthState.phoneNumberStorageKey) == nil)
+    #expect(defaults.object(forKey: AuthState.phoneNumberFieldIsActiveStorageKey) == nil)
     #expect(LastUsedAuth.retrieveStoredIdentifierType(userDefaults: defaults) == nil)
   }
 

--- a/Tests/UI/AuthStateConfigurationTests.swift
+++ b/Tests/UI/AuthStateConfigurationTests.swift
@@ -128,6 +128,28 @@ struct AuthStateConfigurationTests {
   }
 
   @Test
+  func disablingPersistenceWithInitialPhoneNumberShowsButDoesNotStore() {
+    let defaults = makeUserDefaults()
+    defaults.set("stored@example.com", forKey: AuthState.identifierStorageKey)
+    defaults.set("15555550100", forKey: AuthState.phoneNumberStorageKey)
+    defaults.set(false, forKey: AuthState.phoneNumberFieldIsActiveStorageKey)
+    LastUsedAuth.storeIdentifierType(.email, userDefaults: defaults)
+
+    let authState = AuthState(userDefaults: defaults)
+    authState.configure(AuthIdentifierConfig(
+      initialIdentifier: "+17777770123",
+      persistsIdentifiers: false
+    ))
+
+    #expect(authState.authStartPhoneNumber == "+17777770123")
+    #expect(authState.authStartIdentifier.isEmpty)
+    #expect(defaults.string(forKey: AuthState.identifierStorageKey) == nil)
+    #expect(defaults.string(forKey: AuthState.phoneNumberStorageKey) == nil)
+    #expect(defaults.object(forKey: AuthState.phoneNumberFieldIsActiveStorageKey) == nil)
+    #expect(LastUsedAuth.retrieveStoredIdentifierType(userDefaults: defaults) == nil)
+  }
+
+  @Test
   func configurationStoresUnsafeMetadata() {
     let defaults = makeUserDefaults()
     let authState = AuthState(userDefaults: defaults)

--- a/Tests/UI/AuthStateConfigurationTests.swift
+++ b/Tests/UI/AuthStateConfigurationTests.swift
@@ -136,7 +136,7 @@ struct AuthStateConfigurationTests {
     LastUsedAuth.storeIdentifierType(.email, userDefaults: defaults)
 
     let authState = AuthState(userDefaults: defaults)
-    authState.configure(AuthIdentifierConfig(
+    authState.configure(AuthConfig(
       initialIdentifier: "+17777770123",
       persistsIdentifiers: false
     ))

--- a/Tests/UI/AuthStateConfigurationTests.swift
+++ b/Tests/UI/AuthStateConfigurationTests.swift
@@ -40,6 +40,7 @@ struct AuthStateConfigurationTests {
     let defaults = makeUserDefaults()
     defaults.set("stored@example.com", forKey: AuthState.identifierStorageKey)
     defaults.set("15555550100", forKey: AuthState.phoneNumberStorageKey)
+    defaults.set(true, forKey: AuthState.phoneNumberFieldIsActiveStorageKey)
 
     let authState = AuthState(userDefaults: defaults)
     authState.configure(AuthConfig(
@@ -48,7 +49,9 @@ struct AuthStateConfigurationTests {
 
     #expect(authState.authStartIdentifier == "seed@example.com")
     #expect(authState.authStartPhoneNumber.isEmpty)
+    #expect(!authState.authStartPhoneNumberFieldIsActive)
     #expect(defaults.string(forKey: AuthState.identifierStorageKey) == "seed@example.com")
+    #expect(!defaults.bool(forKey: AuthState.phoneNumberFieldIsActiveStorageKey))
   }
 
   @Test
@@ -56,6 +59,7 @@ struct AuthStateConfigurationTests {
     let defaults = makeUserDefaults()
     defaults.set("stored@example.com", forKey: AuthState.identifierStorageKey)
     defaults.set("15555550100", forKey: AuthState.phoneNumberStorageKey)
+    defaults.set(false, forKey: AuthState.phoneNumberFieldIsActiveStorageKey)
 
     let authState = AuthState(userDefaults: defaults)
     authState.configure(AuthConfig(
@@ -64,6 +68,8 @@ struct AuthStateConfigurationTests {
 
     #expect(authState.authStartPhoneNumber == "+17777770123")
     #expect(authState.authStartIdentifier.isEmpty)
+    #expect(authState.authStartPhoneNumberFieldIsActive)
+    #expect(defaults.bool(forKey: AuthState.phoneNumberFieldIsActiveStorageKey))
   }
 
   @Test
@@ -121,6 +127,7 @@ struct AuthStateConfigurationTests {
 
     #expect(authState.authStartIdentifier == "seed@example.com")
     #expect(authState.authStartPhoneNumber.isEmpty)
+    #expect(!authState.authStartPhoneNumberFieldIsActive)
     #expect(defaults.string(forKey: AuthState.identifierStorageKey) == nil)
     #expect(defaults.string(forKey: AuthState.phoneNumberStorageKey) == nil)
     #expect(defaults.object(forKey: AuthState.phoneNumberFieldIsActiveStorageKey) == nil)
@@ -143,6 +150,7 @@ struct AuthStateConfigurationTests {
 
     #expect(authState.authStartPhoneNumber == "+17777770123")
     #expect(authState.authStartIdentifier.isEmpty)
+    #expect(authState.authStartPhoneNumberFieldIsActive)
     #expect(defaults.string(forKey: AuthState.identifierStorageKey) == nil)
     #expect(defaults.string(forKey: AuthState.phoneNumberStorageKey) == nil)
     #expect(defaults.object(forKey: AuthState.phoneNumberFieldIsActiveStorageKey) == nil)


### PR DESCRIPTION
## Summary

This changes AuthStartView so the identifier input mode no longer depends on SwiftUI scene storage. The email/username vs phone-number toggle now reads and writes through AuthState, backed by UserDefaults when identifier persistence is enabled.

This is intended to try to fix an issue seen through the Expo SDK/native component integration where tapping the "Use phone number" / "Use email address" button was not toggling the text field input. In the pure SwiftUI flow the existing behavior worked, but scene storage appears unreliable in the Expo-hosted path, so the active field mode could fail to update even though the rest of the auth start state was intact.

The root cause this PR targets is that AuthStartView kept the active identifier field in @SceneStorage while the rest of the auth start identifier values already lived in AuthState. Moving this bit into AuthState keeps the same user-facing behavior, keeps persistence tied to the existing persistsIdentifiers setting, and avoids relying on scene storage for the native component path.

## Testing

- make test-ui
