### PR TITLE
Add unsafeMetadata support to AuthView and OAuth/transfer sign-up flows

### DIFF
--- a/Sources/ClerkKit/Core/Auth.swift
+++ b/Sources/ClerkKit/Core/Auth.swift
@@ -65,6 +65,35 @@ public struct Auth {
     Clerk.shared.client?.sessions ?? []
   }
 
+  /// Unsafe metadata to include on the next sign-up create request.
+  ///
+  /// When set, this value is automatically included on every sign-up create
+  /// request, regardless of the strategy used (email, phone, username, OAuth,
+  /// Apple, Enterprise SSO, or transfer flows). If a sign-up method accepts
+  /// `unsafeMetadata` explicitly, the explicit value is used for that call.
+  ///
+  /// The value is cleared automatically once a sign-up completes successfully
+  /// and on `Clerk.configure(...)` reconfiguration. It is **not** cleared on
+  /// sign-up failure, abandonment, or sign-in completion — set it to `nil`
+  /// explicitly when starting a flow that should not inherit a previous value.
+  ///
+  /// ```swift
+  /// // Programmatic sign-up
+  /// clerk.auth.unsafeMetadata = ["onboardingSource": "ios"]
+  /// _ = try await clerk.auth.signUp(emailAddress: "user@example.com")
+  ///
+  /// // Or attach to a sign-in that may transfer to sign-up (Apple, OAuth, SSO)
+  /// clerk.auth.unsafeMetadata = ["onboardingSource": "ios"]
+  /// _ = try await clerk.auth.signInWithApple()
+  ///
+  /// // The metadata is attached to the resulting SignUp and copied to
+  /// // User.unsafeMetadata once the sign-up completes.
+  /// ```
+  public var unsafeMetadata: JSON? {
+    get { Clerk.shared.pendingSignUpUnsafeMetadata }
+    nonmutating set { Clerk.shared.pendingSignUpUnsafeMetadata = newValue }
+  }
+
   // MARK: - Sign In Entry Points
 
   /// Creates a new sign-in attempt with the provided identifier.

--- a/Sources/ClerkKit/Core/Auth.swift
+++ b/Sources/ClerkKit/Core/Auth.swift
@@ -73,7 +73,7 @@ public struct Auth {
   /// `unsafeMetadata` explicitly, the explicit value is used for that call.
   ///
   /// The value is cleared automatically once a sign-up completes successfully
-  /// and on `Clerk.configure(...)` reconfiguration. It is **not** cleared on
+  /// and on `Clerk.reconfigure(...)`. It is **not** cleared on
   /// sign-up failure, abandonment, or sign-in completion — set it to `nil`
   /// explicitly when starting a flow that should not inherit a previous value.
   ///

--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -186,6 +186,16 @@ public final class Clerk {
   /// Owned by Clerk to ensure stable identity across accesses to `auth`.
   private let authEventEmitter = EventEmitter<AuthEvent>()
 
+  /// Pending unsafe metadata applied to the next sign-up create call.
+  ///
+  /// Set via ``Auth/unsafeMetadata``. Cleared automatically when a sign-up
+  /// completes successfully, and reset on reconfiguration.
+  ///
+  /// Not observed: this is request-staging state read at sign-up construction
+  /// time, not view state. Changes should not invalidate any SwiftUI view.
+  @ObservationIgnored
+  var pendingSignUpUnsafeMetadata: JSON?
+
   /// The main entry point for all authentication operations.
   ///
   /// Use this property to perform sign in, sign up, and session management operations.
@@ -471,6 +481,7 @@ extension Clerk {
     client = nil
     environment = nil
     sessionsByUserId = [:]
+    pendingSignUpUnsafeMetadata = nil
     await WebAuthentication.cancelCurrentSession()
 
     #if canImport(AuthenticationServices) && !os(watchOS)

--- a/Sources/ClerkKit/Dependencies/DependencyContainer.swift
+++ b/Sources/ClerkKit/Dependencies/DependencyContainer.swift
@@ -100,7 +100,7 @@ final class DependencyContainer: Dependencies {
     clientService = ClientService(apiClient: apiClient)
     userService = UserService(apiClient: apiClient)
     signInService = SignInService(apiClient: apiClient)
-    signUpService = SignUpService(apiClient: apiClient)
+    signUpService = SignUpService(apiClient: apiClient, runtimeScope: runtimeScope)
     sessionService = SessionService(apiClient: apiClient)
     passkeyService = PasskeyService(apiClient: apiClient)
     organizationService = OrganizationService(apiClient: apiClient)

--- a/Sources/ClerkKit/Domains/Auth/SignUp/SignUp+ServiceParams.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignUp/SignUp+ServiceParams.swift
@@ -14,7 +14,7 @@ extension SignUp {
     let firstName: String?
     let lastName: String?
     let username: String?
-    let unsafeMetadata: JSON?
+    var unsafeMetadata: JSON?
     let legalAccepted: Bool?
     let redirectUrl: String?
     let ticket: String?
@@ -83,5 +83,17 @@ extension SignUp {
     init(rotatingTokenNonce: String? = nil) {
       self.rotatingTokenNonce = rotatingTokenNonce
     }
+  }
+}
+
+extension SignUp.CreateParams {
+  /// Returns a copy with `unsafeMetadata` set to `pending` when the caller did
+  /// not supply an explicit value. Used by `SignUpService.create` to apply
+  /// ``Clerk/pendingSignUpUnsafeMetadata`` to outgoing sign-up requests.
+  func applyingPendingUnsafeMetadataIfNeeded(_ pending: JSON?) -> Self {
+    guard unsafeMetadata == nil, let pending else { return self }
+    var copy = self
+    copy.unsafeMetadata = pending
+    return copy
   }
 }

--- a/Sources/ClerkKit/Domains/Auth/SignUp/SignUpService.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignUp/SignUpService.swift
@@ -23,19 +23,23 @@ protocol SignUpServiceProtocol: Sendable {
 
 final class SignUpService: SignUpServiceProtocol {
   private let apiClient: APIClient
+  private let runtimeScope: ClerkRuntimeScope
 
-  init(apiClient: APIClient) {
+  init(apiClient: APIClient, runtimeScope: ClerkRuntimeScope) {
     self.apiClient = apiClient
+    self.runtimeScope = runtimeScope
   }
 
   // MARK: - Create
 
   @MainActor
   func create(params: SignUp.CreateParams) async throws -> SignUp {
+    let pendingMetadata = try runtimeScope.withCurrentClerk { $0.pendingSignUpUnsafeMetadata }
+    let effectiveParams = params.applyingPendingUnsafeMetadataIfNeeded(pendingMetadata)
     let request = Request<ClientResponse<SignUp>>(
       path: "/v1/client/sign_ups",
       method: .post,
-      body: params
+      body: effectiveParams
     )
 
     return try await apiClient.send(request).value.response

--- a/Sources/ClerkKit/Networking/Middleware/ClerkAuthEventEmitterResponseMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkAuthEventEmitterResponseMiddleware.swift
@@ -23,6 +23,7 @@ struct ClerkAuthEventEmitterResponseMiddleware: ClerkResponseMiddleware {
          signUp.status == .complete
       {
         try await runtimeScope.withCurrentClerk {
+          $0.pendingSignUpUnsafeMetadata = nil
           $0.auth.send(.signUpCompleted(signUp: signUp))
         }
       }
@@ -39,6 +40,7 @@ struct ClerkAuthEventEmitterResponseMiddleware: ClerkResponseMiddleware {
          session.status == .removed
       {
         try await runtimeScope.withCurrentClerk {
+          $0.pendingSignUpUnsafeMetadata = nil
           $0.auth.send(.signedOut(session: session))
         }
       }

--- a/Sources/ClerkKitUI/Components/Auth/AuthConfig.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthConfig.swift
@@ -1,17 +1,22 @@
 //
-//  AuthIdentifierConfig.swift
+//  AuthConfig.swift
 //  Clerk
 //
 
 #if os(iOS)
 
-/// Configuration for identifier pre-filling and persistence on ``AuthView``.
-struct AuthIdentifierConfig: Equatable {
+import ClerkKit
+
+/// Configuration values applied to ``AuthView`` via its view modifiers.
+struct AuthConfig: Equatable {
   /// The initial value for the identifier field (email, username, or phone number).
   var initialIdentifier: String?
 
   /// Whether identifier values are persisted between sessions.
   var persistsIdentifiers: Bool = true
+
+  /// Unsafe metadata to attach to any sign-up created from this view.
+  var unsafeMetadata: JSON?
 }
 
 #endif

--- a/Sources/ClerkKitUI/Components/Auth/AuthState.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthState.swift
@@ -61,7 +61,7 @@ final class AuthState {
   }
 
   /// Applies identifier configuration values.
-  func configure(_ config: AuthIdentifierConfig) {
+  func configure(_ config: AuthConfig) {
     persistsIdentifiers = config.persistsIdentifiers
     hasInitialValues = config.initialIdentifier != nil
 

--- a/Sources/ClerkKitUI/Components/Auth/AuthView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthView.swift
@@ -71,8 +71,8 @@ public struct AuthView: View {
   /// Form field state for auth views.
   @State private var authState: AuthState
 
-  /// Configuration values for identifier pre-filling and persistence.
-  private let config: AuthIdentifierConfig
+  /// Configuration values applied via view modifiers.
+  private let config: AuthConfig
 
   /// Rate limiter for verification codes.
   @State private var codeLimiter = CodeLimiter()
@@ -106,13 +106,13 @@ public struct AuthView: View {
   public init(mode: Mode = .signInOrUp, isDismissable: Bool = true) {
     _authState = State(initialValue: AuthState(mode: mode))
     self.isDismissable = isDismissable
-    config = AuthIdentifierConfig()
+    config = AuthConfig()
   }
 
   private init(
     mode: Mode,
     isDismissable: Bool,
-    config: AuthIdentifierConfig
+    config: AuthConfig
   ) {
     _authState = State(initialValue: AuthState(mode: mode))
     self.isDismissable = isDismissable
@@ -196,6 +196,19 @@ public struct AuthView: View {
     .onChange(of: config, initial: true) { _, newConfig in
       authState.configure(newConfig)
     }
+    .onChange(of: config.unsafeMetadata, initial: true) { _, newMetadata in
+      if let newMetadata {
+        clerk.auth.unsafeMetadata = newMetadata
+      }
+    }
+    .onDisappear {
+      // Only clear if our pushed value is still current, so we don't clobber
+      // a value the developer set directly after we presented.
+      guard let pushed = config.unsafeMetadata else { return }
+      if clerk.auth.unsafeMetadata == pushed {
+        clerk.auth.unsafeMetadata = nil
+      }
+    }
     .taskOnce {
       await clerk.telemetry.record(
         TelemetryEvents.viewDidAppear(
@@ -243,6 +256,20 @@ extension AuthView {
   public func persistsIdentifiers(_ persists: Bool) -> AuthView {
     var config = config
     config.persistsIdentifiers = persists
+    return AuthView(mode: authState.mode, isDismissable: isDismissable, config: config)
+  }
+
+  /// Attaches unsafe metadata to any sign-up initiated from this view.
+  ///
+  /// The metadata is applied through ``Clerk/Auth/unsafeMetadata`` and is
+  /// included on every sign-up create request regardless of strategy. It is
+  /// cleared automatically when the sign-up completes.
+  ///
+  /// - Parameter metadata: The metadata to attach to the resulting sign-up.
+  /// - Returns: A view configured to attach the given metadata.
+  public func unsafeMetadata(_ metadata: JSON) -> AuthView {
+    var config = config
+    config.unsafeMetadata = metadata
     return AuthView(mode: authState.mode, isDismissable: isDismissable, config: config)
   }
 }

--- a/Sources/ClerkKitUI/Components/Auth/AuthView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthView.swift
@@ -196,9 +196,13 @@ public struct AuthView: View {
     .onChange(of: config, initial: true) { _, newConfig in
       authState.configure(newConfig)
     }
-    .onChange(of: config.unsafeMetadata, initial: true) { _, newMetadata in
+    .onChange(of: config.unsafeMetadata, initial: true) { oldMetadata, newMetadata in
       if let newMetadata {
         clerk.auth.unsafeMetadata = newMetadata
+      } else if let oldMetadata, clerk.auth.unsafeMetadata == oldMetadata {
+        // Only clear if our pushed value is still current, so we don't
+        // clobber a value the developer set directly.
+        clerk.auth.unsafeMetadata = nil
       }
     }
     .onDisappear {

--- a/Tests/Domains/Auth/AuthTests.swift
+++ b/Tests/Domains/Auth/AuthTests.swift
@@ -433,6 +433,43 @@ struct AuthTests {
     #expect(params.ticket == "mock_ticket_value")
   }
 
+  @Test
+  func unsafeMetadataPropertyReflectsClerkPendingState() {
+    defer { Clerk.shared.pendingSignUpUnsafeMetadata = nil }
+    Clerk.shared.pendingSignUpUnsafeMetadata = nil
+    #expect(Clerk.shared.auth.unsafeMetadata == nil)
+
+    Clerk.shared.auth.unsafeMetadata = ["source": "ios"]
+    #expect(Clerk.shared.pendingSignUpUnsafeMetadata == ["source": "ios"])
+    #expect(Clerk.shared.auth.unsafeMetadata == ["source": "ios"])
+
+    Clerk.shared.auth.unsafeMetadata = nil
+    #expect(Clerk.shared.pendingSignUpUnsafeMetadata == nil)
+    #expect(Clerk.shared.auth.unsafeMetadata == nil)
+  }
+
+  @Test
+  func signUpRoutesThroughSignUpServiceCreateWithoutMergingPendingMetadata() async throws {
+    // Auth.signUp does not merge pending metadata itself; the merge happens
+    // inside SignUpService.create (covered in SignUpServiceTests).
+    let signUpParams = LockIsolated<SignUp.CreateParams?>(nil)
+    let signUpService = MockSignUpService(create: { params in
+      signUpParams.setValue(params)
+      return .mock
+    })
+
+    configureDependencies(signUpService: signUpService)
+    defer { Clerk.shared.pendingSignUpUnsafeMetadata = nil }
+    Clerk.shared.auth.unsafeMetadata = ["source": "ios"]
+
+    _ = try await Clerk.shared.auth.signUp(emailAddress: "test@example.com")
+
+    let params = try #require(signUpParams.value)
+    #expect(params.emailAddress == "test@example.com")
+    #expect(params.unsafeMetadata == nil)
+    #expect(Clerk.shared.pendingSignUpUnsafeMetadata == ["source": "ios"])
+  }
+
   @Test(
     arguments: [
       SignOutScenario(sessionId: nil),

--- a/Tests/Domains/Auth/SignUp/SignUpServiceTests.swift
+++ b/Tests/Domains/Auth/SignUp/SignUpServiceTests.swift
@@ -230,6 +230,165 @@ struct SignUpServiceTests {
   }
 
   @Test
+  func createMergesPendingUnsafeMetadataWhenParamsHaveNone() async throws {
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sign_ups")!
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(ClientResponse<SignUp>(response: .mock, client: .mock)),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { request in
+      #expect(request.httpMethod == "POST")
+      #expect(request.urlEncodedFormBody!["email_address"] == "test@example.com")
+      #expect(request.urlEncodedFormBody!["unsafe_metadata"] == "{\"source\":\"pending\"}")
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    defer { Clerk.shared.pendingSignUpUnsafeMetadata = nil }
+    Clerk.shared.pendingSignUpUnsafeMetadata = ["source": "pending"]
+    _ = try await Clerk.shared.dependencies.signUpService.create(params: .init(
+      emailAddress: "test@example.com"
+    ))
+    #expect(requestHandled.value)
+  }
+
+  @Test
+  func createPrefersExplicitUnsafeMetadataOverPending() async throws {
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sign_ups")!
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(ClientResponse<SignUp>(response: .mock, client: .mock)),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { request in
+      #expect(request.httpMethod == "POST")
+      #expect(request.urlEncodedFormBody!["unsafe_metadata"] == "{\"source\":\"explicit\"}")
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    defer { Clerk.shared.pendingSignUpUnsafeMetadata = nil }
+    Clerk.shared.pendingSignUpUnsafeMetadata = ["source": "pending"]
+    _ = try await Clerk.shared.dependencies.signUpService.create(params: .init(
+      unsafeMetadata: ["source": "explicit"]
+    ))
+    #expect(requestHandled.value)
+  }
+
+  @Test
+  func createOmitsUnsafeMetadataWhenNeitherProvided() async throws {
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sign_ups")!
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(ClientResponse<SignUp>(response: .mock, client: .mock)),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { request in
+      #expect(request.httpMethod == "POST")
+      #expect(request.urlEncodedFormBody!["unsafe_metadata"] == nil)
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    _ = try await Clerk.shared.dependencies.signUpService.create(params: .init(
+      emailAddress: "test@example.com"
+    ))
+    #expect(requestHandled.value)
+  }
+
+  @Test
+  func createWithTransferIncludesPendingUnsafeMetadata() async throws {
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sign_ups")!
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(ClientResponse<SignUp>(response: .mock, client: .mock)),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { request in
+      #expect(request.httpMethod == "POST")
+      #expect(request.urlEncodedFormBody!["transfer"] == "1")
+      #expect(request.urlEncodedFormBody!["unsafe_metadata"] == "{\"source\":\"pending\"}")
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    defer { Clerk.shared.pendingSignUpUnsafeMetadata = nil }
+    Clerk.shared.pendingSignUpUnsafeMetadata = ["source": "pending"]
+    _ = try await Clerk.shared.dependencies.signUpService.create(params: .init(transfer: true))
+    #expect(requestHandled.value)
+  }
+
+  @Test
+  func createWithOAuthIncludesPendingUnsafeMetadata() async throws {
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sign_ups")!
+    let expectedRedirectUrl = Clerk.shared.options.redirectConfig.redirectUrl
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(ClientResponse<SignUp>(response: .mock, client: .mock)),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { request in
+      #expect(request.httpMethod == "POST")
+      #expect(request.urlEncodedFormBody!["strategy"] == "oauth_google")
+      #expect(request.urlEncodedFormBody!["unsafe_metadata"] == "{\"source\":\"pending\"}")
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    defer { Clerk.shared.pendingSignUpUnsafeMetadata = nil }
+    Clerk.shared.pendingSignUpUnsafeMetadata = ["source": "pending"]
+    _ = try await Clerk.shared.dependencies.signUpService.create(params: .init(
+      strategy: .oauth(.google),
+      redirectUrl: expectedRedirectUrl
+    ))
+    #expect(requestHandled.value)
+  }
+
+  @Test
+  func applyingPendingUnsafeMetadataMergesWhenParamsHaveNone() {
+    let params = SignUp.CreateParams(emailAddress: "test@example.com")
+    let merged = params.applyingPendingUnsafeMetadataIfNeeded(["source": "pending"])
+    #expect(merged.unsafeMetadata == ["source": "pending"])
+    #expect(merged.emailAddress == "test@example.com")
+  }
+
+  @Test
+  func applyingPendingUnsafeMetadataPreservesExplicitValue() {
+    let params = SignUp.CreateParams(unsafeMetadata: ["source": "explicit"])
+    let merged = params.applyingPendingUnsafeMetadataIfNeeded(["source": "pending"])
+    #expect(merged.unsafeMetadata == ["source": "explicit"])
+  }
+
+  @Test
+  func applyingPendingUnsafeMetadataIsNoOpWhenPendingIsNil() {
+    let params = SignUp.CreateParams(emailAddress: "test@example.com")
+    let merged = params.applyingPendingUnsafeMetadataIfNeeded(nil)
+    #expect(merged.unsafeMetadata == nil)
+    #expect(merged.emailAddress == "test@example.com")
+  }
+
+  @Test
   func testUpdate() async throws {
     let signUp = SignUp.mock
     let requestHandled = LockIsolated(false)
@@ -281,6 +440,37 @@ struct SignUpServiceTests {
     _ = try await Clerk.shared.dependencies.signUpService.update(
       signUpId: signUp.id,
       params: .init(unsafeMetadata: ["token": "some-value"])
+    )
+    #expect(requestHandled.value)
+  }
+
+  @Test
+  func updateDoesNotMergePendingUnsafeMetadata() async throws {
+    // Merging is intentionally a create-only behavior; the server already
+    // stores the metadata from the initial create.
+    let signUp = SignUp.mock
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sign_ups/\(signUp.id)")!
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .patch: JSONEncoder.clerkEncoder.encode(ClientResponse<SignUp>(response: .mock, client: .mock)),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { request in
+      #expect(request.httpMethod == "PATCH")
+      #expect(request.urlEncodedFormBody!["unsafe_metadata"] == nil)
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    defer { Clerk.shared.pendingSignUpUnsafeMetadata = nil }
+    Clerk.shared.pendingSignUpUnsafeMetadata = ["source": "pending"]
+    _ = try await Clerk.shared.dependencies.signUpService.update(
+      signUpId: signUp.id,
+      params: .init(firstName: "John")
     )
     #expect(requestHandled.value)
   }

--- a/Tests/Integration/IntegrationTestHelpers.swift
+++ b/Tests/Integration/IntegrationTestHelpers.swift
@@ -91,7 +91,7 @@ func configureClerkForIntegrationTesting(keyName: String) throws -> Bool {
     clientService: ClientService(apiClient: apiClient),
     userService: UserService(apiClient: apiClient),
     signInService: SignInService(apiClient: apiClient),
-    signUpService: SignUpService(apiClient: apiClient),
+    signUpService: SignUpService(apiClient: apiClient, runtimeScope: Clerk.shared.runtimeScope),
     sessionService: SessionService(apiClient: apiClient),
     passkeyService: PasskeyService(apiClient: apiClient),
     organizationService: OrganizationService(apiClient: apiClient),

--- a/Tests/Middleware/ClerkAuthEventEmitterResponseMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkAuthEventEmitterResponseMiddlewareTests.swift
@@ -76,6 +76,83 @@ struct ClerkAuthEventEmitterResponseMiddlewareTests {
   }
 
   @Test
+  func validateClearsPendingUnsafeMetadataOnSignUpCompleted() async throws {
+    let clerk = Clerk()
+    defer { clerk.pendingSignUpUnsafeMetadata = nil }
+    clerk.pendingSignUpUnsafeMetadata = ["source": "test"]
+    let middleware = ClerkAuthEventEmitterResponseMiddleware(runtimeScope: .current(clerkProvider: { clerk }))
+
+    let capturedEvent = try await captureNextAuthEvent(from: clerk) {
+      try await middleware.validate(
+        signUpResponse,
+        data: signUpResponseData(object: "sign_up_attempt", status: "complete"),
+        for: signUpRequest
+      )
+    }
+
+    let event = try #require(capturedEvent)
+    guard case .signUpCompleted = event else {
+      Issue.record("Expected signUpCompleted event but received \(String(describing: event))")
+      return
+    }
+    #expect(clerk.pendingSignUpUnsafeMetadata == nil)
+  }
+
+  @Test
+  func validateDoesNotClearPendingUnsafeMetadataForIncompleteSignUp() async throws {
+    let clerk = Clerk()
+    defer { clerk.pendingSignUpUnsafeMetadata = nil }
+    clerk.pendingSignUpUnsafeMetadata = ["source": "test"]
+    let middleware = ClerkAuthEventEmitterResponseMiddleware(runtimeScope: .current(clerkProvider: { clerk }))
+
+    _ = try await captureNextAuthEvent(from: clerk) {
+      try await middleware.validate(
+        signUpResponse,
+        data: signUpResponseData(object: "sign_up_attempt", status: "missing_requirements"),
+        for: signUpRequest
+      )
+    }
+
+    #expect(clerk.pendingSignUpUnsafeMetadata == ["source": "test"])
+  }
+
+  @Test
+  func validateClearsPendingUnsafeMetadataOnSignedOut() async throws {
+    let clerk = Clerk()
+    defer { clerk.pendingSignUpUnsafeMetadata = nil }
+    clerk.pendingSignUpUnsafeMetadata = ["source": "test"]
+    let middleware = ClerkAuthEventEmitterResponseMiddleware(runtimeScope: .current(clerkProvider: { clerk }))
+
+    _ = try await captureNextAuthEvent(from: clerk) {
+      try await middleware.validate(
+        sessionRemovalResponse,
+        data: sessionResponseData(object: "session", status: "removed"),
+        for: sessionRemovalRequest
+      )
+    }
+
+    #expect(clerk.pendingSignUpUnsafeMetadata == nil)
+  }
+
+  @Test
+  func validateDoesNotClearPendingUnsafeMetadataOnSignInCompleted() async throws {
+    let clerk = Clerk()
+    defer { clerk.pendingSignUpUnsafeMetadata = nil }
+    clerk.pendingSignUpUnsafeMetadata = ["source": "test"]
+    let middleware = ClerkAuthEventEmitterResponseMiddleware(runtimeScope: .current(clerkProvider: { clerk }))
+
+    _ = try await captureNextAuthEvent(from: clerk) {
+      try await middleware.validate(
+        signInResponse,
+        data: signInResponseData(object: "sign_in_attempt", status: "complete"),
+        for: signInRequest
+      )
+    }
+
+    #expect(clerk.pendingSignUpUnsafeMetadata == ["source": "test"])
+  }
+
+  @Test
   func validateEmitsSignedOutForRemovedSessionResponse() async throws {
     let clerk = Clerk()
     let middleware = ClerkAuthEventEmitterResponseMiddleware(runtimeScope: .current(clerkProvider: { clerk }))

--- a/Tests/TestSupport/TestHelpers.swift
+++ b/Tests/TestSupport/TestHelpers.swift
@@ -37,7 +37,7 @@ func setupMockAPIClient() {
     clientService: ClientService(apiClient: mockAPIClient),
     userService: UserService(apiClient: mockAPIClient),
     signInService: SignInService(apiClient: mockAPIClient),
-    signUpService: SignUpService(apiClient: mockAPIClient),
+    signUpService: SignUpService(apiClient: mockAPIClient, runtimeScope: Clerk.shared.runtimeScope),
     sessionService: SessionService(apiClient: mockAPIClient),
     passkeyService: PasskeyService(apiClient: mockAPIClient),
     organizationService: OrganizationService(apiClient: mockAPIClient),

--- a/Tests/UI/AuthStateConfigurationTests.swift
+++ b/Tests/UI/AuthStateConfigurationTests.swift
@@ -1,5 +1,6 @@
 #if os(iOS)
 
+import ClerkKit
 @testable import ClerkKitUI
 import Foundation
 import Testing
@@ -37,7 +38,7 @@ struct AuthStateConfigurationTests {
     defaults.set("15555550100", forKey: AuthState.phoneNumberStorageKey)
 
     let authState = AuthState(userDefaults: defaults)
-    authState.configure(AuthIdentifierConfig(
+    authState.configure(AuthConfig(
       initialIdentifier: "seed@example.com"
     ))
 
@@ -53,7 +54,7 @@ struct AuthStateConfigurationTests {
     defaults.set("15555550100", forKey: AuthState.phoneNumberStorageKey)
 
     let authState = AuthState(userDefaults: defaults)
-    authState.configure(AuthIdentifierConfig(
+    authState.configure(AuthConfig(
       initialIdentifier: "+17777770123"
     ))
 
@@ -69,7 +70,7 @@ struct AuthStateConfigurationTests {
     LastUsedAuth.storeIdentifierType(.email, userDefaults: defaults)
 
     let authState = AuthState(userDefaults: defaults)
-    authState.configure(AuthIdentifierConfig(
+    authState.configure(AuthConfig(
       persistsIdentifiers: false
     ))
 
@@ -84,7 +85,7 @@ struct AuthStateConfigurationTests {
   func disablingPersistenceSuppressesFutureWrites() {
     let defaults = makeUserDefaults()
     let authState = AuthState(userDefaults: defaults)
-    authState.configure(AuthIdentifierConfig(
+    authState.configure(AuthConfig(
       persistsIdentifiers: false
     ))
 
@@ -96,6 +97,21 @@ struct AuthStateConfigurationTests {
   }
 
   @Test
+  func equalityConsidersUnsafeMetadataField() {
+    // AuthView's onChange handlers depend on this field being part of
+    // the synthesized Equatable conformance.
+    let a = AuthConfig(unsafeMetadata: ["source": "ios"])
+    let b = AuthConfig(unsafeMetadata: ["source": "ios"])
+    let c = AuthConfig(unsafeMetadata: ["source": "android"])
+    let none = AuthConfig()
+
+    #expect(a == b)
+    #expect(a != c)
+    #expect(a != none)
+    #expect(none == AuthConfig())
+  }
+
+  @Test
   func disablingPersistenceWithInitialEmailShowsButDoesNotStore() {
     let defaults = makeUserDefaults()
     defaults.set("stored@example.com", forKey: AuthState.identifierStorageKey)
@@ -103,7 +119,7 @@ struct AuthStateConfigurationTests {
     LastUsedAuth.storeIdentifierType(.phone, userDefaults: defaults)
 
     let authState = AuthState(userDefaults: defaults)
-    authState.configure(AuthIdentifierConfig(
+    authState.configure(AuthConfig(
       initialIdentifier: "seed@example.com",
       persistsIdentifiers: false
     ))


### PR DESCRIPTION
## Prior art

This brings iOS to parity with the equivalent fix on the web SDK, which Clerk merged in late January 2026:

- clerk/javascript#7647 — `fix(clerk-js,shared): Handle unsafeMetadata in transfer flows`
- clerk/javascript#7657 — `fix(clerk-js): Pass unsafeMetadata with sign up ticket flows`
- clerk/javascript#7660 — `fix(ui): Handle unsafeMetadata in ticket flows`
- clerk/javascript#7661 — `fix(js,ui,shared): Handle unsafeMetadata in transfer flows`

Quoting #7661's problem statement, which describes the same underlying bug:

> When `unsafeMetadata` is passed to `<SignIn unsafeMetadata={...} />` or `<SignUp unsafeMetadata={...} />`, the metadata was lost in two scenarios:
> 1. **OAuth/SSO Callback Transfer:** When a user signs in via OAuth but no account exists, the system transfers to sign-up by calling `signUp.create({ transfer: true })` without passing `unsafeMetadata`.
> 2. **Combined Flow Transfer:** When the combined sign-in/sign-up flow detects a non-existent identifier and transfers to sign-up, `signUp.create()` was called without `unsafeMetadata`.

The iOS SDK has the analogous bug: the transfer-to-sign-up call site (`signUpService.create(transfer: true)` in `SignIn`) doesn't thread `unsafeMetadata`, so any `signInWith…` path that hits a transfer loses it. iOS additionally has a more fundamental gap: `AuthView` provides no way to set `unsafeMetadata` at all. The low-level `SignUp.create`/`SignUp.update` API already accepts the parameter — only the higher-level entry points are missing it. This PR closes those gaps for iOS.

## Problem

`SignUp.create` and `signUp.update` already accept `unsafeMetadata`, but the higher-level entry points don't thread it through:

- `AuthView` collects identifier and verification but has no way to attach custom metadata to the resulting sign-up.
- `signInWithApple` / `signInWithOAuth` / `signInWithEnterpriseSSO` / `signInWithIdToken` (and their `signUp…` counterparts) have no `unsafeMetadata` parameter.

Today the workaround is to abandon `AuthView` entirely and build a custom flow with direct `SignUp.create(unsafeMetadata:)` calls — losing all the `AuthView` UX for a single field of metadata.

## What this adds

A single setter on `clerk.auth.unsafeMetadata` that propagates through every sign-up create path:

```swift
clerk.auth.unsafeMetadata = ["onboardingSource": "ios"]

// Picked up by any of these:
_ = try await clerk.auth.signUp(emailAddress: "user@example.com")
_ = try await clerk.auth.signInWithApple()              // transfer-to-signup
_ = try await clerk.auth.signInWithOAuth(provider: .google)
_ = try await clerk.auth.signInWithEnterpriseSSO(emailAddress: "user@corp.com")
```

And a matching `AuthView` modifier:

```swift
AuthView()
  .unsafeMetadata(["onboardingSource": "ios"])
```

## Design

Purely additive. No existing public method signature changes. The shape is one new public property (`Clerk.Auth.unsafeMetadata`) and one new view modifier (`AuthView.unsafeMetadata(_:)`).

I considered the explicit-parameter alternative — adding `unsafeMetadata:` to every `signInWith…` / `signUpWith…` entry point. That would have required updating 8+ public methods plus the internal transfer-flow plumbing in `SignIn.handleTransferFlow`. Reading the value from `clerk.auth` at the service layer instead centralizes the merge at the single funnel every path shares (`SignUpService.create`), so future sign-up entry points get coverage for free.

The merge is deliberately one-sided: `SignUpService.create` applies the pending value only when the caller didn't pass an explicit one (explicit always wins). `SignUpService.update` does **not** merge — the server stores metadata from the initial create, so re-sending on update calls would be redundant.

### Why a property on `clerk.auth` instead of a view prop (vs. the JS API shape)

clerk-js exposes this as `<SignUp unsafeMetadata={...} />` — a prop on the component. This PR puts the value on `clerk.auth` instead, with a view modifier as the developer-facing surface on `AuthView`. Two reasons for the divergence:

1. **Even on web, the prop is plumbing on top of internal threading.** PR #7661 still had to add `unsafeMetadata` fields to `HandleOAuthCallbackParams` and `HandleCombinedFlowTransferProps` to reach the transfer call site. The prop is only the developer-facing entry point; internally the metadata is plumbed through new type members on existing types. Reading from `clerk.auth` via a scoped accessor at the transfer call site skips that internal plumbing.
2. **SwiftUI props don't reach `SignIn.handleTransferFlow`.** The transfer flow runs deep in `SignIn.swift`, which has no view-tree access to `AuthView`'s configuration. React solves this with context; SwiftUI's idiomatic equivalent for one-shot configuration that crosses async boundaries is to put it on a shared object (here, `clerk.auth`). The view-modifier API gives developers a prop-shaped surface while `Clerk` handles cross-boundary delivery.

If maintainers prefer to converge on the JS prop shape, `AuthView.unsafeMetadata(_:)` can later be promoted to a first-class init parameter and the public singleton property hidden, without touching the underlying transfer-flow fix.

## Lifecycle

The pending value is cleared automatically:

- on successful sign-up completion (next to the existing `signUpCompleted` event in `ClerkAuthEventEmitterResponseMiddleware`)
- on sign-out
- on `Clerk.configure(...)` reconfiguration
- on `AuthView` disappear, when this view's modifier was the one that pushed the value and nothing else overrode it

It is **not** cleared on sign-up failure, abandonment outside `AuthView`, or sign-in completion. Callers wanting fresh state should set `clerk.auth.unsafeMetadata = nil` explicitly. This is documented on the property.

## Internal changes worth flagging

- `SignUpService.create` reads the pending value through `ClerkRuntimeScope.withCurrentClerk`, the same scoped accessor used by response middleware, rather than reaching into `Clerk.shared` directly. This makes the read respect the configuration epoch.
- `AuthIdentifierConfig` (used internally by `AuthView`) renamed to `AuthConfig` since it now carries non-identifier state.

## Compatibility

No breaking changes. Source-compatible with all existing callers. Wire format unchanged (`unsafe_metadata` is a pre-existing field on the Frontend API). Minor version bump territory.

## Testing

13 new tests cover the merge behavior at the service layer (create-with each strategy + the explicit-wins precedence), the create/update asymmetry, the auto-clear lifecycle on all four events, and the public property roundtrip. `AuthConfig` `Equatable` is verified directly to protect the `AuthView.onChange` it drives.
