### PR TITLE
Add framework device token sync API

### DIFF
--- a/Sources/ClerkKit/Core/Clerk+DeviceToken.swift
+++ b/Sources/ClerkKit/Core/Clerk+DeviceToken.swift
@@ -42,14 +42,15 @@ extension Clerk {
   @_spi(FrameworkIntegration)
   @discardableResult
   public func updateDeviceToken(_ token: String) async throws -> Client? {
-    guard !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+    let normalizedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !normalizedToken.isEmpty else {
       throw DeviceTokenError.emptyToken
     }
 
     let previousToken = deviceToken
-    try storeDeviceToken(token)
+    try storeDeviceToken(normalizedToken)
 
-    if previousToken != token {
+    if previousToken != normalizedToken {
       clearCachedClientStateAfterDeviceTokenChange()
     }
 

--- a/Sources/ClerkKit/Core/Clerk+DeviceToken.swift
+++ b/Sources/ClerkKit/Core/Clerk+DeviceToken.swift
@@ -1,0 +1,58 @@
+//
+//  Clerk+DeviceToken.swift
+//  Clerk
+//
+
+import Foundation
+
+extension Clerk {
+  @_spi(FrameworkIntegration) public enum DeviceTokenError: Error, LocalizedError {
+    case emptyToken
+
+    public var errorDescription: String? {
+      switch self {
+      case .emptyToken:
+        "Device token must not be empty."
+      }
+    }
+  }
+
+  /// The currently stored Clerk device token, if one is available.
+  @_spi(FrameworkIntegration)
+  public var deviceToken: String? {
+    do {
+      return try dependencies.keychain.string(forKey: ClerkKeychainKey.clerkDeviceToken.rawValue)
+    } catch {
+      ClerkLogger.logError(error, message: "Failed to read device token from keychain")
+      return nil
+    }
+  }
+
+  /// Updates the stored Clerk device token and refreshes native auth state.
+  ///
+  /// This is intended for framework integrations that need to hand a client token
+  /// from another Clerk SDK runtime to ClerkKit. The refresh intentionally omits
+  /// the current client id so a stale anonymous client cannot conflict with the
+  /// newly supplied device token.
+  ///
+  /// - Parameter token: The Clerk device token to store in ClerkKit's keychain.
+  ///   Empty or whitespace-only values are rejected.
+  /// - Returns: The refreshed client resolved from the stored device token, or
+  ///   `nil` when no client is available.
+  @_spi(FrameworkIntegration)
+  @discardableResult
+  public func updateDeviceToken(_ token: String) async throws -> Client? {
+    guard !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      throw DeviceTokenError.emptyToken
+    }
+
+    let previousToken = deviceToken
+    try storeDeviceToken(token)
+
+    if previousToken != token {
+      clearCachedClientStateAfterDeviceTokenChange()
+    }
+
+    return try await refreshClient(skipClientId: true)
+  }
+}

--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -453,8 +453,19 @@ extension Clerk {
   /// Refreshes the current client from the API.
   @discardableResult
   public func refreshClient() async throws -> Client? {
+    try await refreshClient(skipClientId: false)
+  }
+
+  /// Refreshes the current client from the API.
+  ///
+  /// - Parameter skipClientId: When `true`, omits the currently cached client id
+  ///   from the request while still sending the stored device token. This is used
+  ///   after replacing the device token so a stale client id from the previous
+  ///   native client cannot conflict with the newly stored token.
+  @discardableResult
+  func refreshClient(skipClientId: Bool) async throws -> Client? {
     let runtime = runtimeScope
-    let response = try await dependencies.clientService.getResponse()
+    let response = try await dependencies.clientService.getResponse(skipClientId: skipClientId)
     try runtime.validateStableRuntime()
     applyResponseClient(
       response.client,
@@ -696,6 +707,24 @@ extension Clerk {
     client = incoming
   }
 
+  func clearCachedClientStateAfterDeviceTokenChange() {
+    lastAppliedClientResponseSequence = nil
+    lastClientServerFetchDate = nil
+    client = nil
+
+    for key in [
+      ClerkKeychainKey.cachedClient,
+      .cachedClientServerDate,
+      .cachedEnvironment,
+    ] {
+      do {
+        try dependencies.keychain.deleteItem(forKey: key.rawValue)
+      } catch {
+        ClerkLogger.logError(error, message: "Failed to clear cached Clerk data after device token update")
+      }
+    }
+  }
+
   private func responseIsNewerThanCurrent(_ incoming: Client?, serverDate: Date?) -> Bool {
     guard let serverDate, let lastClientServerFetchDate else {
       return false
@@ -772,13 +801,9 @@ extension Clerk {
     }
   }
 
-  func storeReceivedDeviceToken(_ token: String) {
-    do {
-      try dependencies.keychain.set(token, forKey: ClerkKeychainKey.clerkDeviceToken.rawValue)
-      watchConnectivityCoordinator?.sync()
-    } catch {
-      ClerkLogger.logError(error, message: "Failed to save device token to keychain")
-    }
+  func storeDeviceToken(_ token: String) throws {
+    try dependencies.keychain.set(token, forKey: ClerkKeychainKey.clerkDeviceToken.rawValue)
+    watchConnectivityCoordinator?.sync()
   }
 
   /// Cleans up managers that were started during configuration.

--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -127,6 +127,10 @@ public final class Clerk {
   /// single clock (the server) and advances on every API response.
   private(set) var lastClientServerFetchDate: Date?
 
+  /// Changes when local device-token ownership changes.
+  /// Client responses prepared before this value changes must not update state.
+  private(set) var clientResponseGeneration: ClientResponseGeneration = .initial
+
   /// Shared refresh task used to coalesce invalid-auth recovery refreshes.
   private var invalidAuthRefreshTask: Task<Void, Never>?
 
@@ -465,12 +469,14 @@ extension Clerk {
   @discardableResult
   func refreshClient(skipClientId: Bool) async throws -> Client? {
     let runtime = runtimeScope
+    let clientResponseGeneration = clientResponseGeneration
     let response = try await dependencies.clientService.getResponse(skipClientId: skipClientId)
     try runtime.validateStableRuntime()
     applyResponseClient(
       response.client,
       responseSequence: response.requestSequence,
-      serverDate: response.serverDate
+      serverDate: response.serverDate,
+      clientResponseGeneration: clientResponseGeneration
     )
     return client
   }
@@ -686,7 +692,19 @@ extension Clerk {
     return task
   }
 
-  func applyResponseClient(_ incoming: Client?, responseSequence: Int? = nil, serverDate: Date? = nil) {
+  func applyResponseClient(
+    _ incoming: Client?,
+    responseSequence: Int? = nil,
+    serverDate: Date? = nil,
+    clientResponseGeneration: ClientResponseGeneration? = nil
+  ) {
+    if let clientResponseGeneration, clientResponseGeneration != self.clientResponseGeneration {
+      ClerkLogger.debug(
+        "Ignoring client response from stale device token generation. Current generation: \(self.clientResponseGeneration), incoming generation: \(clientResponseGeneration)"
+      )
+      return
+    }
+
     if let responseSequence {
       if let lastAppliedClientResponseSequence,
          responseSequence <= lastAppliedClientResponseSequence,
@@ -708,6 +726,7 @@ extension Clerk {
   }
 
   func clearCachedClientStateAfterDeviceTokenChange() {
+    clientResponseGeneration = clientResponseGeneration.next()
     lastAppliedClientResponseSequence = nil
     lastClientServerFetchDate = nil
     client = nil

--- a/Sources/ClerkKit/Core/ClerkRuntimeScope.swift
+++ b/Sources/ClerkKit/Core/ClerkRuntimeScope.swift
@@ -68,6 +68,16 @@ struct ClerkConfigurationEpoch: Equatable {
   }
 }
 
+struct ClientResponseGeneration: Equatable {
+  static let initial = ClientResponseGeneration(rawValue: 0)
+
+  private let rawValue: Int
+
+  func next() -> ClientResponseGeneration {
+    ClientResponseGeneration(rawValue: rawValue + 1)
+  }
+}
+
 final class ClerkRuntimeState: @unchecked Sendable {
   private let lock = NSLock()
   private var epoch: ClerkConfigurationEpoch

--- a/Sources/ClerkKit/Domains/Client/ClientService.swift
+++ b/Sources/ClerkKit/Domains/Client/ClientService.swift
@@ -12,7 +12,18 @@ package struct ClientServiceResponse {
 }
 
 protocol ClientServiceProtocol: Sendable {
-  @MainActor func getResponse() async throws -> ClientServiceResponse
+  /// Fetches the client response.
+  ///
+  /// - Parameter skipClientId: When `true`, the request omits the current
+  ///   `x-clerk-client-id` header. Use this when the stored device token may
+  ///   have changed before the in-memory client has been refreshed.
+  @MainActor func getResponse(skipClientId: Bool) async throws -> ClientServiceResponse
+}
+
+extension ClientServiceProtocol {
+  @MainActor func getResponse() async throws -> ClientServiceResponse {
+    try await getResponse(skipClientId: false)
+  }
 }
 
 final class ClientService: ClientServiceProtocol {
@@ -29,9 +40,17 @@ final class ClientService: ClientServiceProtocol {
   }
 
   /// Fetches the client payload plus request ordering metadata.
+  ///
+  /// - Parameter skipClientId: When `true`, requests the header middleware to
+  ///   skip `x-clerk-client-id` for this request. The middleware still sends the
+  ///   stored device token, allowing the backend to resolve the client from that
+  ///   token without also receiving a possibly stale client id.
   @MainActor
-  func getResponse() async throws -> ClientServiceResponse {
-    let request = Request<ClientResponse<Client?>>(path: "/v1/client")
+  func getResponse(skipClientId: Bool = false) async throws -> ClientServiceResponse {
+    let request = Request<ClientResponse<Client?>>(
+      path: "/v1/client",
+      headers: skipClientId ? [ClerkHeaderRequestMiddleware.skipClientIdHeader: "1"] : [:]
+    )
     let response = try await apiClient.send(request)
     return ClientServiceResponse(
       client: response.value.response,

--- a/Sources/ClerkKit/Mocks/MockServices/MockClientService.swift
+++ b/Sources/ClerkKit/Mocks/MockServices/MockClientService.swift
@@ -34,7 +34,7 @@ package final class MockClientService: ClientServiceProtocol {
   }
 
   @MainActor
-  package func getResponse() async throws -> ClientServiceResponse {
+  package func getResponse(skipClientId _: Bool = false) async throws -> ClientServiceResponse {
     if let handler = getHandler {
       return try await ClientServiceResponse(
         client: handler(),

--- a/Sources/ClerkKit/Networking/Middleware/ClerkClientSyncResponseMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkClientSyncResponseMiddleware.swift
@@ -18,12 +18,22 @@ struct ClerkClientSyncResponseMiddleware: ClerkResponseMiddleware {
 
     if let client = Self.decodeClient(from: data) {
       try await runtimeScope.withCurrentClerk {
-        $0.applyResponseClient(client, responseSequence: responseSequence, serverDate: serverDate)
+        $0.applyResponseClient(
+          client,
+          responseSequence: responseSequence,
+          serverDate: serverDate,
+          clientResponseGeneration: request.clerkClientResponseGeneration
+        )
       }
     } else if hasExplicitNullClientField(in: data) {
       ClerkLogger.debug("API response explicitly returned client: null. Clearing local client state.")
       try await runtimeScope.withCurrentClerk {
-        $0.applyResponseClient(nil, responseSequence: responseSequence, serverDate: serverDate)
+        $0.applyResponseClient(
+          nil,
+          responseSequence: responseSequence,
+          serverDate: serverDate,
+          clientResponseGeneration: request.clerkClientResponseGeneration
+        )
       }
     }
   }

--- a/Sources/ClerkKit/Networking/Middleware/ClerkDeviceTokenResponseMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkDeviceTokenResponseMiddleware.swift
@@ -12,9 +12,18 @@ struct ClerkDeviceTokenResponseMiddleware: ClerkResponseMiddleware {
     self.runtimeScope = runtimeScope
   }
 
-  func validate(_ response: HTTPURLResponse, data _: Data, for _: URLRequest) async throws {
+  func validate(_ response: HTTPURLResponse, data _: Data, for request: URLRequest) async throws {
     if let deviceToken = response.value(forHTTPHeaderField: "Authorization") {
       try await runtimeScope.withCurrentClerk {
+        if let requestGeneration = request.clerkClientResponseGeneration,
+           requestGeneration != $0.clientResponseGeneration
+        {
+          ClerkLogger.debug(
+            "Ignoring device token response from stale device token generation. Current generation: \($0.clientResponseGeneration), incoming generation: \(requestGeneration)"
+          )
+          return
+        }
+
         do {
           try $0.storeDeviceToken(deviceToken)
         } catch {

--- a/Sources/ClerkKit/Networking/Middleware/ClerkDeviceTokenResponseMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkDeviceTokenResponseMiddleware.swift
@@ -15,7 +15,11 @@ struct ClerkDeviceTokenResponseMiddleware: ClerkResponseMiddleware {
   func validate(_ response: HTTPURLResponse, data _: Data, for _: URLRequest) async throws {
     if let deviceToken = response.value(forHTTPHeaderField: "Authorization") {
       try await runtimeScope.withCurrentClerk {
-        $0.storeReceivedDeviceToken(deviceToken)
+        do {
+          try $0.storeDeviceToken(deviceToken)
+        } catch {
+          ClerkLogger.logError(error, message: "Failed to save device token to keychain")
+        }
       }
     }
   }

--- a/Sources/ClerkKit/Networking/Middleware/ClerkHeaderRequestMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkHeaderRequestMiddleware.swift
@@ -17,6 +17,7 @@ struct ClerkHeaderRequestMiddleware: ClerkRequestMiddleware {
   @MainActor
   func prepare(_ request: inout URLRequest) async throws {
     let clerk = try runtimeScope.requireCurrentClerk()
+    request.setClerkClientResponseGeneration(clerk.clientResponseGeneration)
     let skipClientId = request.value(forHTTPHeaderField: Self.skipClientIdHeader) == "1"
     request.setValue(nil, forHTTPHeaderField: Self.skipClientIdHeader)
 

--- a/Sources/ClerkKit/Networking/Middleware/ClerkHeaderRequestMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkHeaderRequestMiddleware.swift
@@ -6,6 +6,8 @@
 import Foundation
 
 struct ClerkHeaderRequestMiddleware: ClerkRequestMiddleware {
+  static let skipClientIdHeader = "X-Clerk-SDK-Skip-Client-Id"
+
   private let runtimeScope: ClerkRuntimeScope
 
   init(runtimeScope: ClerkRuntimeScope) {
@@ -15,12 +17,14 @@ struct ClerkHeaderRequestMiddleware: ClerkRequestMiddleware {
   @MainActor
   func prepare(_ request: inout URLRequest) async throws {
     let clerk = try runtimeScope.requireCurrentClerk()
+    let skipClientId = request.value(forHTTPHeaderField: Self.skipClientIdHeader) == "1"
+    request.setValue(nil, forHTTPHeaderField: Self.skipClientIdHeader)
 
     if let deviceToken = try? clerk.dependencies.keychain.string(forKey: ClerkKeychainKey.clerkDeviceToken.rawValue) {
       request.setValue(deviceToken, forHTTPHeaderField: "Authorization")
     }
 
-    if let clientId = clerk.client?.id {
+    if !skipClientId, let clientId = clerk.client?.id {
       request.setValue(clientId, forHTTPHeaderField: "x-clerk-client-id")
     }
 

--- a/Sources/ClerkKit/Networking/Middleware/NetworkMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/NetworkMiddleware.swift
@@ -127,9 +127,14 @@ extension HTTPURLResponse {
 
 extension URLRequest {
   private static let clerkRequestSequenceKey = "com.clerk.request-sequence"
+  private static let clerkClientResponseGenerationKey = "com.clerk.client-response-generation"
 
   var clerkRequestSequence: Int? {
     URLProtocol.property(forKey: Self.clerkRequestSequenceKey, in: self) as? Int
+  }
+
+  var clerkClientResponseGeneration: ClientResponseGeneration? {
+    URLProtocol.property(forKey: Self.clerkClientResponseGenerationKey, in: self) as? ClientResponseGeneration
   }
 
   mutating func setClerkRequestSequence(_ sequence: Int) {
@@ -138,6 +143,16 @@ extension URLRequest {
       return
     }
     URLProtocol.setProperty(sequence, forKey: Self.clerkRequestSequenceKey, in: mutableRequest)
+    self = mutableRequest as URLRequest
+  }
+
+  mutating func setClerkClientResponseGeneration(_ generation: ClientResponseGeneration) {
+    guard let mutableRequest = (self as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+      assertionFailure("Failed to create mutable URLRequest copy.")
+      return
+    }
+
+    URLProtocol.setProperty(generation, forKey: Self.clerkClientResponseGenerationKey, in: mutableRequest)
     self = mutableRequest as URLRequest
   }
 }

--- a/Tests/Domains/Client/ClientTests.swift
+++ b/Tests/Domains/Client/ClientTests.swift
@@ -138,7 +138,7 @@ struct ClientTests {
     )
     Clerk.shared.client = Client.mock
 
-    let client = try await Clerk.shared.updateDeviceToken("new-token")
+    let client = try await Clerk.shared.updateDeviceToken(" new-token\n")
 
     #expect(client?.id == expectedClient.id)
     #expect(Clerk.shared.client?.id == expectedClient.id)

--- a/Tests/Domains/Client/ClientTests.swift
+++ b/Tests/Domains/Client/ClientTests.swift
@@ -1,4 +1,4 @@
-@testable import ClerkKit
+@_spi(FrameworkIntegration) @testable import ClerkKit
 import ConcurrencyExtras
 import Foundation
 import Testing
@@ -109,6 +109,54 @@ struct ClientTests {
     #expect(Clerk.shared.client?.id == current.id)
     #expect(Clerk.shared.client?.lastActiveSessionId == "session-current")
   }
+
+  @Test
+  func updateDeviceTokenStoresTokenAndRefreshesWithoutClientId() async throws {
+    configureClerkForTesting()
+    Clerk.shared.cleanupManagers()
+
+    let keychain = InMemoryKeychain()
+    try keychain.set("old-token", forKey: ClerkKeychainKey.clerkDeviceToken.rawValue)
+    try keychain.set(#require("cached-client".data(using: .utf8)), forKey: ClerkKeychainKey.cachedClient.rawValue)
+    try keychain.set("cached-date", forKey: ClerkKeychainKey.cachedClientServerDate.rawValue)
+    try keychain.set(#require("cached-environment".data(using: .utf8)), forKey: ClerkKeychainKey.cachedEnvironment.rawValue)
+
+    let expectedClient = Client(
+      id: "updated-token-client",
+      sessions: [],
+      lastActiveSessionId: nil,
+      updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+    let service = DeviceTokenUpdateClientService(
+      response: ClientServiceResponse(client: expectedClient, requestSequence: 1, serverDate: Date(timeIntervalSince1970: 2000))
+    )
+
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      keychain: keychain,
+      clientService: service
+    )
+    Clerk.shared.client = Client.mock
+
+    let client = try await Clerk.shared.updateDeviceToken("new-token")
+
+    #expect(client?.id == expectedClient.id)
+    #expect(Clerk.shared.client?.id == expectedClient.id)
+    #expect(Clerk.shared.deviceToken == "new-token")
+    #expect(service.skipClientIdValues == [true])
+    #expect(try keychain.hasItem(forKey: ClerkKeychainKey.cachedClient.rawValue) == false)
+    #expect(try keychain.hasItem(forKey: ClerkKeychainKey.cachedClientServerDate.rawValue) == false)
+    #expect(try keychain.hasItem(forKey: ClerkKeychainKey.cachedEnvironment.rawValue) == false)
+  }
+
+  @Test
+  func updateDeviceTokenRejectsBlankToken() async throws {
+    configureClerkForTesting()
+
+    await #expect(throws: Clerk.DeviceTokenError.emptyToken) {
+      try await Clerk.shared.updateDeviceToken("   ")
+    }
+  }
 }
 
 private final class SequencedClientService: ClientServiceProtocol {
@@ -119,7 +167,26 @@ private final class SequencedClientService: ClientServiceProtocol {
   }
 
   @MainActor
-  func getResponse() async throws -> ClientServiceResponse {
+  func getResponse(skipClientId _: Bool = false) async throws -> ClientServiceResponse {
     response
+  }
+}
+
+private final class DeviceTokenUpdateClientService: ClientServiceProtocol {
+  private let response: ClientServiceResponse
+  private let skipClientIdValuesStore = LockIsolated([Bool]())
+
+  var skipClientIdValues: [Bool] {
+    skipClientIdValuesStore.value
+  }
+
+  init(response: ClientServiceResponse) {
+    self.response = response
+  }
+
+  @MainActor
+  func getResponse(skipClientId: Bool) async throws -> ClientServiceResponse {
+    skipClientIdValuesStore.withValue { $0.append(skipClientId) }
+    return response
   }
 }

--- a/Tests/Domains/Client/ClientTests.swift
+++ b/Tests/Domains/Client/ClientTests.swift
@@ -150,6 +150,32 @@ struct ClientTests {
   }
 
   @Test
+  func refreshClientIgnoresResponseWhenDeviceTokenGenerationChangesDuringRequest() async throws {
+    configureClerkForTesting()
+    Clerk.shared.cleanupManagers()
+
+    let staleClient = Client(
+      id: "stale-client",
+      sessions: [],
+      lastActiveSessionId: nil,
+      updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+    let service = DeviceTokenChangingClientService(
+      response: ClientServiceResponse(client: staleClient, requestSequence: 1, serverDate: Date(timeIntervalSince1970: 2000))
+    )
+
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      clientService: service
+    )
+
+    let client = try await Clerk.shared.refreshClient()
+
+    #expect(client == nil)
+    #expect(Clerk.shared.client == nil)
+  }
+
+  @Test
   func updateDeviceTokenRejectsBlankToken() async throws {
     configureClerkForTesting()
 
@@ -187,6 +213,20 @@ private final class DeviceTokenUpdateClientService: ClientServiceProtocol {
   @MainActor
   func getResponse(skipClientId: Bool) async throws -> ClientServiceResponse {
     skipClientIdValuesStore.withValue { $0.append(skipClientId) }
+    return response
+  }
+}
+
+private final class DeviceTokenChangingClientService: ClientServiceProtocol {
+  private let response: ClientServiceResponse
+
+  init(response: ClientServiceResponse) {
+    self.response = response
+  }
+
+  @MainActor
+  func getResponse(skipClientId _: Bool) async throws -> ClientServiceResponse {
+    Clerk.shared.clearCachedClientStateAfterDeviceTokenChange()
     return response
   }
 }

--- a/Tests/Middleware/ClerkClientSyncResponseMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkClientSyncResponseMiddlewareTests.swift
@@ -92,6 +92,30 @@ struct ClerkClientSyncResponseMiddlewareTests {
   }
 
   @Test
+  func validateIgnoresClientResponseFromStaleDeviceTokenGeneration() async throws {
+    configureClerkForTesting()
+    let clerk = Clerk()
+    let middleware = ClerkClientSyncResponseMiddleware(runtimeScope: .current(clerkProvider: { clerk }))
+    let staleClient = client(id: "stale-client", updatedAt: .distantFuture)
+    let data = try JSONEncoder.clerkEncoder.encode(ClientOnlyEnvelope(response: staleClient, client: nil))
+    let url = try #require(URL(string: "https://example.com/v1/client"))
+    let response = try #require(HTTPURLResponse(
+      url: url,
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: nil
+    ))
+    var request = URLRequest(url: url)
+    request.setClerkClientResponseGeneration(clerk.clientResponseGeneration)
+
+    clerk.clearCachedClientStateAfterDeviceTokenChange()
+
+    try await middleware.validate(response, data: data, for: request)
+
+    #expect(clerk.client == nil)
+  }
+
+  @Test
   func validateAppliesClientFromErrorMetaClientEnvelope() async throws {
     configureClerkForTesting()
     let clerk = Clerk()

--- a/Tests/Middleware/ClerkDeviceTokenResponseMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkDeviceTokenResponseMiddlewareTests.swift
@@ -1,0 +1,62 @@
+@testable import ClerkKit
+import Foundation
+import Testing
+
+@MainActor
+@Suite(.serialized)
+struct ClerkDeviceTokenResponseMiddlewareTests {
+  @Test
+  func validateStoresDeviceTokenHeader() async throws {
+    configureClerkForTesting()
+    let keychain = InMemoryKeychain()
+    let clerk = Clerk()
+    clerk.dependencies = MockDependencyContainer(
+      apiClient: clerk.dependencies.apiClient,
+      keychain: keychain,
+      telemetryCollector: clerk.dependencies.telemetryCollector
+    )
+    let middleware = ClerkDeviceTokenResponseMiddleware(runtimeScope: .current(clerkProvider: { clerk }))
+    let url = try #require(URL(string: "https://example.com/v1/client"))
+    let response = try #require(HTTPURLResponse(
+      url: url,
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: ["Authorization": "new-token"]
+    ))
+    var request = URLRequest(url: url)
+    request.setClerkClientResponseGeneration(clerk.clientResponseGeneration)
+
+    try await middleware.validate(response, data: Data(), for: request)
+
+    #expect(try keychain.string(forKey: ClerkKeychainKey.clerkDeviceToken.rawValue) == "new-token")
+  }
+
+  @Test
+  func validateIgnoresDeviceTokenHeaderFromStaleDeviceTokenGeneration() async throws {
+    configureClerkForTesting()
+    let keychain = InMemoryKeychain()
+    try keychain.set("current-token", forKey: ClerkKeychainKey.clerkDeviceToken.rawValue)
+    let clerk = Clerk()
+    clerk.dependencies = MockDependencyContainer(
+      apiClient: clerk.dependencies.apiClient,
+      keychain: keychain,
+      telemetryCollector: clerk.dependencies.telemetryCollector
+    )
+    let middleware = ClerkDeviceTokenResponseMiddleware(runtimeScope: .current(clerkProvider: { clerk }))
+    let url = try #require(URL(string: "https://example.com/v1/client"))
+    let response = try #require(HTTPURLResponse(
+      url: url,
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: ["Authorization": "stale-token"]
+    ))
+    var request = URLRequest(url: url)
+    request.setClerkClientResponseGeneration(clerk.clientResponseGeneration)
+
+    clerk.clearCachedClientStateAfterDeviceTokenChange()
+
+    try await middleware.validate(response, data: Data(), for: request)
+
+    #expect(try keychain.string(forKey: ClerkKeychainKey.clerkDeviceToken.rawValue) == "current-token")
+  }
+}

--- a/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
@@ -71,6 +71,16 @@ struct ClerkHeaderRequestMiddlewareTests {
   }
 
   @Test
+  func tagsRequestWithCurrentClientResponseGeneration() async throws {
+    let middleware = ClerkHeaderRequestMiddleware(runtimeScope: Clerk.shared.runtimeScope)
+    var request = try URLRequest(url: #require(URL(string: "https://example.com")))
+
+    try await middleware.prepare(&request)
+
+    #expect(request.clerkClientResponseGeneration == Clerk.shared.clientResponseGeneration)
+  }
+
+  @Test
   func omitsClientIdHeaderWhenSkipClientIdHeaderIsPresent() async throws {
     Clerk.shared.client = .mock
 

--- a/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
@@ -71,6 +71,20 @@ struct ClerkHeaderRequestMiddlewareTests {
   }
 
   @Test
+  func omitsClientIdHeaderWhenSkipClientIdHeaderIsPresent() async throws {
+    Clerk.shared.client = .mock
+
+    let middleware = ClerkHeaderRequestMiddleware(runtimeScope: Clerk.shared.runtimeScope)
+    var request = try URLRequest(url: #require(URL(string: "https://example.com")))
+    request.setValue("1", forHTTPHeaderField: ClerkHeaderRequestMiddleware.skipClientIdHeader)
+
+    try await middleware.prepare(&request)
+
+    #expect(request.value(forHTTPHeaderField: "x-clerk-client-id") == nil)
+    #expect(request.value(forHTTPHeaderField: ClerkHeaderRequestMiddleware.skipClientIdHeader) == nil)
+  }
+
+  @Test
   func doesNotAddClientIdHeaderWhenClientMissing() async throws {
     // Ensure no client is set
     Clerk.shared.client = nil


### PR DESCRIPTION
## Summary

Adds a ClerkKit SPI for framework integrations that need to hand an existing Clerk device token into the native SDK and reconcile native client state.

This is needed by `@clerk/expo` on iOS. Expo can have two Clerk runtimes in the same app: the JS SDK and the native ClerkKit SDK used by native UI. If the user signs in through JS first, JS owns the signed-in client token while ClerkKit may still have an older cached native client, often an anonymous client. The Expo bridge needs a supported way to pass that token to ClerkKit without writing ClerkKit keychain internals directly.

Paired Expo PR: https://github.com/clerk/javascript/pull/8851

## What changed

- Adds `@_spi(FrameworkIntegration)` APIs on `Clerk`:
  - `deviceToken`
  - `updateDeviceToken(_:)`
  - `DeviceTokenError.emptyToken`
- `updateDeviceToken(_:)` stores the supplied token, clears cached client/environment state when the token changes, and refreshes the client.
- The refresh after a token replacement omits `x-clerk-client-id` for that one request so a stale cached client id cannot conflict with the newly stored device token.
- Keeps normal device-token response handling behavior: response middleware still logs keychain write failures without failing the response.
- Adds focused tests for token update, cache clearing, blank token rejection, and omitting the client id header.

## Notes

The API is intentionally SPI rather than public API. Device tokens are SDK integration credentials, not the token app developers should use for backend authentication. Keeping this behind `FrameworkIntegration` gives wrapper SDKs a supported integration point without making device-token handling part of the general ClerkKit public surface.

## Testing

```sh
swift test --filter ClientTests --filter ClerkHeaderRequestMiddlewareTests
```

Passed: 24 tests in 3 suites.
