### PR TITLE
fix: Add @Sendable to ASWebAuthenticationSession completion handler to prevent macOS crashes

### DIFF
--- a/Sources/ClerkKit/Utils/WebAuthentication.swift
+++ b/Sources/ClerkKit/Utils/WebAuthentication.swift
@@ -71,7 +71,7 @@ final class WebAuthentication: NSObject {
         let session = ASWebAuthenticationSession(
           url: url,
           callbackURLScheme: Clerk.shared.options.redirectConfig.callbackUrlScheme,
-          completionHandler: { url, error in
+          completionHandler: { @Sendable url, error in
             Task {
               #if os(macOS)
               await WebAuthentication.lifecycleRefreshManager.markPendingForegroundRefreshSuppression()


### PR DESCRIPTION
## The Problem
When using the Clerk SDK in a macOS application, initiating a social sign-in (like Google) and clicking "Continue" in the browse causes the app to crash instantly.

## Why it happens
Under Swift 5/6 Strict Concurrency and on macOS, triggering ASWebAuthenticationSession from a @MainActor-isolated context causes the completion handler closure to implicitly inherit MainActor isolation.

Because the OS authentication services execute the completion handler on a background serial dispatch queue, this mismatch triggers a runtime queue assertion check failure (libdispatch.dylib _dispatch_assert_queue_fail) and crashes the host app with EXC_BREAKPOINT.

## The Fix
 Marking the closure explicitly as @Sendable tells the compiler and runtime that the block is non-isolated and can be safely executed across concurrency boundaries (i.e. on the background thread where the OS calls it). The subsequent Task block within the handler then safely hops back to the correct context using standard Swift await semantics.