### PR TITLE
Retry phone code sign-up preparation before entering verification code

### DIFF
--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -1542,11 +1542,29 @@ extension E2EHostE2ETests {
     let timeoutError = authStartRequestTimedOutError(in: app)
     guard timeoutError.exists else { return }
 
-    let closeButton = app.buttons["Close"].firstMatch
-    if closeButton.waitForExistence(timeout: 5), closeButton.isHittable {
+    let deadline = Date().addingTimeInterval(5)
+    repeat {
+      if let closeButton = hittableButton(labeled: "Close", in: app) {
+        closeButton.tap()
+        _ = timeoutError.waitForNonExistence(timeout: 5)
+        return
+      }
+
+      RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+    } while Date() < deadline
+
+    if let closeButton = hittableButton(labeled: "Close", in: app) {
       closeButton.tap()
       _ = timeoutError.waitForNonExistence(timeout: 5)
     }
+  }
+
+  private func hittableButton(labeled label: String, in app: XCUIApplication) -> XCUIElement? {
+    app.buttons.matching(
+      NSPredicate(format: "label == %@", label)
+    )
+    .allElementsBoundByIndex
+    .first { $0.exists && $0.isEnabled && $0.isHittable }
   }
 
   private func enterText(

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -1153,7 +1153,7 @@ extension E2EHostE2ETests {
   private func completePhoneCodeSignUp(phoneNumber: String, email: String, in app: XCUIApplication) {
     switchToPhoneNumberIdentifier(in: app)
     enterPhoneNumber(phoneNumber, in: app)
-    preparePhoneCodeSignUp(in: app)
+    preparePhoneCodeSignUp(phoneNumber: phoneNumber, in: app)
     enterVerificationCode(verificationCode, into: E2EIdentifier.signUpCode, in: app)
     completeMissingEmailAddressIfNeeded(email: email, in: app)
     completePasswordCollectionIfNeeded(in: app)
@@ -1398,6 +1398,7 @@ extension E2EHostE2ETests {
   }
 
   private func preparePhoneCodeSignUp(
+    phoneNumber: String,
     in app: XCUIApplication,
     file: StaticString = #filePath,
     line: UInt = #line
@@ -1419,6 +1420,10 @@ extension E2EHostE2ETests {
         return
       case .requestTimedOut where attempt < maxAttempts,
            .timedOut where attempt < maxAttempts:
+        dismissAuthIfPresent(in: app)
+        openAuth(in: app, file: file, line: line)
+        switchToPhoneNumberIdentifier(in: app, file: file, line: line)
+        enterPhoneNumber(phoneNumber, in: app, file: file, line: line)
         continue
       case .requestTimedOut, .timedOut:
         XCTFail(

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -1410,9 +1410,8 @@ extension E2EHostE2ETests {
       tap(E2EIdentifier.authStartContinue, in: app, file: file, line: line)
       waitForAuthStartRequestTimedOutErrorToClear(in: app)
 
-      let result = waitForCodePreparationResult(
+      let result = waitForCodeSentResult(
         in: app,
-        codeInputIdentifier: E2EIdentifier.signUpCode,
         timeout: 90
       )
       switch result {
@@ -1466,6 +1465,39 @@ extension E2EHostE2ETests {
     if codeInput.exists {
       return .prepared
     }
+
+    if resendCooldown.exists {
+      return .prepared
+    }
+
+    if timeoutError.exists {
+      return .requestTimedOut
+    }
+
+    return .timedOut
+  }
+
+  private func waitForCodeSentResult(
+    in app: XCUIApplication,
+    timeout: TimeInterval
+  ) -> CodePreparationResult {
+    let resendCooldown = app.buttons.matching(
+      NSPredicate(format: "label CONTAINS %@", "Resend (")
+    ).firstMatch
+    let timeoutError = authStartRequestTimedOutError(in: app)
+    let deadline = Date().addingTimeInterval(timeout)
+
+    repeat {
+      if resendCooldown.exists {
+        return .prepared
+      }
+
+      if timeoutError.exists {
+        return .requestTimedOut
+      }
+
+      RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+    } while Date() < deadline
 
     if resendCooldown.exists {
       return .prepared

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -1153,8 +1153,7 @@ extension E2EHostE2ETests {
   private func completePhoneCodeSignUp(phoneNumber: String, email: String, in app: XCUIApplication) {
     switchToPhoneNumberIdentifier(in: app)
     enterPhoneNumber(phoneNumber, in: app)
-    tap(E2EIdentifier.authStartContinue, in: app)
-    waitForSignUpCodePrepared(in: app)
+    preparePhoneCodeSignUp(in: app)
     enterVerificationCode(verificationCode, into: E2EIdentifier.signUpCode, in: app)
     completeMissingEmailAddressIfNeeded(email: email, in: app)
     completePasswordCollectionIfNeeded(in: app)
@@ -1386,6 +1385,40 @@ extension E2EHostE2ETests {
       case .prepared:
         return
       case .requestTimedOut where attempt < maxAttempts:
+        continue
+      case .requestTimedOut, .timedOut:
+        XCTFail(
+          codePreparationFailureMessage(message, result: result),
+          file: file,
+          line: line
+        )
+        return
+      }
+    }
+  }
+
+  private func preparePhoneCodeSignUp(
+    in app: XCUIApplication,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    let maxAttempts = 2
+    let message = "Expected sign-up code preparation to finish before entering the verification code."
+
+    for attempt in 1 ... maxAttempts {
+      tap(E2EIdentifier.authStartContinue, in: app, file: file, line: line)
+      waitForAuthStartRequestTimedOutErrorToClear(in: app)
+
+      let result = waitForCodePreparationResult(
+        in: app,
+        codeInputIdentifier: E2EIdentifier.signUpCode,
+        timeout: 45
+      )
+      switch result {
+      case .prepared:
+        return
+      case .requestTimedOut where attempt < maxAttempts,
+           .timedOut where attempt < maxAttempts:
         continue
       case .requestTimedOut, .timedOut:
         XCTFail(

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -1413,13 +1413,12 @@ extension E2EHostE2ETests {
       let result = waitForCodePreparationResult(
         in: app,
         codeInputIdentifier: E2EIdentifier.signUpCode,
-        timeout: 45
+        timeout: 90
       )
       switch result {
       case .prepared:
         return
-      case .requestTimedOut where attempt < maxAttempts,
-           .timedOut where attempt < maxAttempts:
+      case .requestTimedOut where attempt < maxAttempts:
         dismissAuthIfPresent(in: app)
         openAuth(in: app, file: file, line: line)
         switchToPhoneNumberIdentifier(in: app, file: file, line: line)

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -1418,6 +1418,7 @@ extension E2EHostE2ETests {
       case .prepared:
         return
       case .requestTimedOut where attempt < maxAttempts:
+        dismissRequestTimedOutErrorIfPresent(in: app)
         dismissAuthIfPresent(in: app)
         openAuth(in: app, file: file, line: line)
         switchToPhoneNumberIdentifier(in: app, file: file, line: line)
@@ -1535,6 +1536,17 @@ extension E2EHostE2ETests {
     guard timeoutError.exists else { return }
 
     _ = timeoutError.waitForNonExistence(timeout: 5)
+  }
+
+  private func dismissRequestTimedOutErrorIfPresent(in app: XCUIApplication) {
+    let timeoutError = authStartRequestTimedOutError(in: app)
+    guard timeoutError.exists else { return }
+
+    let closeButton = app.buttons["Close"].firstMatch
+    if closeButton.waitForExistence(timeout: 5), closeButton.isHittable {
+      closeButton.tap()
+      _ = timeoutError.waitForNonExistence(timeout: 5)
+    }
   }
 
   private func enterText(


### PR DESCRIPTION
## Summary
- Replace the direct phone sign-up continue flow with a preparation helper that waits for the code request to settle before typing the verification code.
- Retry once when the initial code-preparation request times out or leaves the app in a transient timeout state.
- Surface a clearer failure when code preparation never completes within the expected window.

## Testing
- Not run (not requested)