### PR TITLE
Bump Nuke to 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "ClerkKitUI", targets: ["ClerkKitUI"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/kean/Nuke.git", .upToNextMajor(from: "13.0.0")),
+    .package(url: "https://github.com/kean/Nuke.git", .upToNextMajor(from: "13.0.6")),
     .package(url: "https://github.com/marmelroy/PhoneNumberKit", .upToNextMajor(from: "4.0.0")),
     .package(url: "https://github.com/WeTransfer/Mocker", from: "3.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "ClerkKitUI", targets: ["ClerkKitUI"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/kean/Nuke.git", .upToNextMajor(from: "12.0.0")),
+    .package(url: "https://github.com/kean/Nuke.git", .upToNextMajor(from: "13.0.0")),
     .package(url: "https://github.com/marmelroy/PhoneNumberKit", .upToNextMajor(from: "4.0.0")),
     .package(url: "https://github.com/WeTransfer/Mocker", from: "3.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.1.0"),


### PR DESCRIPTION
## Summary
- Update the Nuke package requirement from 12.x to 13.x.

## Verification
- Built ClerkKitUI for iOS locally.
- Ran the Swift package test suite locally.