### PR TITLE
Add AuthView onDismiss callback for Expo support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,15 @@ opt_in_rules:
   - vertical_parameter_alignment_on_call
   - yoda_condition
 
+custom_rules:
+  auth_view_dismiss_auth_view:
+    included:
+      - Sources/ClerkKitUI/Components/Auth/AuthView.swift
+    name: "Use dismissAuthView"
+    regex: "(?m)^\\s*(?:self\\.)?dismiss\\(\\)"
+    message: "Use dismissAuthView() so Expo onDismiss is called before SwiftUI dismissal."
+    severity: error
+
 # Paths to ignore
 excluded:
   - Examples

--- a/Sources/ClerkKitUI/Components/Auth/AuthView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthView.swift
@@ -64,7 +64,7 @@ import SwiftUI
 public struct AuthView: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
-  @Environment(\.dismiss) private var dismiss
+  @Environment(\.dismiss) private var swiftUIDismiss
   /// Navigation state for the auth flow.
   @State private var navigation = AuthNavigation()
 
@@ -94,6 +94,9 @@ public struct AuthView: View {
 
   let isDismissable: Bool
 
+  /// Lets the Expo wrapper observe SwiftUI-initiated dismissals and update its presented state.
+  private let onDismiss: (() -> Void)?
+
   /// Creates a new authentication view.
   ///
   /// - Parameters:
@@ -103,18 +106,25 @@ public struct AuthView: View {
   ///     When `true`, a dismiss button appears and the view automatically
   ///     dismisses on successful authentication. When `false`, no dismiss
   ///     button is shown. Defaults to `true`.
-  public init(mode: Mode = .signInOrUp, isDismissable: Bool = true) {
-    self.init(mode: mode, isDismissable: isDismissable, config: AuthConfig())
+  ///   - onDismiss: Called when the view requests dismissal.
+  public init(
+    mode: Mode = .signInOrUp,
+    isDismissable: Bool = true,
+    onDismiss: (() -> Void)? = nil
+  ) {
+    self.init(mode: mode, isDismissable: isDismissable, config: AuthConfig(), onDismiss: onDismiss)
   }
 
   private init(
     mode: Mode,
     isDismissable: Bool,
-    config: AuthConfig
+    config: AuthConfig,
+    onDismiss: (() -> Void)?
   ) {
     _authState = State(initialValue: AuthState(mode: mode, config: config))
     self.isDismissable = isDismissable
     self.config = config
+    self.onDismiss = onDismiss
   }
 
   public var body: some View {
@@ -124,7 +134,7 @@ public struct AuthView: View {
           if showDismissButton {
             ToolbarItem(placement: .topBarTrailing) {
               DismissButton {
-                dismiss()
+                dismissAuthView()
               }
             }
           }
@@ -135,7 +145,7 @@ public struct AuthView: View {
               if showDismissButton {
                 ToolbarItem(placement: .topBarTrailing) {
                   DismissButton {
-                    dismiss()
+                    dismissAuthView()
                   }
                 }
               }
@@ -169,7 +179,7 @@ public struct AuthView: View {
           let isHandlingSessionTask = navigation.hasSessionTaskStartInPath
           let sessionSwitched = oldValue?.id != newValue?.id
           if becameActive, isDismissable, !isHandlingSessionTask || sessionSwitched {
-            dismiss()
+            dismissAuthView()
           }
         default:
           break
@@ -179,7 +189,7 @@ public struct AuthView: View {
     .onChange(of: navigation.allTasksComplete) { _, isComplete in
       guard isComplete else { return }
       if isDismissable {
-        dismiss()
+        dismissAuthView()
       }
     }
     .onChange(of: clerk.session?.tasks) { _, _ in
@@ -188,7 +198,7 @@ public struct AuthView: View {
     .onChange(of: clerk.user) { _, newUser in
       guard newUser == nil, navigation.hasSessionTaskStartInPath else { return }
       if isDismissable {
-        dismiss()
+        dismissAuthView()
       } else {
         navigation.path = []
       }
@@ -215,6 +225,11 @@ extension AuthView {
   private var showDismissButton: Bool {
     isDismissable && !navigation.hasSessionTaskStartInPath
   }
+
+  private func dismissAuthView() {
+    onDismiss?()
+    swiftUIDismiss()
+  }
 }
 
 // MARK: - View Modifiers
@@ -230,7 +245,7 @@ extension AuthView {
   public func initialIdentifier(_ identifier: String) -> AuthView {
     var config = config
     config.initialIdentifier = identifier
-    return AuthView(mode: authState.mode, isDismissable: isDismissable, config: config)
+    return AuthView(mode: authState.mode, isDismissable: isDismissable, config: config, onDismiss: onDismiss)
   }
 
   /// Controls whether auth identifier values are persisted between sessions.
@@ -243,7 +258,7 @@ extension AuthView {
   public func persistsIdentifiers(_ persists: Bool) -> AuthView {
     var config = config
     config.persistsIdentifiers = persists
-    return AuthView(mode: authState.mode, isDismissable: isDismissable, config: config)
+    return AuthView(mode: authState.mode, isDismissable: isDismissable, config: config, onDismiss: onDismiss)
   }
 
   /// Sets unsafe metadata to attach when this auth flow creates a sign-up.
@@ -256,7 +271,7 @@ extension AuthView {
   public func unsafeMetadata(_ metadata: JSON?) -> AuthView {
     var config = config
     config.unsafeMetadata = metadata
-    return AuthView(mode: authState.mode, isDismissable: isDismissable, config: config)
+    return AuthView(mode: authState.mode, isDismissable: isDismissable, config: config, onDismiss: onDismiss)
   }
 }
 


### PR DESCRIPTION
## Summary
- Add an optional `onDismiss` callback to `AuthView` so the Expo wrapper can track SwiftUI-driven dismissals.
- Route all `AuthView` dismissal paths through `dismissAuthView()`, which invokes `onDismiss` before requesting SwiftUI dismissal.
- Preserve the callback through `AuthView` configuration modifiers.
- Add a SwiftLint custom rule scoped to `AuthView.swift` that blocks direct `dismiss()` calls and keeps future dismiss paths on the callback-aware helper.

## Rationale
Expo owns the presented state for its wrapper around the SwiftUI `AuthView`, but `AuthView` can request dismissal internally from several paths: the close button, successful authentication, completed session tasks, and session-task user changes. Without a callback, Expo has no reliable signal that the native view requested dismissal, which can leave the wrapper state out of sync.

Calling `onDismiss` before the SwiftUI dismissal request lets Expo update its presented state in lockstep with the native dismissal. The SwiftLint rule protects that invariant without adding a test-only seam to production code.

## Testing
- `./.tools/bin/swiftlint lint --no-cache --config .swiftlint.yml Sources/ClerkKitUI/Components/Auth/AuthView.swift`