### PR TITLE
Align Expo PR token secret name

### DIFF
--- a/.github/workflows/bump-javascript-expo-ios-sdk.yml
+++ b/.github/workflows/bump-javascript-expo-ios-sdk.yml
@@ -53,12 +53,12 @@ jobs:
 
       - name: Verify JavaScript repo token
         env:
-          JAVASCRIPT_RELEASE_PR_TOKEN: ${{ secrets.JAVASCRIPT_RELEASE_PR_TOKEN }}
+          OPEN_EXPO_PR_GH_TOKEN: ${{ secrets.OPEN_EXPO_PR_GH_TOKEN }}
         run: |
           set -euo pipefail
 
-          if [ -z "$JAVASCRIPT_RELEASE_PR_TOKEN" ]; then
-            echo "JAVASCRIPT_RELEASE_PR_TOKEN must be configured with clerk/javascript contents and pull request write access."
+          if [ -z "$OPEN_EXPO_PR_GH_TOKEN" ]; then
+            echo "OPEN_EXPO_PR_GH_TOKEN must be configured with clerk/javascript contents and pull request write access."
             echo "Use a token that authenticates as clerk-cookie so the generated PR author is clerk-cookie."
             exit 1
           fi
@@ -69,7 +69,7 @@ jobs:
           repository: ${{ env.JAVASCRIPT_REPO }}
           ref: main
           path: javascript
-          token: ${{ secrets.JAVASCRIPT_RELEASE_PR_TOKEN }}
+          token: ${{ secrets.OPEN_EXPO_PR_GH_TOKEN }}
 
       - name: Update @clerk/expo iOS SDK pin
         id: update
@@ -130,7 +130,7 @@ jobs:
         if: steps.update.outputs.should_open == 'true'
         working-directory: javascript
         env:
-          GH_TOKEN: ${{ secrets.JAVASCRIPT_RELEASE_PR_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPEN_EXPO_PR_GH_TOKEN }}
           BRANCH_NAME: ${{ steps.version.outputs.branch_name }}
           IOS_VERSION: ${{ steps.version.outputs.ios_version }}
           RELEASE_URL: ${{ steps.version.outputs.release_url }}


### PR DESCRIPTION
## Summary

- align the iOS Expo bump workflow with clerk-android by using `OPEN_EXPO_PR_GH_TOKEN`
- update the missing-token error message to reference the shared secret name

## Testing

- actionlint .github/workflows/bump-javascript-expo-ios-sdk.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/bump-javascript-expo-ios-sdk.yml"); puts "yaml ok"'