### PR TITLE
Use WebAuthn RP ID for passkey flows on iOS

### DIFF
--- a/Sources/ClerkKit/Domains/Auth/Passkey/Passkey.swift
+++ b/Sources/ClerkKit/Domains/Auth/Passkey/Passkey.swift
@@ -61,6 +61,13 @@ extension Passkey {
   var userId: Data? {
     nonceJSON?.user?.id?.stringValue?.base64URLFromBase64String().dataFromBase64URL()
   }
+
+  var relyingPartyIdentifier: String? {
+    guard let identifier = nonceJSON?.rp?.id?.stringValue, !identifier.isEmpty else {
+      return nil
+    }
+    return identifier
+  }
 }
 
 extension Passkey {

--- a/Sources/ClerkKit/Domains/Auth/Session/Session+Verification.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/Session+Verification.swift
@@ -99,10 +99,12 @@ extension Session {
     }
 
     let relyingPartyIdentifier = nonceJSON.webAuthnAssertionRelyingPartyIdentifier
+    let allowedCredentialIDs = nonceJSON.webAuthnAssertionAllowedCredentialIDs
     let manager = PasskeyHelper()
     let authorization = try await manager.signIn(
       challenge: challenge,
       relyingPartyIdentifier: relyingPartyIdentifier,
+      allowedCredentialIDs: allowedCredentialIDs,
       preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
     )
 

--- a/Sources/ClerkKit/Domains/Auth/Session/Session+Verification.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/Session+Verification.swift
@@ -98,7 +98,7 @@ extension Session {
       throw ClerkClientError(message: "Unable to get the challenge for the passkey.")
     }
 
-    let relyingPartyIdentifier = nonceJSON["rpId"]?.stringValue
+    let relyingPartyIdentifier = nonceJSON.webAuthnAssertionRelyingPartyIdentifier
     let manager = PasskeyHelper()
     let authorization = try await manager.signIn(
       challenge: challenge,

--- a/Sources/ClerkKit/Domains/Auth/Session/Session+Verification.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/Session+Verification.swift
@@ -98,9 +98,11 @@ extension Session {
       throw ClerkClientError(message: "Unable to get the challenge for the passkey.")
     }
 
+    let relyingPartyIdentifier = nonceJSON["rpId"]?.stringValue
     let manager = PasskeyHelper()
     let authorization = try await manager.signIn(
       challenge: challenge,
+      relyingPartyIdentifier: relyingPartyIdentifier,
       preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
     )
 

--- a/Sources/ClerkKit/Domains/Auth/SignIn/SignIn.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignIn/SignIn.swift
@@ -557,21 +557,27 @@ extension SignIn {
       throw ClerkClientError(message: "Unable to get the challenge for the passkey.")
     }
 
+    let relyingPartyIdentifier = nonceJSON["rpId"]?.stringValue
     let manager = PasskeyHelper()
     let authorization: ASAuthorization
 
     #if os(iOS) && !targetEnvironment(macCatalyst)
     if autofill {
-      authorization = try await manager.beginAutoFillAssistedPasskeySignIn(challenge: challenge)
+      authorization = try await manager.beginAutoFillAssistedPasskeySignIn(
+        challenge: challenge,
+        relyingPartyIdentifier: relyingPartyIdentifier
+      )
     } else {
       authorization = try await manager.signIn(
         challenge: challenge,
+        relyingPartyIdentifier: relyingPartyIdentifier,
         preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
       )
     }
     #else
     authorization = try await manager.signIn(
       challenge: challenge,
+      relyingPartyIdentifier: relyingPartyIdentifier,
       preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
     )
     #endif

--- a/Sources/ClerkKit/Domains/Auth/SignIn/SignIn.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignIn/SignIn.swift
@@ -557,7 +557,7 @@ extension SignIn {
       throw ClerkClientError(message: "Unable to get the challenge for the passkey.")
     }
 
-    let relyingPartyIdentifier = nonceJSON["rpId"]?.stringValue
+    let relyingPartyIdentifier = nonceJSON.webAuthnAssertionRelyingPartyIdentifier
     let manager = PasskeyHelper()
     let authorization: ASAuthorization
 

--- a/Sources/ClerkKit/Domains/Auth/SignIn/SignIn.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignIn/SignIn.swift
@@ -558,6 +558,7 @@ extension SignIn {
     }
 
     let relyingPartyIdentifier = nonceJSON.webAuthnAssertionRelyingPartyIdentifier
+    let allowedCredentialIDs = nonceJSON.webAuthnAssertionAllowedCredentialIDs
     let manager = PasskeyHelper()
     let authorization: ASAuthorization
 
@@ -565,12 +566,14 @@ extension SignIn {
     if autofill {
       authorization = try await manager.beginAutoFillAssistedPasskeySignIn(
         challenge: challenge,
-        relyingPartyIdentifier: relyingPartyIdentifier
+        relyingPartyIdentifier: relyingPartyIdentifier,
+        allowedCredentialIDs: allowedCredentialIDs
       )
     } else {
       authorization = try await manager.signIn(
         challenge: challenge,
         relyingPartyIdentifier: relyingPartyIdentifier,
+        allowedCredentialIDs: allowedCredentialIDs,
         preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
       )
     }
@@ -578,6 +581,7 @@ extension SignIn {
     authorization = try await manager.signIn(
       challenge: challenge,
       relyingPartyIdentifier: relyingPartyIdentifier,
+      allowedCredentialIDs: allowedCredentialIDs,
       preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
     )
     #endif

--- a/Sources/ClerkKit/Domains/User/UserService.swift
+++ b/Sources/ClerkKit/Domains/User/UserService.swift
@@ -166,7 +166,8 @@ final class UserService: UserServiceProtocol {
     let authorization = try await manager.createPasskey(
       challenge: challenge,
       name: name,
-      userId: userId
+      userId: userId,
+      relyingPartyIdentifier: passkey.relyingPartyIdentifier
     )
 
     guard

--- a/Sources/ClerkKit/Helpers/PasskeyHelper.swift
+++ b/Sources/ClerkKit/Helpers/PasskeyHelper.swift
@@ -37,7 +37,10 @@ final class PasskeyHelper: NSObject {
     }
 
     let host = urlComponents.host ?? ""
-    return host.replacingOccurrences(of: "www.", with: "")
+    if host.hasPrefix("www.") {
+      return String(host.dropFirst("www.".count))
+    }
+    return host
   }
 
   @MainActor

--- a/Sources/ClerkKit/Helpers/PasskeyHelper.swift
+++ b/Sources/ClerkKit/Helpers/PasskeyHelper.swift
@@ -60,20 +60,38 @@ final class PasskeyHelper: NSObject {
   private var continuation: CheckedContinuation<ASAuthorization, Error>?
 
   @MainActor
+  func credentialAssertionRequest(
+    challenge: Data,
+    relyingPartyIdentifier: String? = nil,
+    allowedCredentialIDs: [Data] = []
+  ) -> ASAuthorizationPlatformPublicKeyCredentialAssertionRequest {
+    let publicKeyCredentialProvider = publicKeyCredentialProvider(
+      relyingPartyIdentifier: relyingPartyIdentifier
+    )
+
+    let assertionRequest = publicKeyCredentialProvider.createCredentialAssertionRequest(challenge: challenge)
+    assertionRequest.allowedCredentials = allowedCredentialIDs.map {
+      ASAuthorizationPlatformPublicKeyCredentialDescriptor(credentialID: $0)
+    }
+    return assertionRequest
+  }
+
+  @MainActor
   func signIn(
     challenge: Data,
     relyingPartyIdentifier: String? = nil,
+    allowedCredentialIDs: [Data] = [],
     preferImmediatelyAvailableCredentials: Bool
   ) async throws -> ASAuthorization {
     try await withCheckedThrowingContinuation { continuation in
       self.continuation = continuation
       Self.activeHelper = self
 
-      let publicKeyCredentialProvider = publicKeyCredentialProvider(
-        relyingPartyIdentifier: relyingPartyIdentifier
+      let assertionRequest = credentialAssertionRequest(
+        challenge: challenge,
+        relyingPartyIdentifier: relyingPartyIdentifier,
+        allowedCredentialIDs: allowedCredentialIDs
       )
-
-      let assertionRequest = publicKeyCredentialProvider.createCredentialAssertionRequest(challenge: challenge)
 
       // Pass in any mix of supported sign-in request types.
       let authController = ASAuthorizationController(authorizationRequests: [assertionRequest])
@@ -108,17 +126,18 @@ final class PasskeyHelper: NSObject {
   @MainActor
   func beginAutoFillAssistedPasskeySignIn(
     challenge: Data,
-    relyingPartyIdentifier: String? = nil
+    relyingPartyIdentifier: String? = nil,
+    allowedCredentialIDs: [Data] = []
   ) async throws -> ASAuthorization {
     try await withCheckedThrowingContinuation { continuation in
       self.continuation = continuation
       Self.activeHelper = self
 
-      let publicKeyCredentialProvider = publicKeyCredentialProvider(
-        relyingPartyIdentifier: relyingPartyIdentifier
+      let assertionRequest = credentialAssertionRequest(
+        challenge: challenge,
+        relyingPartyIdentifier: relyingPartyIdentifier,
+        allowedCredentialIDs: allowedCredentialIDs
       )
-
-      let assertionRequest = publicKeyCredentialProvider.createCredentialAssertionRequest(challenge: challenge)
 
       // AutoFill-assisted requests only support ASAuthorizationPlatformPublicKeyCredentialAssertionRequest.
       let authController = ASAuthorizationController(authorizationRequests: [assertionRequest])

--- a/Sources/ClerkKit/Helpers/PasskeyHelper.swift
+++ b/Sources/ClerkKit/Helpers/PasskeyHelper.swift
@@ -31,7 +31,7 @@ final class PasskeyHelper: NSObject {
   }
 
   @MainActor
-  var domain: String {
+  private var defaultRelyingPartyIdentifier: String {
     guard let urlComponents = URLComponents(string: Clerk.shared.frontendApiUrl) else {
       return ""
     }
@@ -40,15 +40,38 @@ final class PasskeyHelper: NSObject {
     return host.replacingOccurrences(of: "www.", with: "")
   }
 
+  @MainActor
+  private func publicKeyCredentialProvider(
+    relyingPartyIdentifier: String?
+  ) -> ASAuthorizationPlatformPublicKeyCredentialProvider {
+    let identifier = relyingPartyIdentifier.map {
+      $0.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    let resolvedIdentifier = if let identifier, !identifier.isEmpty {
+      identifier
+    } else {
+      defaultRelyingPartyIdentifier
+    }
+    return ASAuthorizationPlatformPublicKeyCredentialProvider(
+      relyingPartyIdentifier: resolvedIdentifier
+    )
+  }
+
   private var continuation: CheckedContinuation<ASAuthorization, Error>?
 
   @MainActor
-  func signIn(challenge: Data, preferImmediatelyAvailableCredentials: Bool) async throws -> ASAuthorization {
+  func signIn(
+    challenge: Data,
+    relyingPartyIdentifier: String? = nil,
+    preferImmediatelyAvailableCredentials: Bool
+  ) async throws -> ASAuthorization {
     try await withCheckedThrowingContinuation { continuation in
       self.continuation = continuation
       Self.activeHelper = self
 
-      let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: domain)
+      let publicKeyCredentialProvider = publicKeyCredentialProvider(
+        relyingPartyIdentifier: relyingPartyIdentifier
+      )
 
       let assertionRequest = publicKeyCredentialProvider.createCredentialAssertionRequest(challenge: challenge)
 
@@ -83,12 +106,17 @@ final class PasskeyHelper: NSObject {
 
   #if os(iOS) && !targetEnvironment(macCatalyst)
   @MainActor
-  func beginAutoFillAssistedPasskeySignIn(challenge: Data) async throws -> ASAuthorization {
+  func beginAutoFillAssistedPasskeySignIn(
+    challenge: Data,
+    relyingPartyIdentifier: String? = nil
+  ) async throws -> ASAuthorization {
     try await withCheckedThrowingContinuation { continuation in
       self.continuation = continuation
       Self.activeHelper = self
 
-      let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: domain)
+      let publicKeyCredentialProvider = publicKeyCredentialProvider(
+        relyingPartyIdentifier: relyingPartyIdentifier
+      )
 
       let assertionRequest = publicKeyCredentialProvider.createCredentialAssertionRequest(challenge: challenge)
 
@@ -104,12 +132,19 @@ final class PasskeyHelper: NSObject {
   #endif
 
   @MainActor
-  func createPasskey(challenge: Data, name: String, userId: Data) async throws -> ASAuthorization {
+  func createPasskey(
+    challenge: Data,
+    name: String,
+    userId: Data,
+    relyingPartyIdentifier: String? = nil
+  ) async throws -> ASAuthorization {
     try await withCheckedThrowingContinuation { continuation in
       self.continuation = continuation
       Self.activeHelper = self
 
-      let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: domain)
+      let publicKeyCredentialProvider = publicKeyCredentialProvider(
+        relyingPartyIdentifier: relyingPartyIdentifier
+      )
 
       let registrationRequest = publicKeyCredentialProvider.createCredentialRegistrationRequest(
         challenge: challenge,

--- a/Sources/ClerkKit/Utils/JSON+WebAuthn.swift
+++ b/Sources/ClerkKit/Utils/JSON+WebAuthn.swift
@@ -2,11 +2,30 @@
 //  JSON+WebAuthn.swift
 //
 
+import Foundation
+
 extension JSON {
   var webAuthnAssertionRelyingPartyIdentifier: String? {
     guard let identifier = self["rpId"]?.stringValue, !identifier.isEmpty else {
       return nil
     }
     return identifier
+  }
+
+  var webAuthnAssertionAllowedCredentialIDs: [Data] {
+    guard let allowedCredentials = self["allowCredentials"]?.arrayValue else {
+      return []
+    }
+
+    return allowedCredentials.compactMap { credential in
+      guard
+        let id = credential["id"]?.stringValue,
+        !id.isEmpty
+      else {
+        return nil
+      }
+
+      return id.dataFromBase64URL()
+    }
   }
 }

--- a/Sources/ClerkKit/Utils/JSON+WebAuthn.swift
+++ b/Sources/ClerkKit/Utils/JSON+WebAuthn.swift
@@ -1,0 +1,12 @@
+//
+//  JSON+WebAuthn.swift
+//
+
+extension JSON {
+  var webAuthnAssertionRelyingPartyIdentifier: String? {
+    guard let identifier = self["rpId"]?.stringValue, !identifier.isEmpty else {
+      return nil
+    }
+    return identifier
+  }
+}

--- a/Tests/Domains/Auth/Passkey/PasskeyHelperTests.swift
+++ b/Tests/Domains/Auth/Passkey/PasskeyHelperTests.swift
@@ -1,0 +1,24 @@
+#if canImport(AuthenticationServices) && !os(watchOS)
+
+@testable import ClerkKit
+import Foundation
+import Testing
+
+@MainActor
+struct PasskeyHelperTests {
+  @Test
+  func credentialAssertionRequestSetsAllowedCredentials() {
+    let allowedCredentialID = Data([1, 2, 3, 4])
+
+    let request = PasskeyHelper().credentialAssertionRequest(
+      challenge: Data([5, 6, 7, 8]),
+      relyingPartyIdentifier: "example.com",
+      allowedCredentialIDs: [allowedCredentialID]
+    )
+
+    #expect(request.allowedCredentials.count == 1)
+    #expect(request.allowedCredentials.first?.credentialID == allowedCredentialID)
+  }
+}
+
+#endif

--- a/Tests/Domains/Auth/Passkey/PasskeyTests.swift
+++ b/Tests/Domains/Auth/Passkey/PasskeyTests.swift
@@ -68,4 +68,25 @@ struct PasskeyTests {
 
     #expect(captured.value == passkey.id)
   }
+
+  @Test
+  func relyingPartyIdentifierReadsRegistrationNonce() throws {
+    let passkey = passkey(withNonce: #"{"rp":{"id":"example.com"},"challenge":"Y2hhbGxlbmdl"}"#)
+
+    #expect(passkey.relyingPartyIdentifier == "example.com")
+  }
+
+  private func passkey(withNonce nonce: String) -> Passkey {
+    Passkey(
+      id: "passkey_test",
+      name: "Test passkey",
+      verification: Verification(
+        status: .unverified,
+        strategy: .passkey,
+        nonce: nonce
+      ),
+      createdAt: Date(timeIntervalSinceReferenceDate: 1_234_567_890),
+      updatedAt: Date(timeIntervalSinceReferenceDate: 1_234_567_890)
+    )
+  }
 }

--- a/Tests/Domains/Auth/Passkey/PasskeyTests.swift
+++ b/Tests/Domains/Auth/Passkey/PasskeyTests.swift
@@ -70,7 +70,7 @@ struct PasskeyTests {
   }
 
   @Test
-  func relyingPartyIdentifierReadsRegistrationNonce() throws {
+  func relyingPartyIdentifierReadsRegistrationNonce() {
     let passkey = passkey(withNonce: #"{"rp":{"id":"example.com"},"challenge":"Y2hhbGxlbmdl"}"#)
 
     #expect(passkey.relyingPartyIdentifier == "example.com")

--- a/Tests/Utils/JSONWebAuthnTests.swift
+++ b/Tests/Utils/JSONWebAuthnTests.swift
@@ -1,0 +1,52 @@
+@testable import ClerkKit
+import Foundation
+import Testing
+
+struct JSONWebAuthnTests {
+  @Test
+  func assertionRelyingPartyIdentifierReadsNonce() throws {
+    let nonce = try JSON([
+      "rpId": "example.com",
+    ])
+
+    #expect(nonce.webAuthnAssertionRelyingPartyIdentifier == "example.com")
+  }
+
+  @Test
+  func assertionAllowedCredentialIDsDecodeBase64URLIDs() throws {
+    let nonce = try JSON([
+      "allowCredentials": [
+        [
+          "type": "public-key",
+          "id": "AQIDBA",
+          "transports": ["internal", "hybrid"],
+        ],
+        [
+          "type": "public-key",
+          "id": "aGVsbG8",
+        ],
+      ],
+    ])
+
+    #expect(nonce.webAuthnAssertionAllowedCredentialIDs == [
+      Data([1, 2, 3, 4]),
+      Data("hello".utf8),
+    ])
+  }
+
+  @Test
+  func assertionAllowedCredentialIDsIgnoreInvalidEntries() throws {
+    let nonce = try JSON([
+      "allowCredentials": [
+        ["type": "public-key"],
+        ["type": "public-key", "id": ""],
+        ["type": "public-key", "id": "!!!"],
+        ["type": "public-key", "id": "AQID"],
+      ],
+    ])
+
+    #expect(nonce.webAuthnAssertionAllowedCredentialIDs == [
+      Data([1, 2, 3]),
+    ])
+  }
+}


### PR DESCRIPTION
## Summary
- Read the registration RP identifier from the passkey nonce and pass the assertion RP ID through sign-in and verification flows.
- Update `PasskeyHelper` to prefer a provided RP identifier and fall back to the Clerk frontend host when needed.
- Add unit coverage for the registration nonce parsing path.

## Context
Passkeys are scoped to the WebAuthn relying party ID, and Apple's `ASAuthorizationPlatformPublicKeyCredentialProvider` needs to be initialized with that same RP ID to find or create matching credentials. The iOS SDK was deriving the provider identifier from `Clerk.shared.frontendApiUrl`, which works only when the Clerk frontend host is also the WebAuthn RP ID.

For web-to-mobile passkey interoperability, the backend can return WebAuthn options for a different RP ID: registration uses `rp.id`, while assertion uses `rpId`. In those cases, using the frontend host causes iOS to look in the wrong credential scope, so passkeys created on web are not available on mobile and mobile-created passkeys may not line up with web.

This change makes iOS use the RP ID from the WebAuthn nonce when it is present, while preserving the existing frontend-host fallback for older or unexpected nonce shapes.

## Testing
- `make test` passed locally.
