### PR TITLE
Fix dismissible spelling in prebuilt UI APIs

### DIFF
--- a/Sources/ClerkKitUI/Components/Auth/AuthView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 ///
 /// ## Usage
 ///
-/// Basic usage as a dismissable sheet:
+/// Basic usage as a dismissible sheet:
 ///
 /// ```swift
 /// struct HomeView: View {
@@ -44,7 +44,7 @@ import SwiftUI
 /// }
 /// ```
 ///
-/// Full-screen authentication (non-dismissable):
+/// Full-screen authentication (non-dismissible):
 ///
 /// ```swift
 /// struct ProfileView: View {
@@ -53,9 +53,9 @@ import SwiftUI
 ///   var body: some View {
 ///     Group {
 ///       if clerk.user != nil {
-///         UserProfileView(isDismissable: false)
+///         UserProfileView(isDismissible: false)
 ///       } else {
-///         AuthView(isDismissable: false)
+///         AuthView(isDismissible: false)
 ///       }
 ///     }
 ///   }
@@ -92,28 +92,28 @@ public struct AuthView: View {
     case signUp
   }
 
-  let isDismissable: Bool
+  let isDismissible: Bool
 
   /// Creates a new authentication view.
   ///
   /// - Parameters:
   ///   - mode: The authentication mode that determines available flows.
   ///     Defaults to `.signInOrUp()` which allows both sign-in and sign-up.
-  ///   - isDismissable: Whether the view can be dismissed by the user.
+  ///   - isDismissible: Whether the view can be dismissed by the user.
   ///     When `true`, a dismiss button appears and the view automatically
   ///     dismisses on successful authentication. When `false`, no dismiss
   ///     button is shown. Defaults to `true`.
-  public init(mode: Mode = .signInOrUp, isDismissable: Bool = true) {
-    self.init(mode: mode, isDismissable: isDismissable, config: AuthConfig())
+  public init(mode: Mode = .signInOrUp, isDismissible: Bool = true) {
+    self.init(mode: mode, isDismissible: isDismissible, config: AuthConfig())
   }
 
   private init(
     mode: Mode,
-    isDismissable: Bool,
+    isDismissible: Bool,
     config: AuthConfig
   ) {
     _authState = State(initialValue: AuthState(mode: mode, config: config))
-    self.isDismissable = isDismissable
+    self.isDismissible = isDismissible
     self.config = config
   }
 
@@ -168,7 +168,7 @@ public struct AuthView: View {
           let becameActive = newValue?.status == .active && (oldValue?.status != .active || oldValue?.id != newValue?.id)
           let isHandlingSessionTask = navigation.hasSessionTaskStartInPath
           let sessionSwitched = oldValue?.id != newValue?.id
-          if becameActive, isDismissable, !isHandlingSessionTask || sessionSwitched {
+          if becameActive, isDismissible, !isHandlingSessionTask || sessionSwitched {
             dismiss()
           }
         default:
@@ -178,7 +178,7 @@ public struct AuthView: View {
     }
     .onChange(of: navigation.allTasksComplete) { _, isComplete in
       guard isComplete else { return }
-      if isDismissable {
+      if isDismissible {
         dismiss()
       }
     }
@@ -187,7 +187,7 @@ public struct AuthView: View {
     }
     .onChange(of: clerk.user) { _, newUser in
       guard newUser == nil, navigation.hasSessionTaskStartInPath else { return }
-      if isDismissable {
+      if isDismissible {
         dismiss()
       } else {
         navigation.path = []
@@ -202,7 +202,7 @@ public struct AuthView: View {
           "AuthView",
           payload: [
             "mode": .string(authState.mode.rawValue),
-            "isDismissable": .bool(isDismissable),
+            "isDismissible": .bool(isDismissible),
           ]
         )
       )
@@ -213,7 +213,7 @@ public struct AuthView: View {
 extension AuthView {
   /// Whether the dismiss button should be shown, accounting for required session tasks.
   private var showDismissButton: Bool {
-    isDismissable && !navigation.hasSessionTaskStartInPath
+    isDismissible && !navigation.hasSessionTaskStartInPath
   }
 }
 
@@ -230,7 +230,7 @@ extension AuthView {
   public func initialIdentifier(_ identifier: String) -> AuthView {
     var config = config
     config.initialIdentifier = identifier
-    return AuthView(mode: authState.mode, isDismissable: isDismissable, config: config)
+    return AuthView(mode: authState.mode, isDismissible: isDismissible, config: config)
   }
 
   /// Controls whether auth identifier values are persisted between sessions.
@@ -243,7 +243,7 @@ extension AuthView {
   public func persistsIdentifiers(_ persists: Bool) -> AuthView {
     var config = config
     config.persistsIdentifiers = persists
-    return AuthView(mode: authState.mode, isDismissable: isDismissable, config: config)
+    return AuthView(mode: authState.mode, isDismissible: isDismissible, config: config)
   }
 
   /// Sets unsafe metadata to attach when this auth flow creates a sign-up.
@@ -256,7 +256,7 @@ extension AuthView {
   public func unsafeMetadata(_ metadata: JSON?) -> AuthView {
     var config = config
     config.unsafeMetadata = metadata
-    return AuthView(mode: authState.mode, isDismissable: isDismissable, config: config)
+    return AuthView(mode: authState.mode, isDismissible: isDismissible, config: config)
   }
 }
 
@@ -354,7 +354,7 @@ extension AuthView {
 }
 
 #Preview("Not in sheet") {
-  AuthView(isDismissable: false)
+  AuthView(isDismissible: false)
     .clerkPreview()
 }
 

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationListView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationListView.swift
@@ -20,7 +20,7 @@ import SwiftUI
 ///
 /// ## Usage
 ///
-/// As a dismissable sheet:
+/// As a dismissible sheet:
 ///
 /// ```swift
 /// struct AccountPickerButton: View {
@@ -45,7 +45,7 @@ import SwiftUI
 ///
 ///   var body: some View {
 ///     NavigationStack(path: $path) {
-///       OrganizationListView(isDismissable: false, navigationPath: $path)
+///       OrganizationListView(isDismissible: false, navigationPath: $path)
 ///     }
 ///   }
 /// }
@@ -56,7 +56,7 @@ public struct OrganizationListView: View {
   @Environment(\.dismiss) private var dismiss
 
   private let hidePersonal: Bool
-  private let isDismissable: Bool
+  private let isDismissible: Bool
   private let skipInvitationScreen: Bool
   private let navigationPath: Binding<NavigationPath>?
   private let title: LocalizedStringKey
@@ -98,7 +98,7 @@ public struct OrganizationListView: View {
   /// - Parameters:
   ///   - hidePersonal: Whether the personal account row should be hidden even when
   ///     personal account selection is allowed.
-  ///   - isDismissable: Whether the view can dismiss itself after account selection and
+  ///   - isDismissible: Whether the view can dismiss itself after account selection and
   ///     show a dismiss button.
   ///   - navigationPath: An optional parent navigation path for embedded usage. Pass
   ///     a parent path when the view is hosted inside your own `NavigationStack`.
@@ -106,13 +106,13 @@ public struct OrganizationListView: View {
   ///     post-create invite step.
   public init(
     hidePersonal: Bool = false,
-    isDismissable: Bool = true,
+    isDismissible: Bool = true,
     navigationPath: Binding<NavigationPath>? = nil,
     skipInvitationScreen: Bool = false
   ) {
     self.init(
       hidePersonal: hidePersonal,
-      isDismissable: isDismissable,
+      isDismissible: isDismissible,
       navigationPath: navigationPath,
       skipInvitationScreen: skipInvitationScreen,
       title: "Choose an account",
@@ -122,14 +122,14 @@ public struct OrganizationListView: View {
 
   init(
     hidePersonal: Bool = false,
-    isDismissable: Bool = true,
+    isDismissible: Bool = true,
     navigationPath: Binding<NavigationPath>? = nil,
     skipInvitationScreen: Bool = false,
     title: LocalizedStringKey,
     subtitle: LocalizedStringKey?
   ) {
     self.hidePersonal = hidePersonal
-    self.isDismissable = isDismissable
+    self.isDismissible = isDismissible
     self.skipInvitationScreen = skipInvitationScreen
     self.navigationPath = navigationPath
     self.title = title
@@ -184,7 +184,7 @@ public struct OrganizationListView: View {
       }
     }
     .toolbar {
-      if isDismissable {
+      if isDismissible {
         ToolbarItem(placement: .cancellationAction) {
           Button("Cancel") {
             dismiss()
@@ -297,12 +297,12 @@ public struct OrganizationListView: View {
   }
 
   private func dismissIfNeeded() {
-    guard isDismissable else { return }
+    guard isDismissible else { return }
     dismiss()
   }
 
   private func completeCreateOrganizationFlow() {
-    if isDismissable {
+    if isDismissible {
       dismiss()
     } else {
       popCreateOrganizationFlow()

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationProfileView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationProfileView.swift
@@ -20,7 +20,7 @@ import SwiftUI
 ///
 /// ## Usage
 ///
-/// As a dismissable sheet:
+/// As a dismissible sheet:
 ///
 /// ```swift
 /// struct OrganizationSettingsButton: View {
@@ -45,7 +45,7 @@ import SwiftUI
 ///
 ///   var body: some View {
 ///     NavigationStack(path: $path) {
-///       OrganizationProfileView(isDismissable: false, navigationPath: $path)
+///       OrganizationProfileView(isDismissible: false, navigationPath: $path)
 ///     }
 ///   }
 /// }
@@ -88,7 +88,7 @@ public struct OrganizationProfileView<Route: Hashable, Destination: View>: View 
   @Environment(\.clerkTheme) private var theme
   @Environment(\.dismiss) private var dismiss
 
-  private let isDismissable: Bool
+  private let isDismissible: Bool
   private let navigationPath: Binding<NavigationPath>?
   private let customRows: [OrganizationProfileCustomRow<Route>]
   private let customDestination: (@MainActor (Route) -> Destination)?
@@ -144,12 +144,12 @@ public struct OrganizationProfileView<Route: Hashable, Destination: View>: View 
   }
 
   init(
-    isDismissable: Bool,
+    isDismissible: Bool,
     navigationPath: Binding<NavigationPath>?,
     customRows: [OrganizationProfileCustomRow<Route>],
     customDestination: (@MainActor (Route) -> Destination)?
   ) {
-    self.isDismissable = isDismissable
+    self.isDismissible = isDismissible
     self.navigationPath = navigationPath
     self.customRows = customRows
     self.customDestination = customDestination
@@ -158,17 +158,17 @@ public struct OrganizationProfileView<Route: Hashable, Destination: View>: View 
   /// Creates a new organization profile view.
   ///
   /// - Parameters:
-  ///   - isDismissable: Whether the view can be dismissed by the user. When `true`,
+  ///   - isDismissible: Whether the view can be dismissed by the user. When `true`,
   ///     a dismiss button appears in the navigation bar. When `false`, no dismiss
   ///     button is shown.
   ///   - navigationPath: An optional parent navigation path for embedded usage. Pass
   ///     a parent path when the view is hosted inside your own `NavigationStack`.
   public init(
-    isDismissable: Bool = true,
+    isDismissible: Bool = true,
     navigationPath: Binding<NavigationPath>? = nil
   ) where Route == Never, Destination == EmptyView {
     self.init(
-      isDismissable: isDismissable,
+      isDismissible: isDismissible,
       navigationPath: navigationPath,
       customRows: [],
       customDestination: nil
@@ -264,7 +264,7 @@ public struct OrganizationProfileView<Route: Hashable, Destination: View>: View 
           .foregroundStyle(theme.colors.foreground)
       }
 
-      if isDismissable {
+      if isDismissible {
         ToolbarItem(placement: .topBarTrailing) {
           DismissButton()
         }
@@ -296,7 +296,7 @@ extension OrganizationProfileView {
     _ rows: [OrganizationProfileCustomRow<Route>]
   ) -> OrganizationProfileView<Route, Destination> {
     OrganizationProfileView<Route, Destination>(
-      isDismissable: isDismissable,
+      isDismissible: isDismissible,
       navigationPath: navigationPath,
       customRows: rows,
       customDestination: customDestination
@@ -314,7 +314,7 @@ extension OrganizationProfileView where Destination == EmptyView {
     @ViewBuilder _ destination: @escaping @MainActor (Route) -> NewDestination
   ) -> OrganizationProfileView<Route, NewDestination> {
     OrganizationProfileView<Route, NewDestination>(
-      isDismissable: isDismissable,
+      isDismissible: isDismissible,
       navigationPath: navigationPath,
       customRows: customRows,
       customDestination: destination
@@ -328,7 +328,7 @@ extension OrganizationProfileView where Route == Never, Destination == EmptyView
     _ rows: [OrganizationProfileCustomRow<NewRoute>]
   ) -> OrganizationProfileView<NewRoute, EmptyView> {
     OrganizationProfileView<NewRoute, EmptyView>(
-      isDismissable: isDismissable,
+      isDismissible: isDismissible,
       navigationPath: navigationPath,
       customRows: rows,
       customDestination: nil
@@ -345,7 +345,7 @@ extension OrganizationProfileView where Route == Never, Destination == EmptyView
     @ViewBuilder _ destination: @escaping @MainActor (NewRoute) -> NewDestination
   ) -> OrganizationProfileView<NewRoute, NewDestination> {
     OrganizationProfileView<NewRoute, NewDestination>(
-      isDismissable: isDismissable,
+      isDismissible: isDismissible,
       navigationPath: navigationPath,
       customRows: [],
       customDestination: destination

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationSwitcher.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationSwitcher.swift
@@ -217,7 +217,7 @@ public struct OrganizationSwitcher<Route: Hashable, LabelContent: View, Destinat
       )
     case .profile:
       OrganizationProfileView(
-        isDismissable: true,
+        isDismissible: true,
         navigationPath: nil,
         customRows: customRows,
         customDestination: customDestination

--- a/Sources/ClerkKitUI/Components/UserButton/UserButton.swift
+++ b/Sources/ClerkKitUI/Components/UserButton/UserButton.swift
@@ -156,7 +156,7 @@ public struct UserButton<Route: Hashable, SignedOutContent: View, Destination: V
       switch sheet {
       case .userProfile:
         UserProfileView(
-          isDismissable: true,
+          isDismissible: true,
           navigationPath: nil,
           customRows: customRows,
           customDestination: customDestination,

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -27,16 +27,16 @@ import SwiftUI
 ///   var body: some View {
 ///     Group {
 ///       if clerk.user != nil {
-///         UserProfileView(isDismissable: false)
+///         UserProfileView(isDismissible: false)
 ///       } else {
-///         AuthView(isDismissable: false)
+///         AuthView(isDismissible: false)
 ///       }
 ///     }
 ///   }
 /// }
 /// ```
 ///
-/// As a dismissable sheet:
+/// As a dismissible sheet:
 ///
 /// ```swift
 /// struct MainView: View {
@@ -65,7 +65,7 @@ import SwiftUI
 ///         .navigationDestination(for: AppRoute.self) { route in
 ///           switch route {
 ///           case .profile:
-///             UserProfileView(isDismissable: false, navigationPath: $path)
+///             UserProfileView(isDismissible: false, navigationPath: $path)
 ///           }
 ///         }
 ///     }
@@ -103,7 +103,7 @@ public struct UserProfileView<Route: Hashable, Destination: View>: View {
   @Environment(\.clerkTheme) private var theme
   @Environment(\.dismiss) private var dismiss
 
-  private let isDismissable: Bool
+  private let isDismissible: Bool
   private let navigationPath: Binding<NavigationPath>?
   private let customRows: [UserProfileCustomRow<Route>]
   private let customDestination: (@MainActor (Route) -> Destination)?
@@ -118,13 +118,13 @@ public struct UserProfileView<Route: Hashable, Destination: View>: View {
   @State private var error: Error?
 
   init(
-    isDismissable: Bool,
+    isDismissible: Bool,
     navigationPath: Binding<NavigationPath>?,
     customRows: [UserProfileCustomRow<Route>],
     customDestination: (@MainActor (Route) -> Destination)?,
     oauthConfig: UserProfileOAuthConfiguration
   ) {
-    self.isDismissable = isDismissable
+    self.isDismissible = isDismissible
     self.navigationPath = navigationPath
     self.customRows = customRows
     self.customDestination = customDestination
@@ -134,9 +134,9 @@ public struct UserProfileView<Route: Hashable, Destination: View>: View {
   /// Creates a new user profile view.
   ///
   /// - Parameters:
-  ///   - isDismissable: Whether the view can be dismissed by the user.
+  ///   - isDismissible: Whether the view can be dismissed by the user.
   ///   When `true`, a dismiss button appears in the navigation bar and the view
-  ///   can be used in sheets or other dismissable contexts. When `false`, no
+  ///   can be used in sheets or other dismissible contexts. When `false`, no
   ///   dismiss button is shown, making it suitable for full-screen usage.
   ///   Defaults to `true`.
   ///   - navigationPath: An optional binding to a parent `NavigationPath`. When provided,
@@ -144,11 +144,11 @@ public struct UserProfileView<Route: Hashable, Destination: View>: View {
   ///   parent's path instead. Use this when embedding `UserProfileView` inside your own
   ///   `NavigationStack` to avoid nested navigation stacks. Defaults to `nil`.
   public init(
-    isDismissable: Bool = true,
+    isDismissible: Bool = true,
     navigationPath: Binding<NavigationPath>? = nil
   ) where Route == Never, Destination == EmptyView {
     self.init(
-      isDismissable: isDismissable,
+      isDismissible: isDismissible,
       navigationPath: navigationPath,
       customRows: [],
       customDestination: nil,
@@ -227,7 +227,7 @@ public struct UserProfileView<Route: Hashable, Destination: View>: View {
           TelemetryEvents.viewDidAppear(
             "UserProfileView",
             payload: [
-              "isDismissable": .bool(isDismissable),
+              "isDismissible": .bool(isDismissible),
               "isEmbedded": .bool(navigationPath != nil),
             ]
           )
@@ -317,7 +317,7 @@ public struct UserProfileView<Route: Hashable, Destination: View>: View {
           .foregroundStyle(theme.colors.foreground)
       }
 
-      if isDismissable {
+      if isDismissible {
         ToolbarItem(placement: .topBarTrailing) {
           DismissButton()
         }
@@ -352,7 +352,7 @@ extension UserProfileView {
     _ rows: [UserProfileCustomRow<Route>]
   ) -> UserProfileView<Route, Destination> {
     UserProfileView<Route, Destination>(
-      isDismissable: isDismissable,
+      isDismissible: isDismissible,
       navigationPath: navigationPath,
       customRows: rows,
       customDestination: customDestination,
@@ -365,7 +365,7 @@ extension UserProfileView {
     _ configs: [OAuthProviderConfig]
   ) -> UserProfileView<Route, Destination> {
     UserProfileView<Route, Destination>(
-      isDismissable: isDismissable,
+      isDismissible: isDismissible,
       navigationPath: navigationPath,
       customRows: customRows,
       customDestination: customDestination,
@@ -384,7 +384,7 @@ extension UserProfileView where Destination == EmptyView {
     @ViewBuilder _ destination: @escaping @MainActor (Route) -> NewDestination
   ) -> UserProfileView<Route, NewDestination> {
     UserProfileView<Route, NewDestination>(
-      isDismissable: isDismissable,
+      isDismissible: isDismissible,
       navigationPath: navigationPath,
       customRows: customRows,
       customDestination: destination,
@@ -399,7 +399,7 @@ extension UserProfileView where Route == Never, Destination == EmptyView {
     _ rows: [UserProfileCustomRow<NewRoute>]
   ) -> UserProfileView<NewRoute, EmptyView> {
     UserProfileView<NewRoute, EmptyView>(
-      isDismissable: isDismissable,
+      isDismissible: isDismissible,
       navigationPath: navigationPath,
       customRows: rows,
       customDestination: nil,
@@ -417,7 +417,7 @@ extension UserProfileView where Route == Never, Destination == EmptyView {
     @ViewBuilder _ destination: @escaping @MainActor (NewRoute) -> NewDestination
   ) -> UserProfileView<NewRoute, NewDestination> {
     UserProfileView<NewRoute, NewDestination>(
-      isDismissable: isDismissable,
+      isDismissible: isDismissible,
       navigationPath: navigationPath,
       customRows: [],
       customDestination: destination,
@@ -624,7 +624,7 @@ private enum UserProfileListRowID<Route: Hashable>: Hashable {
   case custom(route: Route, occurrence: Int)
 }
 
-#Preview("Dismissable") {
+#Preview("Dismissible") {
   UserProfileView()
     .environment(
       Clerk.preview { builder in
@@ -698,8 +698,8 @@ private enum UserProfileListRowID<Route: Hashable>: Hashable {
     .environment(\.clerkTheme, .clerk)
 }
 
-#Preview("Not dismissable") {
-  UserProfileView(isDismissable: false)
+#Preview("Not dismissible") {
+  UserProfileView(isDismissible: false)
     .environment(
       Clerk.preview { builder in
         builder.services.clientService.getHandler = {
@@ -726,7 +726,7 @@ private enum UserProfileListRowID<Route: Hashable>: Hashable {
 #Preview("Embedded in parent NavigationStack") {
   @Previewable @State var navigationPath = NavigationPath()
 
-  UserProfileView(isDismissable: false, navigationPath: $navigationPath)
+  UserProfileView(isDismissible: false, navigationPath: $navigationPath)
     .environment(
       Clerk.preview { builder in
         builder.services.clientService.getHandler = {


### PR DESCRIPTION
## Summary
- Rename prebuilt UI dismissibility labels from isDismissable to isDismissible
- Update related docs examples and telemetry payload spelling

## Testing
- make check