### PR TITLE
Add in-session reverification API to Session

### DIFF
--- a/Sources/ClerkKit/Domains/Auth/Factor.swift
+++ b/Sources/ClerkKit/Domains/Auth/Factor.swift
@@ -18,25 +18,40 @@ public struct Factor: Codable, Equatable, Hashable, Sendable {
   /// The ID of the Web3 wallet that will be used to sign a message.
   public var web3WalletId: String?
 
+  /// The ID of the enterprise connection that will be used for SSO.
+  public var enterpriseConnectionId: String?
+
+  /// The display name of the enterprise connection that will be used for SSO.
+  public var enterpriseConnectionName: String?
+
   /// The safe identifier of the factor.
   public var safeIdentifier: String?
 
   /// Whether the factor is the primary factor.
   public var primary: Bool?
 
+  /// Whether the factor is the default second factor.
+  public var `default`: Bool?
+
   public init(
     strategy: FactorStrategy,
     emailAddressId: String? = nil,
     phoneNumberId: String? = nil,
     web3WalletId: String? = nil,
+    enterpriseConnectionId: String? = nil,
+    enterpriseConnectionName: String? = nil,
     safeIdentifier: String? = nil,
-    primary: Bool? = nil
+    primary: Bool? = nil,
+    default: Bool? = nil
   ) {
     self.strategy = strategy
     self.emailAddressId = emailAddressId
     self.phoneNumberId = phoneNumberId
     self.web3WalletId = web3WalletId
+    self.enterpriseConnectionId = enterpriseConnectionId
+    self.enterpriseConnectionName = enterpriseConnectionName
     self.safeIdentifier = safeIdentifier
     self.primary = primary
+    self.default = `default`
   }
 }

--- a/Sources/ClerkKit/Domains/Auth/Session/Session+ServiceParams.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/Session+ServiceParams.swift
@@ -15,22 +15,19 @@ extension Session {
     let phoneNumberId: String?
     let enterpriseConnectionId: String?
     let redirectUrl: String?
-    let `default`: Bool?
 
     init(
       strategy: FactorStrategy,
       emailAddressId: String? = nil,
       phoneNumberId: String? = nil,
       enterpriseConnectionId: String? = nil,
-      redirectUrl: String? = nil,
-      default: Bool? = nil
+      redirectUrl: String? = nil
     ) {
       self.strategy = strategy
       self.emailAddressId = emailAddressId
       self.phoneNumberId = phoneNumberId
       self.enterpriseConnectionId = enterpriseConnectionId
       self.redirectUrl = redirectUrl
-      self.default = `default`
     }
   }
 

--- a/Sources/ClerkKit/Domains/Auth/Session/Session+ServiceParams.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/Session+ServiceParams.swift
@@ -1,0 +1,70 @@
+//
+//  Session+ServiceParams.swift
+//
+
+import Foundation
+
+extension Session {
+  struct StartVerificationParams: Encodable {
+    let level: SessionVerification.Level
+  }
+
+  struct PrepareFirstFactorVerificationParams: Encodable {
+    let strategy: FactorStrategy
+    let emailAddressId: String?
+    let phoneNumberId: String?
+    let enterpriseConnectionId: String?
+    let redirectUrl: String?
+    let `default`: Bool?
+
+    init(
+      strategy: FactorStrategy,
+      emailAddressId: String? = nil,
+      phoneNumberId: String? = nil,
+      enterpriseConnectionId: String? = nil,
+      redirectUrl: String? = nil,
+      default: Bool? = nil
+    ) {
+      self.strategy = strategy
+      self.emailAddressId = emailAddressId
+      self.phoneNumberId = phoneNumberId
+      self.enterpriseConnectionId = enterpriseConnectionId
+      self.redirectUrl = redirectUrl
+      self.default = `default`
+    }
+  }
+
+  struct AttemptFirstFactorVerificationParams: Encodable {
+    let strategy: FactorStrategy
+    let code: String?
+    let password: String?
+    let publicKeyCredential: String?
+
+    init(
+      strategy: FactorStrategy,
+      code: String? = nil,
+      password: String? = nil,
+      publicKeyCredential: String? = nil
+    ) {
+      self.strategy = strategy
+      self.code = code
+      self.password = password
+      self.publicKeyCredential = publicKeyCredential
+    }
+  }
+
+  struct PrepareSecondFactorVerificationParams: Encodable {
+    let strategy: FactorStrategy
+    let phoneNumberId: String?
+
+    init(strategy: FactorStrategy, phoneNumberId: String? = nil) {
+      self.strategy = strategy
+      self.phoneNumberId = phoneNumberId
+    }
+  }
+
+  struct AttemptSecondFactorVerificationParams: Encodable {
+    let strategy: FactorStrategy
+    let code: String
+  }
+}

--- a/Sources/ClerkKit/Domains/Auth/Session/Session+Verification.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/Session+Verification.swift
@@ -1,0 +1,177 @@
+//
+//  Session+Verification.swift
+//
+
+#if canImport(AuthenticationServices) && !os(watchOS) && !os(tvOS)
+import AuthenticationServices
+#endif
+import Foundation
+
+extension Session {
+  // MARK: - Reverification (Step-up)
+
+  /// Starts an in-session reverification (step-up) flow.
+  ///
+  /// Use this when your backend has indicated that the current session's first factor is too
+  /// old and a fresh factor is required to perform a sensitive action. After completing the
+  /// returned verification, refresh the session token (for example with ``getToken(_:)``
+  /// using ``GetTokenOptions/skipCache``) so subsequent API calls carry an updated first-factor
+  /// age claim.
+  ///
+  /// - Parameter level: The verification level to request.
+  /// - Returns: A ``SessionVerification`` reflecting the current state of the flow.
+  @discardableResult @MainActor
+  public func startVerification(level: SessionVerification.Level) async throws -> SessionVerification {
+    try await Clerk.shared.dependencies.sessionService.startVerification(
+      sessionId: id,
+      params: .init(level: level)
+    )
+  }
+
+  /// Prepares the first factor of an in-session reverification flow.
+  ///
+  /// For strategies that do not require preparation (for example `password` or `passkey`'s
+  /// `attempt` step) you can skip this call and go straight to ``attemptFirstFactorVerification(strategy:code:password:publicKeyCredential:)``.
+  @discardableResult @MainActor
+  public func prepareFirstFactorVerification(
+    strategy: FactorStrategy,
+    emailAddressId: String? = nil,
+    phoneNumberId: String? = nil,
+    enterpriseConnectionId: String? = nil,
+    redirectUrl: String? = nil,
+    default: Bool? = nil
+  ) async throws -> SessionVerification {
+    try await Clerk.shared.dependencies.sessionService.prepareFirstFactorVerification(
+      sessionId: id,
+      params: .init(
+        strategy: strategy,
+        emailAddressId: emailAddressId,
+        phoneNumberId: phoneNumberId,
+        enterpriseConnectionId: enterpriseConnectionId,
+        redirectUrl: redirectUrl,
+        default: `default`
+      )
+    )
+  }
+
+  /// Attempts the first factor of an in-session reverification flow.
+  @discardableResult @MainActor
+  public func attemptFirstFactorVerification(
+    strategy: FactorStrategy,
+    code: String? = nil,
+    password: String? = nil,
+    publicKeyCredential: String? = nil
+  ) async throws -> SessionVerification {
+    try await Clerk.shared.dependencies.sessionService.attemptFirstFactorVerification(
+      sessionId: id,
+      params: .init(
+        strategy: strategy,
+        code: code,
+        password: password,
+        publicKeyCredential: publicKeyCredential
+      )
+    )
+  }
+
+  /// Prepares the second factor of an in-session reverification flow.
+  @discardableResult @MainActor
+  public func prepareSecondFactorVerification(
+    strategy: FactorStrategy,
+    phoneNumberId: String? = nil
+  ) async throws -> SessionVerification {
+    try await Clerk.shared.dependencies.sessionService.prepareSecondFactorVerification(
+      sessionId: id,
+      params: .init(strategy: strategy, phoneNumberId: phoneNumberId)
+    )
+  }
+
+  /// Attempts the second factor of an in-session reverification flow.
+  @discardableResult @MainActor
+  public func attemptSecondFactorVerification(
+    strategy: FactorStrategy,
+    code: String
+  ) async throws -> SessionVerification {
+    try await Clerk.shared.dependencies.sessionService.attemptSecondFactorVerification(
+      sessionId: id,
+      params: .init(strategy: strategy, code: code)
+    )
+  }
+
+  // MARK: - Convenience strategies
+
+  /// Verifies the current session by asking the user to re-enter their password.
+  @discardableResult @MainActor
+  public func verifyWithPassword(_ password: String) async throws -> SessionVerification {
+    try await attemptFirstFactorVerification(strategy: .password, password: password)
+  }
+
+  /// Verifies the current session with a TOTP code.
+  @discardableResult @MainActor
+  public func verifyWithTOTP(code: String) async throws -> SessionVerification {
+    try await attemptSecondFactorVerification(strategy: .totp, code: code)
+  }
+
+  /// Verifies the current session with a backup code.
+  @discardableResult @MainActor
+  public func verifyWithBackupCode(code: String) async throws -> SessionVerification {
+    try await attemptSecondFactorVerification(strategy: .backupCode, code: code)
+  }
+
+  #if canImport(AuthenticationServices) && !os(watchOS) && !os(tvOS)
+  /// Verifies the current session with a passkey.
+  ///
+  /// This convenience method prepares the passkey first-factor verification, requests the
+  /// platform credential, and attempts the verification in a single call.
+  ///
+  /// - Parameter preferImmediatelyAvailableCredentials: Whether to prefer immediately
+  ///   available credentials (default is `true`).
+  /// - Returns: The resulting ``SessionVerification``.
+  @discardableResult @MainActor
+  public func verifyWithPasskey(
+    preferImmediatelyAvailableCredentials: Bool = true
+  ) async throws -> SessionVerification {
+    let prepared = try await prepareFirstFactorVerification(strategy: .passkey)
+
+    guard
+      let nonceJSON = prepared.firstFactorVerification?.nonce?.toJSON(),
+      let challengeString = nonceJSON["challenge"]?.stringValue,
+      let challenge = challengeString.dataFromBase64URL()
+    else {
+      throw ClerkClientError(message: "Unable to get the challenge for the passkey.")
+    }
+
+    let manager = PasskeyHelper()
+    let authorization = try await manager.signIn(
+      challenge: challenge,
+      preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
+    )
+
+    guard
+      let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion,
+      let authenticatorData = credentialAssertion.rawAuthenticatorData
+    else {
+      throw ClerkClientError(message: "Invalid credential type.")
+    }
+
+    let publicKeyCredential: [String: Any] = [
+      "id": credentialAssertion.credentialID.base64EncodedString().base64URLFromBase64String(),
+      "rawId": credentialAssertion.credentialID.base64EncodedString().base64URLFromBase64String(),
+      "type": "public-key",
+      "response": [
+        "authenticatorData": authenticatorData.base64EncodedString().base64URLFromBase64String(),
+        "clientDataJSON": credentialAssertion.rawClientDataJSON.base64EncodedString().base64URLFromBase64String(),
+        "signature": credentialAssertion.signature.base64EncodedString().base64URLFromBase64String(),
+        "userHandle": credentialAssertion.userID.base64EncodedString().base64URLFromBase64String(),
+      ],
+    ]
+
+    let jsonData = try JSONSerialization.data(withJSONObject: publicKeyCredential, options: [])
+    let credentialString = String(data: jsonData, encoding: .utf8) ?? ""
+
+    return try await attemptFirstFactorVerification(
+      strategy: .passkey,
+      publicKeyCredential: credentialString
+    )
+  }
+  #endif
+}

--- a/Sources/ClerkKit/Domains/Auth/Session/Session+Verification.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/Session+Verification.swift
@@ -30,7 +30,7 @@ extension Session {
 
   /// Prepares the first factor of an in-session reverification flow.
   ///
-  /// For strategies that do not require preparation (for example `password` or `passkey`'s
+  /// For strategies that do not require preparation (for example `password`'s
   /// `attempt` step) you can skip this call and go straight to ``attemptFirstFactorVerification(strategy:code:password:publicKeyCredential:)``.
   @discardableResult @MainActor
   public func prepareFirstFactorVerification(
@@ -38,8 +38,7 @@ extension Session {
     emailAddressId: String? = nil,
     phoneNumberId: String? = nil,
     enterpriseConnectionId: String? = nil,
-    redirectUrl: String? = nil,
-    default: Bool? = nil
+    redirectUrl: String? = nil
   ) async throws -> SessionVerification {
     try await Clerk.shared.dependencies.sessionService.prepareFirstFactorVerification(
       sessionId: id,
@@ -48,8 +47,7 @@ extension Session {
         emailAddressId: emailAddressId,
         phoneNumberId: phoneNumberId,
         enterpriseConnectionId: enterpriseConnectionId,
-        redirectUrl: redirectUrl,
-        default: `default`
+        redirectUrl: redirectUrl
       )
     )
   }

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionService.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionService.swift
@@ -23,6 +23,36 @@ protocol SessionServiceProtocol: Sendable {
   ///   - sessionId: The session ID to generate a token for.
   ///   - template: Optional JWT template name.
   @MainActor func fetchToken(sessionId: String, template: String?) async throws -> TokenResource?
+
+  /// Starts an in-session reverification (step-up) flow.
+  @MainActor func startVerification(
+    sessionId: String,
+    params: Session.StartVerificationParams
+  ) async throws -> SessionVerification
+
+  /// Prepares the first factor of an in-session reverification flow.
+  @MainActor func prepareFirstFactorVerification(
+    sessionId: String,
+    params: Session.PrepareFirstFactorVerificationParams
+  ) async throws -> SessionVerification
+
+  /// Attempts the first factor of an in-session reverification flow.
+  @MainActor func attemptFirstFactorVerification(
+    sessionId: String,
+    params: Session.AttemptFirstFactorVerificationParams
+  ) async throws -> SessionVerification
+
+  /// Prepares the second factor of an in-session reverification flow.
+  @MainActor func prepareSecondFactorVerification(
+    sessionId: String,
+    params: Session.PrepareSecondFactorVerificationParams
+  ) async throws -> SessionVerification
+
+  /// Attempts the second factor of an in-session reverification flow.
+  @MainActor func attemptSecondFactorVerification(
+    sessionId: String,
+    params: Session.AttemptSecondFactorVerificationParams
+  ) async throws -> SessionVerification
 }
 
 final class SessionService: SessionServiceProtocol {
@@ -90,5 +120,75 @@ final class SessionService: SessionServiceProtocol {
     )
 
     return try await apiClient.send(request).value
+  }
+
+  @MainActor
+  func startVerification(
+    sessionId: String,
+    params: Session.StartVerificationParams
+  ) async throws -> SessionVerification {
+    let request = Request<ClientResponse<SessionVerification>>(
+      path: "/v1/client/sessions/\(sessionId)/verify",
+      method: .post,
+      body: params
+    )
+
+    return try await apiClient.send(request).value.response
+  }
+
+  @MainActor
+  func prepareFirstFactorVerification(
+    sessionId: String,
+    params: Session.PrepareFirstFactorVerificationParams
+  ) async throws -> SessionVerification {
+    let request = Request<ClientResponse<SessionVerification>>(
+      path: "/v1/client/sessions/\(sessionId)/verify/prepare_first_factor",
+      method: .post,
+      body: params
+    )
+
+    return try await apiClient.send(request).value.response
+  }
+
+  @MainActor
+  func attemptFirstFactorVerification(
+    sessionId: String,
+    params: Session.AttemptFirstFactorVerificationParams
+  ) async throws -> SessionVerification {
+    let request = Request<ClientResponse<SessionVerification>>(
+      path: "/v1/client/sessions/\(sessionId)/verify/attempt_first_factor",
+      method: .post,
+      body: params
+    )
+
+    return try await apiClient.send(request).value.response
+  }
+
+  @MainActor
+  func prepareSecondFactorVerification(
+    sessionId: String,
+    params: Session.PrepareSecondFactorVerificationParams
+  ) async throws -> SessionVerification {
+    let request = Request<ClientResponse<SessionVerification>>(
+      path: "/v1/client/sessions/\(sessionId)/verify/prepare_second_factor",
+      method: .post,
+      body: params
+    )
+
+    return try await apiClient.send(request).value.response
+  }
+
+  @MainActor
+  func attemptSecondFactorVerification(
+    sessionId: String,
+    params: Session.AttemptSecondFactorVerificationParams
+  ) async throws -> SessionVerification {
+    let request = Request<ClientResponse<SessionVerification>>(
+      path: "/v1/client/sessions/\(sessionId)/verify/attempt_second_factor",
+      method: .post,
+      body: params
+    )
+
+    return try await apiClient.send(request).value.response
   }
 }

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionVerification.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionVerification.swift
@@ -1,0 +1,162 @@
+//
+//  SessionVerification.swift
+//
+
+import Foundation
+
+/// Represents the state of an in-session reverification (step-up) flow.
+///
+/// Use ``Session/startVerification(level:)`` to begin a reverification, then complete it
+/// with the appropriate first- and/or second-factor methods (for example,
+/// ``Session/verifyWithPasskey()``). When the verification completes successfully the
+/// associated session's first-factor age is refreshed, allowing subsequent calls that
+/// require step-up to succeed without forcing the user to sign out and back in.
+public struct SessionVerification: Codable, Equatable, Sendable {
+  /// The unique identifier for the verification attempt.
+  public var id: String?
+
+  /// The current status of the verification.
+  public var status: Status
+
+  /// The required verification level.
+  public var level: Level
+
+  /// The session associated with the verification.
+  public var session: Session?
+
+  /// First factors supported for this verification.
+  public var supportedFirstFactors: [Factor]?
+
+  /// Second factors supported for this verification.
+  public var supportedSecondFactors: [Factor]?
+
+  /// The state of the first-factor verification.
+  public var firstFactorVerification: Verification?
+
+  /// The state of the second-factor verification.
+  public var secondFactorVerification: Verification?
+
+  public init(
+    id: String? = nil,
+    status: Status,
+    level: Level,
+    session: Session? = nil,
+    supportedFirstFactors: [Factor]? = nil,
+    supportedSecondFactors: [Factor]? = nil,
+    firstFactorVerification: Verification? = nil,
+    secondFactorVerification: Verification? = nil
+  ) {
+    self.id = id
+    self.status = status
+    self.level = level
+    self.session = session
+    self.supportedFirstFactors = supportedFirstFactors
+    self.supportedSecondFactors = supportedSecondFactors
+    self.firstFactorVerification = firstFactorVerification
+    self.secondFactorVerification = secondFactorVerification
+  }
+
+  /// The status of a session verification attempt.
+  public enum Status: Codable, Sendable, Equatable, Hashable {
+    /// The first factor still needs to be verified.
+    case needsFirstFactor
+
+    /// The first factor is verified but a second factor is required.
+    case needsSecondFactor
+
+    /// The verification completed successfully.
+    case complete
+
+    /// Represents an unknown status, capturing the raw value for forward compatibility.
+    case unknown(String)
+
+    public var rawValue: String {
+      switch self {
+      case .needsFirstFactor:
+        "needs_first_factor"
+      case .needsSecondFactor:
+        "needs_second_factor"
+      case .complete:
+        "complete"
+      case .unknown(let value):
+        value
+      }
+    }
+
+    public init(rawValue: String) {
+      switch rawValue {
+      case "needs_first_factor":
+        self = .needsFirstFactor
+      case "needs_second_factor":
+        self = .needsSecondFactor
+      case "complete":
+        self = .complete
+      default:
+        self = .unknown(rawValue)
+      }
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      let rawValue = try container.decode(String.self)
+      self.init(rawValue: rawValue)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+      try container.encode(rawValue)
+    }
+  }
+
+  /// The required level of verification.
+  public enum Level: Codable, Sendable, Equatable, Hashable {
+    /// Only a first factor is required (for example a password or passkey).
+    case firstFactor
+
+    /// Only a second factor is required (for example TOTP).
+    case secondFactor
+
+    /// Both a first and second factor are required.
+    case multiFactor
+
+    /// Represents an unknown level, capturing the raw value for forward compatibility.
+    case unknown(String)
+
+    public var rawValue: String {
+      switch self {
+      case .firstFactor:
+        "first_factor"
+      case .secondFactor:
+        "second_factor"
+      case .multiFactor:
+        "multi_factor"
+      case .unknown(let value):
+        value
+      }
+    }
+
+    public init(rawValue: String) {
+      switch rawValue {
+      case "first_factor":
+        self = .firstFactor
+      case "second_factor":
+        self = .secondFactor
+      case "multi_factor":
+        self = .multiFactor
+      default:
+        self = .unknown(rawValue)
+      }
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      let rawValue = try container.decode(String.self)
+      self.init(rawValue: rawValue)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+      try container.encode(rawValue)
+    }
+  }
+}

--- a/Sources/ClerkKit/Mocks/MockModels.swift
+++ b/Sources/ClerkKit/Mocks/MockModels.swift
@@ -138,6 +138,49 @@ extension Session {
   }
 }
 
+// MARK: SessionVerification
+
+extension SessionVerification {
+  public static var mockNeedsFirstFactor: SessionVerification {
+    SessionVerification(
+      id: "ver_1",
+      status: .needsFirstFactor,
+      level: .firstFactor,
+      session: .mock,
+      supportedFirstFactors: [.mockPassword, .mockPasskey],
+      supportedSecondFactors: nil,
+      firstFactorVerification: .mockPasskeyUnverifiedVerification,
+      secondFactorVerification: nil
+    )
+  }
+
+  public static var mockNeedsSecondFactor: SessionVerification {
+    SessionVerification(
+      id: "ver_1",
+      status: .needsSecondFactor,
+      level: .secondFactor,
+      session: .mock,
+      supportedFirstFactors: nil,
+      supportedSecondFactors: [.mockTotp],
+      firstFactorVerification: nil,
+      secondFactorVerification: .mockTotpUnverifiedVerification
+    )
+  }
+
+  public static var mockComplete: SessionVerification {
+    SessionVerification(
+      id: "ver_1",
+      status: .complete,
+      level: .firstFactor,
+      session: .mock,
+      supportedFirstFactors: nil,
+      supportedSecondFactors: nil,
+      firstFactorVerification: .mockPasskeyVerifiedVerification,
+      secondFactorVerification: nil
+    )
+  }
+}
+
 // MARK: SignIn
 
 extension SignIn {

--- a/Sources/ClerkKit/Mocks/MockServices/MockSessionService.swift
+++ b/Sources/ClerkKit/Mocks/MockServices/MockSessionService.swift
@@ -24,19 +24,19 @@ package final class MockSessionService: SessionServiceProtocol {
   /// Custom handler for the `fetchToken(sessionId:template:)` method.
   package nonisolated(unsafe) var fetchTokenHandler: ((String, String?) async throws -> TokenResource?)?
 
-  /// Custom handler for `startVerification`.
+  /// Custom handler for the `startVerification(sessionId:params:)` method.
   nonisolated(unsafe) var startVerificationHandler: ((String, Session.StartVerificationParams) async throws -> SessionVerification)?
 
-  /// Custom handler for `prepareFirstFactorVerification`.
+  /// Custom handler for the `prepareFirstFactorVerification(sessionId:params:)` method.
   nonisolated(unsafe) var prepareFirstFactorVerificationHandler: ((String, Session.PrepareFirstFactorVerificationParams) async throws -> SessionVerification)?
 
-  /// Custom handler for `attemptFirstFactorVerification`.
+  /// Custom handler for the `attemptFirstFactorVerification(sessionId:params:)` method.
   nonisolated(unsafe) var attemptFirstFactorVerificationHandler: ((String, Session.AttemptFirstFactorVerificationParams) async throws -> SessionVerification)?
 
-  /// Custom handler for `prepareSecondFactorVerification`.
+  /// Custom handler for the `prepareSecondFactorVerification(sessionId:params:)` method.
   nonisolated(unsafe) var prepareSecondFactorVerificationHandler: ((String, Session.PrepareSecondFactorVerificationParams) async throws -> SessionVerification)?
 
-  /// Custom handler for `attemptSecondFactorVerification`.
+  /// Custom handler for the `attemptSecondFactorVerification(sessionId:params:)` method.
   nonisolated(unsafe) var attemptSecondFactorVerificationHandler: ((String, Session.AttemptSecondFactorVerificationParams) async throws -> SessionVerification)?
 
   init(

--- a/Sources/ClerkKit/Mocks/MockServices/MockSessionService.swift
+++ b/Sources/ClerkKit/Mocks/MockServices/MockSessionService.swift
@@ -24,16 +24,41 @@ package final class MockSessionService: SessionServiceProtocol {
   /// Custom handler for the `fetchToken(sessionId:template:)` method.
   package nonisolated(unsafe) var fetchTokenHandler: ((String, String?) async throws -> TokenResource?)?
 
-  package init(
+  /// Custom handler for `startVerification`.
+  nonisolated(unsafe) var startVerificationHandler: ((String, Session.StartVerificationParams) async throws -> SessionVerification)?
+
+  /// Custom handler for `prepareFirstFactorVerification`.
+  nonisolated(unsafe) var prepareFirstFactorVerificationHandler: ((String, Session.PrepareFirstFactorVerificationParams) async throws -> SessionVerification)?
+
+  /// Custom handler for `attemptFirstFactorVerification`.
+  nonisolated(unsafe) var attemptFirstFactorVerificationHandler: ((String, Session.AttemptFirstFactorVerificationParams) async throws -> SessionVerification)?
+
+  /// Custom handler for `prepareSecondFactorVerification`.
+  nonisolated(unsafe) var prepareSecondFactorVerificationHandler: ((String, Session.PrepareSecondFactorVerificationParams) async throws -> SessionVerification)?
+
+  /// Custom handler for `attemptSecondFactorVerification`.
+  nonisolated(unsafe) var attemptSecondFactorVerificationHandler: ((String, Session.AttemptSecondFactorVerificationParams) async throws -> SessionVerification)?
+
+  init(
     revoke: ((String) async throws -> Session)? = nil,
     signOut: ((String?) async throws -> Void)? = nil,
     setActive: ((String, String?) async throws -> Void)? = nil,
-    fetchToken: ((String, String?) async throws -> TokenResource?)? = nil
+    fetchToken: ((String, String?) async throws -> TokenResource?)? = nil,
+    startVerification: ((String, Session.StartVerificationParams) async throws -> SessionVerification)? = nil,
+    prepareFirstFactorVerification: ((String, Session.PrepareFirstFactorVerificationParams) async throws -> SessionVerification)? = nil,
+    attemptFirstFactorVerification: ((String, Session.AttemptFirstFactorVerificationParams) async throws -> SessionVerification)? = nil,
+    prepareSecondFactorVerification: ((String, Session.PrepareSecondFactorVerificationParams) async throws -> SessionVerification)? = nil,
+    attemptSecondFactorVerification: ((String, Session.AttemptSecondFactorVerificationParams) async throws -> SessionVerification)? = nil
   ) {
     revokeHandler = revoke
     signOutHandler = signOut
     setActiveHandler = setActive
     fetchTokenHandler = fetchToken
+    startVerificationHandler = startVerification
+    prepareFirstFactorVerificationHandler = prepareFirstFactorVerification
+    attemptFirstFactorVerificationHandler = attemptFirstFactorVerification
+    prepareSecondFactorVerificationHandler = prepareSecondFactorVerification
+    attemptSecondFactorVerificationHandler = attemptSecondFactorVerification
   }
 
   @MainActor
@@ -66,5 +91,60 @@ package final class MockSessionService: SessionServiceProtocol {
     }
 
     return .mock
+  }
+
+  @MainActor
+  func startVerification(
+    sessionId: String,
+    params: Session.StartVerificationParams
+  ) async throws -> SessionVerification {
+    if let handler = startVerificationHandler {
+      return try await handler(sessionId, params)
+    }
+    return .mockNeedsFirstFactor
+  }
+
+  @MainActor
+  func prepareFirstFactorVerification(
+    sessionId: String,
+    params: Session.PrepareFirstFactorVerificationParams
+  ) async throws -> SessionVerification {
+    if let handler = prepareFirstFactorVerificationHandler {
+      return try await handler(sessionId, params)
+    }
+    return .mockNeedsFirstFactor
+  }
+
+  @MainActor
+  func attemptFirstFactorVerification(
+    sessionId: String,
+    params: Session.AttemptFirstFactorVerificationParams
+  ) async throws -> SessionVerification {
+    if let handler = attemptFirstFactorVerificationHandler {
+      return try await handler(sessionId, params)
+    }
+    return .mockComplete
+  }
+
+  @MainActor
+  func prepareSecondFactorVerification(
+    sessionId: String,
+    params: Session.PrepareSecondFactorVerificationParams
+  ) async throws -> SessionVerification {
+    if let handler = prepareSecondFactorVerificationHandler {
+      return try await handler(sessionId, params)
+    }
+    return .mockNeedsSecondFactor
+  }
+
+  @MainActor
+  func attemptSecondFactorVerification(
+    sessionId: String,
+    params: Session.AttemptSecondFactorVerificationParams
+  ) async throws -> SessionVerification {
+    if let handler = attemptSecondFactorVerificationHandler {
+      return try await handler(sessionId, params)
+    }
+    return .mockComplete
   }
 }

--- a/Sources/ClerkKit/Mocks/MockServices/MockSessionService.swift
+++ b/Sources/ClerkKit/Mocks/MockServices/MockSessionService.swift
@@ -39,6 +39,25 @@ package final class MockSessionService: SessionServiceProtocol {
   /// Custom handler for the `attemptSecondFactorVerification(sessionId:params:)` method.
   nonisolated(unsafe) var attemptSecondFactorVerificationHandler: ((String, Session.AttemptSecondFactorVerificationParams) async throws -> SessionVerification)?
 
+  package convenience init(
+    revoke: ((String) async throws -> Session)? = nil,
+    signOut: ((String?) async throws -> Void)? = nil,
+    setActive: ((String, String?) async throws -> Void)? = nil,
+    fetchToken: ((String, String?) async throws -> TokenResource?)? = nil
+  ) {
+    self.init(
+      revoke: revoke,
+      signOut: signOut,
+      setActive: setActive,
+      fetchToken: fetchToken,
+      startVerification: nil,
+      prepareFirstFactorVerification: nil,
+      attemptFirstFactorVerification: nil,
+      prepareSecondFactorVerification: nil,
+      attemptSecondFactorVerification: nil
+    )
+  }
+
   init(
     revoke: ((String) async throws -> Session)? = nil,
     signOut: ((String?) async throws -> Void)? = nil,

--- a/Tests/Domains/Auth/FactorTests.swift
+++ b/Tests/Domains/Auth/FactorTests.swift
@@ -1,0 +1,29 @@
+@testable import ClerkKit
+import Foundation
+import Testing
+
+struct FactorTests {
+  @Test
+  func defaultInitializerParameterRoundTripsThroughJSON() throws {
+    let factor = Factor(
+      strategy: .phoneCode,
+      phoneNumberId: "idn_123",
+      safeIdentifier: "+15555550123",
+      primary: true,
+      default: true
+    )
+
+    let data = try JSONEncoder.clerkEncoder.encode(factor)
+    let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+    #expect(object["default"] as? Bool == true)
+    #expect(object["phone_number_id"] as? String == "idn_123")
+    #expect(object["safe_identifier"] as? String == "+15555550123")
+    #expect(object["primary"] as? Bool == true)
+
+    let decoded = try JSONDecoder.clerkDecoder.decode(Factor.self, from: data)
+
+    #expect(decoded == factor)
+    #expect(decoded.default == true)
+  }
+}

--- a/Tests/Domains/Auth/Session/SessionServiceTests.swift
+++ b/Tests/Domains/Auth/Session/SessionServiceTests.swift
@@ -362,6 +362,48 @@ struct SessionServiceTests {
   }
 
   @Test
+  func prepareFirstFactorVerificationEnterpriseSSO() async throws {
+    let session = Session.mock
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(
+      string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/verify/prepare_first_factor"
+    )!
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(
+          ClientResponse<SessionVerification>(response: .mockNeedsFirstFactor, client: .mock)
+        ),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { request in
+      #expect(request.httpMethod == "POST")
+      let body = request.urlEncodedFormBody!
+      #expect(body["strategy"] == "enterprise_sso")
+      #expect(body["email_address_id"] == "idn_email")
+      #expect(body["enterprise_connection_id"] == "econn_123")
+      #expect(body["redirect_url"] == "myapp://callback")
+      #expect(body["default"] == nil)
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    _ = try await Clerk.shared.dependencies.sessionService.prepareFirstFactorVerification(
+      sessionId: session.id,
+      params: .init(
+        strategy: .enterpriseSSO,
+        emailAddressId: "idn_email",
+        enterpriseConnectionId: "econn_123",
+        redirectUrl: "myapp://callback"
+      )
+    )
+
+    #expect(requestHandled.value)
+  }
+
+  @Test
   func attemptFirstFactorVerificationPasskey() async throws {
     let session = Session.mock
     let requestHandled = LockIsolated(false)

--- a/Tests/Domains/Auth/Session/SessionServiceTests.swift
+++ b/Tests/Domains/Auth/Session/SessionServiceTests.swift
@@ -297,6 +297,141 @@ struct SessionServiceTests {
   }
 
   @Test
+  func startVerification() async throws {
+    let session = Session.mock
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/verify")!
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(
+          ClientResponse<SessionVerification>(response: .mockNeedsFirstFactor, client: .mock)
+        ),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { request in
+      #expect(request.httpMethod == "POST")
+      let body = request.urlEncodedFormBody!
+      #expect(body["level"] == "first_factor")
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    let verification = try await Clerk.shared.dependencies.sessionService.startVerification(
+      sessionId: session.id,
+      params: .init(level: .firstFactor)
+    )
+
+    #expect(requestHandled.value)
+    #expect(verification.status == .needsFirstFactor)
+  }
+
+  @Test
+  func prepareFirstFactorVerificationPasskey() async throws {
+    let session = Session.mock
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(
+      string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/verify/prepare_first_factor"
+    )!
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(
+          ClientResponse<SessionVerification>(response: .mockNeedsFirstFactor, client: .mock)
+        ),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { request in
+      #expect(request.httpMethod == "POST")
+      let body = request.urlEncodedFormBody!
+      #expect(body["strategy"] == "passkey")
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    _ = try await Clerk.shared.dependencies.sessionService.prepareFirstFactorVerification(
+      sessionId: session.id,
+      params: .init(strategy: .passkey)
+    )
+
+    #expect(requestHandled.value)
+  }
+
+  @Test
+  func attemptFirstFactorVerificationPasskey() async throws {
+    let session = Session.mock
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(
+      string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/verify/attempt_first_factor"
+    )!
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(
+          ClientResponse<SessionVerification>(response: .mockComplete, client: .mock)
+        ),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { request in
+      #expect(request.httpMethod == "POST")
+      let body = request.urlEncodedFormBody!
+      #expect(body["strategy"] == "passkey")
+      #expect(body["public_key_credential"] == "{\"id\":\"abc\"}")
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    let verification = try await Clerk.shared.dependencies.sessionService.attemptFirstFactorVerification(
+      sessionId: session.id,
+      params: .init(strategy: .passkey, publicKeyCredential: "{\"id\":\"abc\"}")
+    )
+
+    #expect(requestHandled.value)
+    #expect(verification.status == .complete)
+  }
+
+  @Test
+  func attemptSecondFactorVerificationTOTP() async throws {
+    let session = Session.mock
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(
+      string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/verify/attempt_second_factor"
+    )!
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(
+          ClientResponse<SessionVerification>(response: .mockComplete, client: .mock)
+        ),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { request in
+      #expect(request.httpMethod == "POST")
+      let body = request.urlEncodedFormBody!
+      #expect(body["strategy"] == "totp")
+      #expect(body["code"] == "123456")
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    let verification = try await Clerk.shared.dependencies.sessionService.attemptSecondFactorVerification(
+      sessionId: session.id,
+      params: .init(strategy: .totp, code: "123456")
+    )
+
+    #expect(requestHandled.value)
+    #expect(verification.status == .complete)
+  }
+
+  @Test
   func testRevoke() async throws {
     let session = Session.mock
     let requestHandled = LockIsolated(false)

--- a/Tests/Domains/Auth/Session/SessionTests.swift
+++ b/Tests/Domains/Auth/Session/SessionTests.swift
@@ -46,4 +46,73 @@ struct SessionTests {
     let task = Session.Task(key: "another-task")
     #expect(task == .unknown("another-task"))
   }
+
+  @Test
+  func startVerificationForwardsLevelToService() async throws {
+    let session = Session.mock
+    let capturedSessionId = LockIsolated<String?>(nil)
+    let capturedLevel = LockIsolated<SessionVerification.Level?>(nil)
+    let service = MockSessionService(startVerification: { sessionId, params in
+      capturedSessionId.setValue(sessionId)
+      capturedLevel.setValue(params.level)
+      return .mockNeedsFirstFactor
+    })
+
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let verification = try await session.startVerification(level: .firstFactor)
+
+    #expect(capturedSessionId.value == session.id)
+    #expect(capturedLevel.value == .firstFactor)
+    #expect(verification.status == .needsFirstFactor)
+  }
+
+  @Test
+  func verifyWithPasswordCallsAttemptFirstFactor() async throws {
+    let session = Session.mock
+    let capturedStrategy = LockIsolated<FactorStrategy?>(nil)
+    let capturedPassword = LockIsolated<String?>(nil)
+    let service = MockSessionService(attemptFirstFactorVerification: { _, params in
+      capturedStrategy.setValue(params.strategy)
+      capturedPassword.setValue(params.password)
+      return .mockComplete
+    })
+
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let verification = try await session.verifyWithPassword("hunter2")
+
+    #expect(capturedStrategy.value == .password)
+    #expect(capturedPassword.value == "hunter2")
+    #expect(verification.status == .complete)
+  }
+
+  @Test
+  func verifyWithTOTPCallsAttemptSecondFactor() async throws {
+    let session = Session.mock
+    let capturedStrategy = LockIsolated<FactorStrategy?>(nil)
+    let capturedCode = LockIsolated<String?>(nil)
+    let service = MockSessionService(attemptSecondFactorVerification: { _, params in
+      capturedStrategy.setValue(params.strategy)
+      capturedCode.setValue(params.code)
+      return .mockComplete
+    })
+
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let verification = try await session.verifyWithTOTP(code: "123456")
+
+    #expect(capturedStrategy.value == .totp)
+    #expect(capturedCode.value == "123456")
+    #expect(verification.status == .complete)
+  }
 }

--- a/Tests/Domains/Auth/Session/SessionTests.swift
+++ b/Tests/Domains/Auth/Session/SessionTests.swift
@@ -48,6 +48,46 @@ struct SessionTests {
   }
 
   @Test
+  func sessionVerificationDecodesSupportedFactorMetadata() throws {
+    let json = """
+    {
+      "status": "needs_first_factor",
+      "level": "first_factor",
+      "supported_first_factors": [
+        {
+          "strategy": "enterprise_sso",
+          "enterprise_connection_id": "econn_123",
+          "enterprise_connection_name": "Acme"
+        }
+      ],
+      "supported_second_factors": [
+        {
+          "strategy": "phone_code",
+          "phone_number_id": "idn_123",
+          "safe_identifier": "+15555550123",
+          "primary": true,
+          "default": true
+        }
+      ]
+    }
+    """
+
+    let data = try #require(json.data(using: .utf8))
+    let verification = try JSONDecoder.clerkDecoder.decode(SessionVerification.self, from: data)
+    let firstFactor = try #require(verification.supportedFirstFactors?.first)
+    let secondFactor = try #require(verification.supportedSecondFactors?.first)
+
+    #expect(firstFactor.strategy == .enterpriseSSO)
+    #expect(firstFactor.enterpriseConnectionId == "econn_123")
+    #expect(firstFactor.enterpriseConnectionName == "Acme")
+    #expect(secondFactor.strategy == .phoneCode)
+    #expect(secondFactor.phoneNumberId == "idn_123")
+    #expect(secondFactor.safeIdentifier == "+15555550123")
+    #expect(secondFactor.primary == true)
+    #expect(secondFactor.default == true)
+  }
+
+  @Test
   func startVerificationForwardsLevelToService() async throws {
     let session = Session.mock
     let capturedSessionId = LockIsolated<String?>(nil)

--- a/Tests/Domains/Auth/Session/SessionTests.swift
+++ b/Tests/Domains/Auth/Session/SessionTests.swift
@@ -155,4 +155,27 @@ struct SessionTests {
     #expect(capturedCode.value == "123456")
     #expect(verification.status == .complete)
   }
+
+  @Test
+  func verifyWithBackupCodeCallsAttemptSecondFactor() async throws {
+    let session = Session.mock
+    let capturedStrategy = LockIsolated<FactorStrategy?>(nil)
+    let capturedCode = LockIsolated<String?>(nil)
+    let service = MockSessionService(attemptSecondFactorVerification: { _, params in
+      capturedStrategy.setValue(params.strategy)
+      capturedCode.setValue(params.code)
+      return .mockComplete
+    })
+
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let verification = try await session.verifyWithBackupCode(code: "abcdef")
+
+    #expect(capturedStrategy.value == .backupCode)
+    #expect(capturedCode.value == "abcdef")
+    #expect(verification.status == .complete)
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `Session.startVerification(level:)` plus prepare/attempt first- and second-factor verification methods, mirroring clerk-js.
- Adds convenience methods: `verifyWithPasskey`, `verifyWithPassword`, `verifyWithTOTP`, `verifyWithBackupCode`. After step-up, callers can refresh the token with `getToken(.init(skipCache: true))` so the next API call carries an updated first-factor age.
- New `SessionVerification` resource (`status`, `level`, supported factors, factor verifications), service endpoints under `/v1/client/sessions/{id}/verify[...]`, and matching `MockSessionService` handlers + mocks.

## Test plan
- [x] `swift test` — 681/681 passing, including new `SessionTests` (Session → service forwarding for `startVerification`, `verifyWithPassword`, `verifyWithTOTP`) and `SessionServiceTests` (HTTP path/body assertions for start, prepare/attempt first factor passkey, attempt second factor TOTP).