### PR TITLE
Improve iOS E2E reliability and CI diagnostics

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,8 @@ name: Checks
 
 on:
   push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -14,6 +16,3 @@ jobs:
       checks: write
       contents: read
     uses: ./.github/workflows/shared-checks.yml
-    with:
-      run_integration_tests: true
-    secrets: inherit

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,8 +2,6 @@ name: Checks
 
 on:
   push:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,3 +16,6 @@ jobs:
       checks: write
       contents: read
     uses: ./.github/workflows/shared-checks.yml
+    with:
+      run_integration_tests: true
+    secrets: inherit

--- a/.github/workflows/shared-checks.yml
+++ b/.github/workflows/shared-checks.yml
@@ -92,11 +92,8 @@ jobs:
             check_run_names+=(
               "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (auth-email)"
               "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (auth-phone)"
-              "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (auth-username-cleanup)"
-              "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (user-profile-password-change)"
-              "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (user-profile-security)"
-              "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (session-tasks)"
-              "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (account-reset)"
+              "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (user-profile)"
+              "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (session-task-cleanup)"
             )
           fi
 
@@ -354,133 +351,6 @@ jobs:
           rm -f .keys.json
           echo "✅ Cleaned up .keys.json"
 
-  test-e2e-extended:
-    name: Run extended E2EHost tests on iOS (${{ matrix.shard }})
-    needs: format-and-lint
-    if: inputs.run_integration_tests
-    continue-on-error: true
-    runs-on: macos-26
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - shard: auth-alternates
-            only_testing: >-
-              E2EHostE2ETests/E2EHostE2ETests/testMultiMethodsEmailSignUpThenEmailCodeSignInViaUseAnotherMethod()
-              E2EHostE2ETests/E2EHostE2ETests/testMultiMethodsPhoneSignUpThenPhoneCodeSignInViaUseAnotherMethod()
-              E2EHostE2ETests/E2EHostE2ETests/testUsernamePasswordSignUpThenUsernamePasswordSignInWithRequiredUserModelFields()
-              E2EHostE2ETests/E2EHostE2ETests/testEmailCodeSignUpCompletesRequiredLegalConsent()
-          - shard: user-profile-security-extended
-            only_testing: >-
-              E2EHostE2ETests/E2EHostE2ETests/testUserProfileSecurityChangesPassword()
-              E2EHostE2ETests/E2EHostE2ETests/testUserProfileSecurityAddsTwoStepVerificationWithAuthenticatorApp()
-              E2EHostE2ETests/E2EHostE2ETests/testUserProfileSecurityAddsTwoStepVerificationWithSmsCode()
-          - shard: session-tasks-extended
-            only_testing: >-
-              E2EHostE2ETests/E2EHostE2ETests/testSessionTaskSetupMfaSignUpCompletesSmsCodeSetup()
-              E2EHostE2ETests/E2EHostE2ETests/testSessionTaskChooseOrganizationSignUpAcceptsInvitationAndSelectsOrganization()
-              E2EHostE2ETests/E2EHostE2ETests/testSessionTaskChooseOrganizationSignUpCreatesOrganization()
-              E2EHostE2ETests/E2EHostE2ETests/testSessionTaskResetPasswordSignInCompletesPasswordReset()
-          - shard: account-switching
-            only_testing: >-
-              E2EHostE2ETests/E2EHostE2ETests/testUserProfileAddsAccountThenSwitchesAccounts()
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        with:
-          persist-credentials: false
-
-      - name: Verify macOS and Xcode version
-        run: |
-          sw_vers
-          xcodebuild -version
-
-      - name: Cache Swift dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
-        with:
-          path: .build
-          key: swiftpm-e2e-extended-${{ hashFiles('Package.resolved') }}
-          restore-keys: swiftpm-e2e-extended-
-
-      - name: Setup E2E test keys
-        env:
-          CLERK_TEST_KEYS_JSON: ${{ secrets.CLERK_TEST_KEYS_JSON }}
-        run: |
-          set +x
-          if [ -z "$CLERK_TEST_KEYS_JSON" ]; then
-            echo "❌ Error: CLERK_TEST_KEYS_JSON secret is not set"
-            echo "   Please configure CLERK_TEST_KEYS_JSON secret in repository settings"
-            exit 1
-          fi
-
-          printf '%s\n' "$CLERK_TEST_KEYS_JSON" > .keys.json
-          chmod 600 .keys.json
-          echo "✅ Created .keys.json from CLERK_TEST_KEYS_JSON secret"
-
-      - name: Validate extended E2E test instances
-        env:
-          CLERK_E2E_KEY_NAME: ${{ inputs.e2e_key_name }}
-        run: |
-          set -euo pipefail
-
-          ./scripts/validate-e2e-test-instances.sh \
-            "auth-email-code-password" \
-            "auth-legal-consent" \
-            "auth-multi-methods" \
-            "auth-username-password-user-model" \
-            "session-task-choose-organization" \
-            "session-task-reset-password" \
-            "session-task-setup-mfa" \
-            "$CLERK_E2E_KEY_NAME"
-
-      - name: Run extended E2EHost tests
-        env:
-          CLERK_E2E_KEY_NAME: ${{ inputs.e2e_key_name }}
-          E2E_ONLY_TESTING: ${{ matrix.only_testing }}
-          E2E_RESULT_BUNDLE_PATH: build/reports/E2EHost-extended-${{ matrix.shard }}.xcresult
-          E2E_XCODEBUILD_ATTEMPTS: "2"
-        run: |
-          set -euo pipefail
-          make test-e2e
-
-      - name: Summarize extended E2EHost timings
-        if: always()
-        env:
-          E2E_RESULT_BUNDLE_PATH: build/reports/E2EHost-extended-${{ matrix.shard }}.xcresult
-        run: |
-          set -euo pipefail
-
-          if [ ! -d "$E2E_RESULT_BUNDLE_PATH" ]; then
-            echo "No extended E2EHost result bundle found at $E2E_RESULT_BUNDLE_PATH."
-            exit 0
-          fi
-
-          {
-            echo "### Extended E2EHost timings (${{ matrix.shard }})"
-            echo
-            echo "| Test | Result | Duration |"
-            echo "| --- | --- | ---: |"
-            xcrun xcresulttool get test-results tests --path "$E2E_RESULT_BUNDLE_PATH" --format json \
-              | jq -r '.. | objects | select(.nodeType? == "Test Case") | "| `\(.name)` | \(.result // "") | \(((.durationInSeconds // 0) * 10 | round / 10))s |"'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload extended E2EHost result bundle
-        if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: E2EHost-extended-${{ matrix.shard }}-artifacts
-          path: |
-            build/reports/E2EHost-extended-${{ matrix.shard }}.xcresult
-            build/reports/E2EHost-extended-${{ matrix.shard }}*.log
-          if-no-files-found: ignore
-
-      - name: Cleanup E2E test keys
-        if: always()
-        run: |
-          rm -f .keys.json
-          echo "✅ Cleaned up .keys.json"
-
   build:
     name: Build ${{ matrix.platform }}
     needs: [test, test-ui]
@@ -615,9 +485,6 @@ jobs:
           if [ "$RUN_INTEGRATION_TESTS" = "true" ]; then
             update_check_run "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (auth-email)" "$(job_result "Run E2EHost tests on iOS (auth-email)")"
             update_check_run "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (auth-phone)" "$(job_result "Run E2EHost tests on iOS (auth-phone)")"
-            update_check_run "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (auth-username-cleanup)" "$(job_result "Run E2EHost tests on iOS (auth-username-cleanup)")"
-            update_check_run "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (user-profile-password-change)" "$(job_result "Run E2EHost tests on iOS (user-profile-password-change)")"
-            update_check_run "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (user-profile-security)" "$(job_result "Run E2EHost tests on iOS (user-profile-security)")"
-            update_check_run "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (session-tasks)" "$(job_result "Run E2EHost tests on iOS (session-tasks)")"
-            update_check_run "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (account-reset)" "$(job_result "Run E2EHost tests on iOS (account-reset)")"
+            update_check_run "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (user-profile)" "$(job_result "Run E2EHost tests on iOS (user-profile)")"
+            update_check_run "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (session-task-cleanup)" "$(job_result "Run E2EHost tests on iOS (session-task-cleanup)")"
           fi

--- a/.github/workflows/shared-checks.yml
+++ b/.github/workflows/shared-checks.yml
@@ -238,12 +238,11 @@ jobs:
         run: make test-ui
 
   test-e2e:
-    name: Run E2EHost tests on iOS (${{ matrix.shard }})
+    name: Run required E2EHost smoke tests on iOS (${{ matrix.shard }})
     needs: format-and-lint
     if: inputs.run_integration_tests
     runs-on: macos-26
     timeout-minutes: 30
-    continue-on-error: ${{ matrix.continue_on_error == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -251,35 +250,16 @@ jobs:
           - shard: auth-email
             only_testing: >-
               E2EHostE2ETests/E2EHostE2ETests/testEmailCodeSignUpThenPasswordSignIn()
-              E2EHostE2ETests/E2EHostE2ETests/testMultiMethodsEmailSignUpThenEmailCodeSignInViaUseAnotherMethod()
-              E2EHostE2ETests/E2EHostE2ETests/testEmailCodeSignUpCompletesRequiredLegalConsent()
           - shard: auth-phone
             only_testing: >-
               E2EHostE2ETests/E2EHostE2ETests/testPhoneCodeSignUpThenPhoneCodeSignIn()
-              E2EHostE2ETests/E2EHostE2ETests/testMultiMethodsPhoneSignUpThenPhoneCodeSignInViaUseAnotherMethod()
-          - shard: auth-username-cleanup
+          - shard: user-profile
             only_testing: >-
-              E2EHostE2ETests/E2EHostE2ETests/testUsernamePasswordSignUpThenUsernamePasswordSignInWithRequiredUserModelFields()
-              E2EHostE2ETests/E2EHostE2ETests/testInAppCleanupDeletesPendingUser()
-          - shard: user-profile-password-change
-            continue_on_error: true
-            only_testing: >-
-              E2EHostE2ETests/E2EHostE2ETests/testUserProfileSecurityChangesPassword()
-          - shard: user-profile-security
-            only_testing: >-
-              E2EHostE2ETests/E2EHostE2ETests/testUserProfileSecurityAddsTwoStepVerificationWithAuthenticatorApp()
-              E2EHostE2ETests/E2EHostE2ETests/testUserProfileSecurityAddsTwoStepVerificationWithSmsCode()
               E2EHostE2ETests/E2EHostE2ETests/testUserProfileSecurityDeletesAccount()
-          - shard: session-tasks
+          - shard: session-task-cleanup
             only_testing: >-
               E2EHostE2ETests/E2EHostE2ETests/testSessionTaskSetupMfaSignUpCompletesAuthenticatorAppSetup()
-              E2EHostE2ETests/E2EHostE2ETests/testSessionTaskSetupMfaSignUpCompletesSmsCodeSetup()
-              E2EHostE2ETests/E2EHostE2ETests/testSessionTaskChooseOrganizationSignUpAcceptsInvitationAndSelectsOrganization()
-              E2EHostE2ETests/E2EHostE2ETests/testSessionTaskChooseOrganizationSignUpCreatesOrganization()
-          - shard: account-reset
-            only_testing: >-
-              E2EHostE2ETests/E2EHostE2ETests/testUserProfileAddsAccountThenSwitchesAccounts()
-              E2EHostE2ETests/E2EHostE2ETests/testSessionTaskResetPasswordSignInCompletesPasswordReset()
+              E2EHostE2ETests/E2EHostE2ETests/testInAppCleanupDeletesPendingUser()
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -315,50 +295,24 @@ jobs:
           chmod 600 .keys.json
           echo "✅ Created .keys.json from CLERK_TEST_KEYS_JSON secret"
 
-      - name: Validate E2E test keys
+      - name: Validate E2E test instances
         env:
           CLERK_E2E_KEY_NAME: ${{ inputs.e2e_key_name }}
         run: |
           set -euo pipefail
 
-          required_keys="$(printf '%s\n' \
+          ./scripts/validate-e2e-test-instances.sh \
             "auth-email-code-password" \
-            "auth-legal-consent" \
-            "auth-multi-methods" \
             "auth-phone-code" \
-            "auth-username-password-user-model" \
-            "session-task-choose-organization" \
-            "session-task-reset-password" \
             "session-task-setup-mfa" \
-            "$CLERK_E2E_KEY_NAME" \
-            | sort -u)"
+            "$CLERK_E2E_KEY_NAME"
 
-          missing=0
-          while IFS= read -r key_name; do
-            if ! jq -e --arg key_name "$key_name" '.[$key_name].pk | strings | select(length > 0)' .keys.json > /dev/null; then
-              echo "::error::Missing $key_name.pk in CLERK_TEST_KEYS_JSON."
-              missing=1
-            fi
-          done <<< "$required_keys"
-
-          if ! jq -e '.["session-task-reset-password"].sk | strings | select(length > 0)' .keys.json > /dev/null; then
-            echo "::error::Missing session-task-reset-password.sk in CLERK_TEST_KEYS_JSON."
-            missing=1
-          fi
-
-          if [ "$missing" -ne 0 ]; then
-            echo "Add the missing key to 1Password, then sync GitHub with:"
-            echo "  make sync-test-keys-to-github"
-            exit 1
-          fi
-
-          echo "✅ Required E2E test keys are configured"
-
-      - name: Run E2EHost tests
+      - name: Run required E2EHost smoke tests
         env:
           CLERK_E2E_KEY_NAME: ${{ inputs.e2e_key_name }}
           E2E_ONLY_TESTING: ${{ matrix.only_testing }}
           E2E_RESULT_BUNDLE_PATH: build/reports/E2EHost-${{ matrix.shard }}.xcresult
+          E2E_XCODEBUILD_ATTEMPTS: "2"
         run: |
           set -euo pipefail
           make test-e2e
@@ -376,7 +330,7 @@ jobs:
           fi
 
           {
-            echo "### E2EHost timings (${{ matrix.shard }})"
+            echo "### Required E2EHost timings (${{ matrix.shard }})"
             echo
             echo "| Test | Result | Duration |"
             echo "| --- | --- | ---: |"
@@ -388,8 +342,137 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: E2EHost-${{ matrix.shard }}.xcresult
-          path: build/reports/E2EHost-${{ matrix.shard }}.xcresult
+          name: E2EHost-${{ matrix.shard }}-artifacts
+          path: |
+            build/reports/E2EHost-${{ matrix.shard }}.xcresult
+            build/reports/E2EHost-${{ matrix.shard }}*.log
+          if-no-files-found: ignore
+
+      - name: Cleanup E2E test keys
+        if: always()
+        run: |
+          rm -f .keys.json
+          echo "✅ Cleaned up .keys.json"
+
+  test-e2e-extended:
+    name: Run extended E2EHost tests on iOS (${{ matrix.shard }})
+    needs: format-and-lint
+    if: inputs.run_integration_tests
+    continue-on-error: true
+    runs-on: macos-26
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: auth-alternates
+            only_testing: >-
+              E2EHostE2ETests/E2EHostE2ETests/testMultiMethodsEmailSignUpThenEmailCodeSignInViaUseAnotherMethod()
+              E2EHostE2ETests/E2EHostE2ETests/testMultiMethodsPhoneSignUpThenPhoneCodeSignInViaUseAnotherMethod()
+              E2EHostE2ETests/E2EHostE2ETests/testUsernamePasswordSignUpThenUsernamePasswordSignInWithRequiredUserModelFields()
+              E2EHostE2ETests/E2EHostE2ETests/testEmailCodeSignUpCompletesRequiredLegalConsent()
+          - shard: user-profile-security-extended
+            only_testing: >-
+              E2EHostE2ETests/E2EHostE2ETests/testUserProfileSecurityChangesPassword()
+              E2EHostE2ETests/E2EHostE2ETests/testUserProfileSecurityAddsTwoStepVerificationWithAuthenticatorApp()
+              E2EHostE2ETests/E2EHostE2ETests/testUserProfileSecurityAddsTwoStepVerificationWithSmsCode()
+          - shard: session-tasks-extended
+            only_testing: >-
+              E2EHostE2ETests/E2EHostE2ETests/testSessionTaskSetupMfaSignUpCompletesSmsCodeSetup()
+              E2EHostE2ETests/E2EHostE2ETests/testSessionTaskChooseOrganizationSignUpAcceptsInvitationAndSelectsOrganization()
+              E2EHostE2ETests/E2EHostE2ETests/testSessionTaskChooseOrganizationSignUpCreatesOrganization()
+              E2EHostE2ETests/E2EHostE2ETests/testSessionTaskResetPasswordSignInCompletesPasswordReset()
+          - shard: account-switching
+            only_testing: >-
+              E2EHostE2ETests/E2EHostE2ETests/testUserProfileAddsAccountThenSwitchesAccounts()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Verify macOS and Xcode version
+        run: |
+          sw_vers
+          xcodebuild -version
+
+      - name: Cache Swift dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: .build
+          key: swiftpm-e2e-extended-${{ hashFiles('Package.resolved') }}
+          restore-keys: swiftpm-e2e-extended-
+
+      - name: Setup E2E test keys
+        env:
+          CLERK_TEST_KEYS_JSON: ${{ secrets.CLERK_TEST_KEYS_JSON }}
+        run: |
+          set +x
+          if [ -z "$CLERK_TEST_KEYS_JSON" ]; then
+            echo "❌ Error: CLERK_TEST_KEYS_JSON secret is not set"
+            echo "   Please configure CLERK_TEST_KEYS_JSON secret in repository settings"
+            exit 1
+          fi
+
+          printf '%s\n' "$CLERK_TEST_KEYS_JSON" > .keys.json
+          chmod 600 .keys.json
+          echo "✅ Created .keys.json from CLERK_TEST_KEYS_JSON secret"
+
+      - name: Validate extended E2E test instances
+        env:
+          CLERK_E2E_KEY_NAME: ${{ inputs.e2e_key_name }}
+        run: |
+          set -euo pipefail
+
+          ./scripts/validate-e2e-test-instances.sh \
+            "auth-email-code-password" \
+            "auth-legal-consent" \
+            "auth-multi-methods" \
+            "auth-username-password-user-model" \
+            "session-task-choose-organization" \
+            "session-task-reset-password" \
+            "session-task-setup-mfa" \
+            "$CLERK_E2E_KEY_NAME"
+
+      - name: Run extended E2EHost tests
+        env:
+          CLERK_E2E_KEY_NAME: ${{ inputs.e2e_key_name }}
+          E2E_ONLY_TESTING: ${{ matrix.only_testing }}
+          E2E_RESULT_BUNDLE_PATH: build/reports/E2EHost-extended-${{ matrix.shard }}.xcresult
+          E2E_XCODEBUILD_ATTEMPTS: "2"
+        run: |
+          set -euo pipefail
+          make test-e2e
+
+      - name: Summarize extended E2EHost timings
+        if: always()
+        env:
+          E2E_RESULT_BUNDLE_PATH: build/reports/E2EHost-extended-${{ matrix.shard }}.xcresult
+        run: |
+          set -euo pipefail
+
+          if [ ! -d "$E2E_RESULT_BUNDLE_PATH" ]; then
+            echo "No extended E2EHost result bundle found at $E2E_RESULT_BUNDLE_PATH."
+            exit 0
+          fi
+
+          {
+            echo "### Extended E2EHost timings (${{ matrix.shard }})"
+            echo
+            echo "| Test | Result | Duration |"
+            echo "| --- | --- | ---: |"
+            xcrun xcresulttool get test-results tests --path "$E2E_RESULT_BUNDLE_PATH" --format json \
+              | jq -r '.. | objects | select(.nodeType? == "Test Case") | "| `\(.name)` | \(.result // "") | \(((.durationInSeconds // 0) * 10 | round / 10))s |"'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload extended E2EHost result bundle
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: E2EHost-extended-${{ matrix.shard }}-artifacts
+          path: |
+            build/reports/E2EHost-extended-${{ matrix.shard }}.xcresult
+            build/reports/E2EHost-extended-${{ matrix.shard }}*.log
           if-no-files-found: ignore
 
       - name: Cleanup E2E test keys

--- a/.github/workflows/shared-checks.yml
+++ b/.github/workflows/shared-checks.yml
@@ -246,7 +246,7 @@ jobs:
         include:
           - shard: auth-email
             only_testing: >-
-              E2EHostE2ETests/E2EHostE2ETests/testEmailCodeSignUpThenPasswordSignIn()
+              E2EHostE2ETests/E2EHostE2ETests/testEmailCodeSignUpDeletesAccount()
           - shard: auth-phone
             only_testing: >-
               E2EHostE2ETests/E2EHostE2ETests/testPhoneCodeSignUpThenPhoneCodeSignIn()

--- a/.github/workflows/shared-checks.yml
+++ b/.github/workflows/shared-checks.yml
@@ -90,10 +90,10 @@ jobs:
 
           if [ "$RUN_INTEGRATION_TESTS" = "true" ]; then
             check_run_names+=(
-              "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (auth-email)"
-              "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (auth-phone)"
-              "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (user-profile)"
-              "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (session-task-cleanup)"
+              "$CHECK_RUN_NAME_PREFIX / Run required E2EHost smoke tests on iOS (auth-email)"
+              "$CHECK_RUN_NAME_PREFIX / Run required E2EHost smoke tests on iOS (auth-phone)"
+              "$CHECK_RUN_NAME_PREFIX / Run required E2EHost smoke tests on iOS (user-profile)"
+              "$CHECK_RUN_NAME_PREFIX / Run required E2EHost smoke tests on iOS (session-task-cleanup)"
             )
           fi
 
@@ -483,8 +483,8 @@ jobs:
           update_check_run "$CHECK_RUN_NAME_PREFIX / Build visionOS" "$(job_result "Build visionOS")"
 
           if [ "$RUN_INTEGRATION_TESTS" = "true" ]; then
-            update_check_run "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (auth-email)" "$(job_result "Run E2EHost tests on iOS (auth-email)")"
-            update_check_run "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (auth-phone)" "$(job_result "Run E2EHost tests on iOS (auth-phone)")"
-            update_check_run "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (user-profile)" "$(job_result "Run E2EHost tests on iOS (user-profile)")"
-            update_check_run "$CHECK_RUN_NAME_PREFIX / Run E2EHost tests on iOS (session-task-cleanup)" "$(job_result "Run E2EHost tests on iOS (session-task-cleanup)")"
+            update_check_run "$CHECK_RUN_NAME_PREFIX / Run required E2EHost smoke tests on iOS (auth-email)" "$(job_result "Run required E2EHost smoke tests on iOS (auth-email)")"
+            update_check_run "$CHECK_RUN_NAME_PREFIX / Run required E2EHost smoke tests on iOS (auth-phone)" "$(job_result "Run required E2EHost smoke tests on iOS (auth-phone)")"
+            update_check_run "$CHECK_RUN_NAME_PREFIX / Run required E2EHost smoke tests on iOS (user-profile)" "$(job_result "Run required E2EHost smoke tests on iOS (user-profile)")"
+            update_check_run "$CHECK_RUN_NAME_PREFIX / Run required E2EHost smoke tests on iOS (session-task-cleanup)" "$(job_result "Run required E2EHost smoke tests on iOS (session-task-cleanup)")"
           fi

--- a/Examples/E2EHost/E2EHost/E2EHostView.swift
+++ b/Examples/E2EHost/E2EHost/E2EHostView.swift
@@ -8,12 +8,19 @@ import ClerkKitUI
 import SwiftUI
 
 struct E2EHostView: View {
+  private enum CleanupStatus: Equatable {
+    case idle
+    case inProgress
+    case complete
+    case failed(String)
+  }
+
   @Environment(Clerk.self) private var clerk
 
   let configuration: E2EConfiguration
 
   @State private var authViewIsPresented = false
-  @State private var cleanupDidComplete = false
+  @State private var cleanupStatus = CleanupStatus.idle
 
   init(configuration: E2EConfiguration) {
     self.configuration = configuration
@@ -25,6 +32,7 @@ struct E2EHostView: View {
         Button("Sign in") {
           authViewIsPresented = true
         }
+        .accessibilityIdentifier(E2EIdentifiers.Auth.signIn)
       })
 
       e2eControls
@@ -40,9 +48,18 @@ struct E2EHostView: View {
 
   @ViewBuilder
   private var e2eControls: some View {
-    if cleanupDidComplete {
+    switch cleanupStatus {
+    case .idle:
+      EmptyView()
+    case .inProgress:
+      Text("Cleanup in progress")
+        .accessibilityIdentifier(E2EIdentifiers.Auth.cleanupInProgress)
+    case .complete:
       Text("Cleanup complete")
         .accessibilityIdentifier(E2EIdentifiers.Auth.cleanupComplete)
+    case .failed(let message):
+      Text(message)
+        .accessibilityIdentifier(E2EIdentifiers.Auth.cleanupFailed)
     }
 
     if clerk.user != nil {
@@ -107,32 +124,43 @@ struct E2EHostView: View {
 
   private func deleteAccount() {
     Task { @MainActor in
-      await deleteCurrentAccountIfPresent()
+      try? await deleteCurrentAccountIfPresent()
     }
   }
 
   private func cleanupAccount() {
     Task { @MainActor in
-      guard await deleteCurrentAccountIfPresent() else { return }
-      cleanupDidComplete = true
+      cleanupStatus = .inProgress
+
+      do {
+        try await deleteCurrentAccountIfPresent()
+        cleanupStatus = .complete
+      } catch {
+        cleanupStatus = .failed(Self.cleanupFailureMessage(for: error))
+      }
     }
   }
 
-  @discardableResult
   @MainActor
-  private func deleteCurrentAccountIfPresent() async -> Bool {
+  private func deleteCurrentAccountIfPresent() async throws {
     guard let user = clerk.user else {
       authViewIsPresented = false
-      return true
+      return
     }
 
-    guard await (try? user.delete()) != nil else {
-      return false
-    }
-
+    try await user.delete()
     try? await clerk.auth.signOut()
     authViewIsPresented = false
-    return true
+  }
+
+  private static func cleanupFailureMessage(for error: Error) -> String {
+    let detail = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !detail.isEmpty else {
+      return "Cleanup failed while deleting the current account."
+    }
+
+    let truncatedDetail = detail.count > 240 ? "\(detail.prefix(240))..." : detail
+    return "Cleanup failed while deleting the current account: \(truncatedDetail)"
   }
 }
 

--- a/Examples/E2EHost/E2EHost/E2EIdentifiers.swift
+++ b/Examples/E2EHost/E2EHost/E2EIdentifiers.swift
@@ -5,6 +5,7 @@
 
 enum E2EIdentifiers {
   enum Auth {
+    static let signIn = "e2e.auth.signIn"
     static let signedIn = "e2e.auth.signedIn"
     static let signedOut = "e2e.auth.signedOut"
     static let sessionActive = "e2e.auth.sessionActive"
@@ -12,7 +13,9 @@ enum E2EIdentifiers {
     static let sessionStatus = "e2e.auth.sessionStatus"
     static let pendingTasks = "e2e.auth.pendingTasks"
     static let userID = "e2e.auth.userID"
+    static let cleanupInProgress = "e2e.auth.cleanupInProgress"
     static let cleanupComplete = "e2e.auth.cleanupComplete"
+    static let cleanupFailed = "e2e.auth.cleanupFailed"
     static let signOut = "e2e.auth.signOut"
     static let deleteAccount = "e2e.auth.deleteAccount"
   }

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -43,6 +43,7 @@ final class E2EHostE2ETests: XCTestCase {
   private let testPassword = "ClerkIOS2026E2ETestPassword9!"
 
   private var app: XCUIApplication?
+  private var testPhoneNumbers: [String] = []
 
   override func setUpWithError() throws {
     continueAfterFailure = false
@@ -155,7 +156,7 @@ final class E2EHostE2ETests: XCTestCase {
   func testUserProfileSecurityAddsTwoStepVerificationWithSmsCode() throws {
     let publishableKey = try requiredPublishableKey(named: Self.multiMethodsPublishableKeyName)
     let email = Self.makeUniqueTestEmail()
-    let phoneNumber = Self.makeUniqueTestPhoneNumber()
+    let phoneNumber = makeTrackedTestPhoneNumber()
     let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
 
     app = launchApp(
@@ -319,7 +320,7 @@ final class E2EHostE2ETests: XCTestCase {
   func testPhoneCodeSignUpThenPhoneCodeSignIn() throws {
     let publishableKey = try requiredPublishableKey(named: Self.phonePublishableKeyName)
     let email = Self.makeUniqueTestEmail()
-    let phoneNumber = Self.makeUniqueTestPhoneNumber()
+    let phoneNumber = makeTrackedTestPhoneNumber()
     let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
 
     app = launchApp(
@@ -362,7 +363,7 @@ final class E2EHostE2ETests: XCTestCase {
   func testMultiMethodsPhoneSignUpThenPhoneCodeSignInViaUseAnotherMethod() throws {
     let publishableKey = try requiredPublishableKey(named: Self.multiMethodsPublishableKeyName)
     let email = Self.makeUniqueTestEmail()
-    let phoneNumber = Self.makeUniqueTestPhoneNumber()
+    let phoneNumber = makeTrackedTestPhoneNumber()
     let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
 
     app = launchApp(
@@ -501,7 +502,7 @@ final class E2EHostE2ETests: XCTestCase {
   func testSessionTaskSetupMfaSignUpCompletesSmsCodeSetup() throws {
     let publishableKey = try requiredPublishableKey(named: Self.sessionTaskSetupMfaPublishableKeyName)
     let email = Self.makeUniqueTestEmail()
-    let phoneNumber = Self.makeUniqueTestPhoneNumber()
+    let phoneNumber = makeTrackedTestPhoneNumber()
     let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
 
     app = launchApp(
@@ -698,8 +699,11 @@ extension E2EHostE2ETests {
     static let sessionStatus = "e2e.auth.sessionStatus"
     static let pendingTasks = "e2e.auth.pendingTasks"
     static let userID = "e2e.auth.userID"
+    static let cleanupInProgress = "e2e.auth.cleanupInProgress"
     static let cleanupComplete = "e2e.auth.cleanupComplete"
+    static let cleanupFailed = "e2e.auth.cleanupFailed"
     static let signOut = "e2e.auth.signOut"
+    static let signIn = "e2e.auth.signIn"
     static let deleteAccount = "e2e.auth.deleteAccount"
     static let dismissButton = "clerk.dismissButton"
     static let userButtonProfile = "clerk.userButton.profile"
@@ -779,6 +783,16 @@ extension E2EHostE2ETests {
     case invalidSecret
   }
 
+  private static let approvedTestPhoneNumberPrefix = "5555550"
+  private static let approvedTestPhoneNumberSuffixRange = 100 ... 199
+  private static let approvedTestPhoneNumberRangeDescription = "5555550100...5555550199"
+  private static let approvedTestPhoneNumberSuffixByTestName = [
+    "testUserProfileSecurityAddsTwoStepVerificationWithSmsCode": 110,
+    "testPhoneCodeSignUpThenPhoneCodeSignIn": 120,
+    "testMultiMethodsPhoneSignUpThenPhoneCodeSignInViaUseAnotherMethod": 130,
+    "testSessionTaskSetupMfaSignUpCompletesSmsCodeSetup": 140,
+  ]
+
   fileprivate static func makeUniqueTestEmail() -> String {
     let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
     return "clerk_ios_e2e+clerk_test_\(suffix)@example.com"
@@ -791,9 +805,33 @@ extension E2EHostE2ETests {
     return "clerk_ios_e2e+clerk_test_\(suffix)@\(domain)"
   }
 
-  fileprivate static func makeUniqueTestPhoneNumber() -> String {
-    let suffix = Int.random(in: 100 ... 199)
-    return "5555550\(suffix)"
+  fileprivate static func makeUniqueTestPhoneNumber(
+    testName: String? = nil,
+    sequence: Int = 0
+  ) -> String {
+    let suffix = approvedTestPhoneNumberSuffix(for: testName, sequence: sequence)
+    let phoneNumber = "\(approvedTestPhoneNumberPrefix)\(suffix)"
+    precondition(
+      isApprovedTestPhoneNumber(phoneNumber),
+      "Generated E2E phone number must be inside \(approvedTestPhoneNumberRangeDescription)."
+    )
+    return phoneNumber
+  }
+
+  private static func approvedTestPhoneNumberSuffix(for testName: String?, sequence: Int) -> Int {
+    let baseSuffix = approvedTestPhoneNumberSuffixByTestName.first { testName?.contains($0.key) == true }?.value
+      ?? stableApprovedTestPhoneNumberSuffix(for: testName ?? "")
+    let zeroBasedOffset = baseSuffix - approvedTestPhoneNumberSuffixRange.lowerBound + sequence
+    let suffixCount = approvedTestPhoneNumberSuffixRange.count
+    return approvedTestPhoneNumberSuffixRange.lowerBound + (zeroBasedOffset % suffixCount)
+  }
+
+  private static func stableApprovedTestPhoneNumberSuffix(for value: String) -> Int {
+    var hash = 0
+    for scalar in value.unicodeScalars {
+      hash = (hash * 31 + Int(scalar.value)) % approvedTestPhoneNumberSuffixRange.count
+    }
+    return approvedTestPhoneNumberSuffixRange.lowerBound + hash
   }
 
   fileprivate static func makeUniqueTestUsername() -> String {
@@ -804,6 +842,30 @@ extension E2EHostE2ETests {
   fileprivate static func makeUniqueTestPassword() -> String {
     let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased().prefix(12)
     return "ClerkIOS2026E2ENewPassword9!\(suffix)"
+  }
+
+  private static func isApprovedTestPhoneNumber(_ phoneNumber: String) -> Bool {
+    let digits = phoneNumber.filter(\.isWholeNumber)
+    guard digits.count == 10, let value = Int(digits) else {
+      return false
+    }
+
+    let lowerBound = Int("\(approvedTestPhoneNumberPrefix)\(approvedTestPhoneNumberSuffixRange.lowerBound)")!
+    let upperBound = Int("\(approvedTestPhoneNumberPrefix)\(approvedTestPhoneNumberSuffixRange.upperBound)")!
+    return (lowerBound ... upperBound).contains(value)
+  }
+
+  private func makeTrackedTestPhoneNumber(
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) -> String {
+    let phoneNumber = Self.makeUniqueTestPhoneNumber(testName: name, sequence: testPhoneNumbers.count)
+    guard assertApprovedTestPhoneNumber(phoneNumber, file: file, line: line) else {
+      return phoneNumber
+    }
+
+    testPhoneNumbers.append(phoneNumber)
+    return phoneNumber
   }
 
   private func requiredPublishableKey(named keyName: String) throws -> String {
@@ -989,8 +1051,13 @@ extension E2EHostE2ETests {
     let maxAttempts = 4
 
     for attempt in 1 ... maxAttempts {
-      let signInButton = app.buttons["Sign in"].firstMatch
-      guard signInButton.waitForExistence(timeout: 20) else {
+      guard let signInButton = waitForHittableElement(withIdentifier: E2EIdentifier.signIn, in: app, timeout: 20) else {
+        attachAuthStartDiagnostics(
+          in: app,
+          reason: "Expected the E2EHost sign-in button.",
+          attempt: attempt,
+          maxAttempts: maxAttempts
+        )
         XCTFail("Expected the E2EHost sign-in button.", file: file, line: line)
         return
       }
@@ -1002,6 +1069,12 @@ extension E2EHostE2ETests {
       }
 
       guard attempt < maxAttempts else {
+        attachAuthStartDiagnostics(
+          in: app,
+          reason: "Expected AuthView to render an auth start input.",
+          attempt: attempt,
+          maxAttempts: maxAttempts
+        )
         XCTFail("Expected AuthView to render an auth start input.", file: file, line: line)
         return
       }
@@ -1032,13 +1105,181 @@ extension E2EHostE2ETests {
     return identifierInput.exists || phoneNumberInput.exists
   }
 
+  private func attachAuthStartDiagnostics(
+    in app: XCUIApplication,
+    reason: String,
+    attempt: Int,
+    maxAttempts: Int
+  ) {
+    let summary = authStartDiagnosticSummary(
+      in: app,
+      reason: reason,
+      attempt: attempt,
+      maxAttempts: maxAttempts
+    )
+    let summaryAttachment = XCTAttachment(string: summary)
+    summaryAttachment.name = "auth-start-diagnostics"
+    summaryAttachment.lifetime = .keepAlways
+    add(summaryAttachment)
+
+    let treeAttachment = XCTAttachment(string: app.debugDescription)
+    treeAttachment.name = "auth-start-accessibility-tree"
+    treeAttachment.lifetime = .keepAlways
+    add(treeAttachment)
+
+    let screenshotAttachment = XCTAttachment(screenshot: app.screenshot())
+    screenshotAttachment.name = "auth-start-timeout"
+    screenshotAttachment.lifetime = .keepAlways
+    add(screenshotAttachment)
+  }
+
+  private func authStartDiagnosticSummary(
+    in app: XCUIApplication,
+    reason: String,
+    attempt: Int,
+    maxAttempts: Int
+  ) -> String {
+    let launchEnvironment = app.launchEnvironment
+    let lines = [
+      "reason: \(reason)",
+      "test: \(name)",
+      "attempt: \(attempt)/\(maxAttempts)",
+      "appState: \(appStateDescription(app.state))",
+      "launchEnvironment:",
+      "  CLERK_E2E_KEY_NAME: \(launchEnvironment["CLERK_E2E_KEY_NAME"] ?? "<missing>")",
+      "  CLERK_E2E_AUTH_MODE: \(launchEnvironment["CLERK_E2E_AUTH_MODE"] ?? "<missing>")",
+      "  CLERK_E2E_KEYCHAIN_SERVICE: \(launchEnvironment["CLERK_E2E_KEYCHAIN_SERVICE"] ?? "<missing>")",
+      "  CLERK_E2E_MODE: \(launchEnvironment["CLERK_E2E_MODE"] ?? "<missing>")",
+      "  CLERK_PUBLISHABLE_KEY: \(redactedPublishableKey(launchEnvironment["CLERK_PUBLISHABLE_KEY"]))",
+      "testPhoneNumbers:",
+      testPhoneNumberDiagnosticSummary(),
+      "stateMarkers:",
+      authStartDiagnosticProbe(E2EIdentifier.signedOut, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.signedIn, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.sessionActive, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.sessionPending, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.sessionStatus, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.pendingTasks, in: app),
+      "authStartElements:",
+      authStartDiagnosticProbe(E2EIdentifier.authStartIdentifier, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.authStartPhoneNumber, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.authStartContinue, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.authStartIdentifierSwitcher, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.dismissButton, in: app),
+      "requestTimedOutError: \(authStartRequestTimedOutError(in: app).exists)",
+      "keyboardVisible: \(app.keyboards.firstMatch.exists)",
+      "visibleButtons:",
+      visibleElementSummary(app.buttons),
+      "visibleTextFields:",
+      visibleElementSummary(app.textFields),
+      "visibleSecureTextFields:",
+      visibleElementSummary(app.secureTextFields),
+      "visibleSwitches:",
+      visibleElementSummary(app.switches),
+      "visibleStaticTexts:",
+      visibleElementSummary(app.staticTexts),
+    ]
+
+    return lines.joined(separator: "\n")
+  }
+
+  private func appStateDescription(_ state: XCUIApplication.State) -> String {
+    switch state {
+    case .unknown:
+      return "unknown"
+    case .notRunning:
+      return "notRunning"
+    case .runningBackgroundSuspended:
+      return "runningBackgroundSuspended"
+    case .runningBackground:
+      return "runningBackground"
+    case .runningForeground:
+      return "runningForeground"
+    @unknown default:
+      return "unrecognized(\(state.rawValue))"
+    }
+  }
+
+  private func redactedPublishableKey(_ key: String?) -> String {
+    guard let key, !key.isEmpty else {
+      return "<missing>"
+    }
+
+    guard key.count > 12 else {
+      return "<redacted>"
+    }
+
+    return "\(key.prefix(6))...\(key.suffix(4))"
+  }
+
+  private func testPhoneNumberDiagnosticSummary() -> String {
+    guard !testPhoneNumbers.isEmpty else {
+      return "  <none>"
+    }
+
+    return testPhoneNumbers.map { "  - \($0)" }.joined(separator: "\n")
+  }
+
+  private func authStartDiagnosticProbe(_ identifier: String, in app: XCUIApplication) -> String {
+    let matches = app.descendants(matching: .any).matching(identifier: identifier).allElementsBoundByIndex
+    guard let element = matches.first, element.exists else {
+      return "  \(identifier): exists=false"
+    }
+
+    return [
+      "  \(identifier): exists=true",
+      "matches=\(matches.count)",
+      "hittable=\(element.isHittable)",
+      "enabled=\(element.isEnabled)",
+      "label=\(truncatedDiagnosticValue(element.label))",
+      "value=\(truncatedDiagnosticValue(element.value as? String))",
+    ].joined(separator: ", ")
+  }
+
+  private func visibleElementSummary(_ query: XCUIElementQuery, limit: Int = 30) -> String {
+    let summaries = query.allElementsBoundByIndex
+      .filter(\.exists)
+      .prefix(limit)
+      .map { element in
+        [
+          "identifier=\(truncatedDiagnosticValue(element.identifier))",
+          "label=\(truncatedDiagnosticValue(element.label))",
+          "value=\(truncatedDiagnosticValue(element.value as? String))",
+          "hittable=\(element.isHittable)",
+          "enabled=\(element.isEnabled)",
+        ].joined(separator: ", ")
+      }
+
+    guard !summaries.isEmpty else {
+      return "  <none>"
+    }
+
+    return summaries.map { "  - \($0)" }.joined(separator: "\n")
+  }
+
+  private func truncatedDiagnosticValue(_ value: String?, limit: Int = 120) -> String {
+    guard let value, !value.isEmpty else {
+      return "<empty>"
+    }
+
+    let sanitized = value
+      .replacingOccurrences(of: "\n", with: "\\n")
+      .replacingOccurrences(of: "\r", with: "\\r")
+
+    guard sanitized.count > limit else {
+      return sanitized
+    }
+
+    return "\(sanitized.prefix(limit))..."
+  }
+
   private func dismissAuthIfPresent(in app: XCUIApplication) {
     guard let dismissButton = waitForHittableElement(withIdentifier: E2EIdentifier.dismissButton, in: app, timeout: 5) else {
       return
     }
 
     dismissButton.tap()
-    _ = app.buttons["Sign in"].firstMatch.waitForExistence(timeout: 5)
+    _ = app.descendants(matching: .any)[E2EIdentifier.signIn].waitForExistence(timeout: 5)
   }
 
   private func relaunchSignedOutApp(
@@ -1728,6 +1969,10 @@ extension E2EHostE2ETests {
     file: StaticString = #filePath,
     line: UInt = #line
   ) {
+    guard assertApprovedTestPhoneNumber(phoneNumber, file: file, line: line) else {
+      return
+    }
+
     let element = focusedPhoneNumberInput(withIdentifier: identifier, in: app, file: file, line: line)
     let digits = phoneNumber.filter(\.isWholeNumber)
 
@@ -1750,6 +1995,21 @@ extension E2EHostE2ETests {
       file: file,
       line: line
     )
+  }
+
+  private func assertApprovedTestPhoneNumber(
+    _ phoneNumber: String,
+    file: StaticString,
+    line: UInt
+  ) -> Bool {
+    let isApproved = Self.isApprovedTestPhoneNumber(phoneNumber)
+    XCTAssertTrue(
+      isApproved,
+      "E2E phone number '\(phoneNumber)' must be inside the approved \(Self.approvedTestPhoneNumberRangeDescription) test-number range.",
+      file: file,
+      line: line
+    )
+    return isApproved
   }
 
   private func focusedPhoneNumberInput(
@@ -2303,12 +2563,71 @@ extension E2EHostE2ETests {
     file: StaticString = #filePath,
     line: UInt = #line
   ) {
-    XCTAssertTrue(
-      app.staticTexts[E2EIdentifier.cleanupComplete].waitForExistence(timeout: 45),
-      "Expected E2EHost in-app cleanup to finish.",
-      file: file,
-      line: line
-    )
+    let cleanupComplete = app.staticTexts[E2EIdentifier.cleanupComplete]
+    let cleanupFailed = app.staticTexts[E2EIdentifier.cleanupFailed]
+    let deadline = Date().addingTimeInterval(45)
+
+    repeat {
+      if cleanupComplete.exists {
+        return
+      }
+
+      if cleanupFailed.exists {
+        attachCleanupDiagnostics(in: app, reason: cleanupFailed.label)
+        XCTFail(
+          "Expected E2EHost in-app cleanup to finish, but cleanup failed: \(cleanupFailed.label)",
+          file: file,
+          line: line
+        )
+        return
+      }
+
+      RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+    } while Date() < deadline
+
+    attachCleanupDiagnostics(in: app, reason: "Timed out waiting for cleanup to finish.")
+    XCTFail("Expected E2EHost in-app cleanup to finish.", file: file, line: line)
+  }
+
+  private func attachCleanupDiagnostics(in app: XCUIApplication, reason: String) {
+    let lines = [
+      "reason: \(truncatedDiagnosticValue(reason, limit: 300))",
+      "test: \(name)",
+      "appState: \(appStateDescription(app.state))",
+      "testPhoneNumbers:",
+      testPhoneNumberDiagnosticSummary(),
+      "stateMarkers:",
+      authStartDiagnosticProbe(E2EIdentifier.signedOut, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.signedIn, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.sessionActive, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.sessionPending, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.sessionStatus, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.pendingTasks, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.userID, in: app),
+      "cleanupMarkers:",
+      authStartDiagnosticProbe(E2EIdentifier.cleanupInProgress, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.cleanupComplete, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.cleanupFailed, in: app),
+      "visibleButtons:",
+      visibleElementSummary(app.buttons),
+      "visibleStaticTexts:",
+      visibleElementSummary(app.staticTexts),
+    ]
+
+    let summaryAttachment = XCTAttachment(string: lines.joined(separator: "\n"))
+    summaryAttachment.name = "cleanup-diagnostics"
+    summaryAttachment.lifetime = .keepAlways
+    add(summaryAttachment)
+
+    let treeAttachment = XCTAttachment(string: app.debugDescription)
+    treeAttachment.name = "cleanup-accessibility-tree"
+    treeAttachment.lifetime = .keepAlways
+    add(treeAttachment)
+
+    let screenshotAttachment = XCTAttachment(screenshot: app.screenshot())
+    screenshotAttachment.name = "cleanup-failure"
+    screenshotAttachment.lifetime = .keepAlways
+    add(screenshotAttachment)
   }
 
   private func assertPendingTasksContain(

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -58,7 +58,7 @@ final class E2EHostE2ETests: XCTestCase {
     app = nil
   }
 
-  func testEmailCodeSignUpThenPasswordSignIn() throws {
+  func testEmailCodeSignUpDeletesAccount() throws {
     let publishableKey = try requiredPublishableKey(named: Self.defaultPublishableKeyName)
     let email = Self.makeUniqueTestEmail()
     let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
@@ -74,30 +74,11 @@ final class E2EHostE2ETests: XCTestCase {
     openAuth(in: signUpApp)
     completeEmailCodeSignUp(email: email, in: signUpApp)
     waitForSignedIn(in: signUpApp)
+    waitForSessionActive(in: signUpApp)
     dismissSavePasswordPromptIfPresent(in: signUpApp)
 
-    tapWhenHittableRecoveringFromSavePasswordPrompt(E2EIdentifier.signOut, in: signUpApp)
+    tapWhenHittableRecoveringFromSavePasswordPrompt(E2EIdentifier.deleteAccount, in: signUpApp)
     waitForSignedOut(in: signUpApp)
-    signUpApp.terminate()
-
-    app = launchApp(
-      authMode: "signIn",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.defaultPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signInApp = app else { return }
-
-    openAuth(in: signInApp)
-    enterAuthStartIdentifier(email, in: signInApp)
-    guard submitAuthStartAndWaitForSignInPassword(identifier: email, in: signInApp) else { return }
-    enterText(testPassword, into: E2EIdentifier.signInPassword, in: signInApp)
-    tap(E2EIdentifier.signInContinue, in: signInApp)
-    waitForSignedIn(in: signInApp)
-    dismissSavePasswordPromptIfPresent(in: signInApp)
-
-    tap(E2EIdentifier.deleteAccount, in: signInApp)
-    waitForSignedOut(in: signInApp)
   }
 
   func testUserProfileSecurityDeletesAccount() throws {
@@ -303,12 +284,6 @@ extension E2EHostE2ETests {
   private enum CodePreparationResult: Equatable {
     case prepared
     case identifierTaken(String)
-    case requestTimedOut
-    case timedOut
-  }
-
-  private enum SignInPasswordPreparationResult: Equatable {
-    case prepared
     case requestTimedOut
     case timedOut
   }
@@ -939,18 +914,6 @@ extension E2EHostE2ETests {
     completePasswordCollectionIfNeeded(in: app)
   }
 
-  private func completePasswordSignIn(
-    email: String,
-    in app: XCUIApplication,
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) {
-    enterAuthStartIdentifier(email, in: app, file: file, line: line)
-    guard submitAuthStartAndWaitForSignInPassword(identifier: email, in: app, file: file, line: line) else { return }
-    enterText(testPassword, into: E2EIdentifier.signInPassword, in: app, file: file, line: line)
-    tap(E2EIdentifier.signInContinue, in: app, file: file, line: line)
-  }
-
   private func completePhoneCodeSignUp(phoneNumber: String, email: String, in app: XCUIApplication) {
     switchToPhoneNumberIdentifier(in: app)
     enterPhoneNumber(phoneNumber, in: app)
@@ -1270,158 +1233,6 @@ extension E2EHostE2ETests {
         return
       }
     }
-  }
-
-  private func submitAuthStartAndWaitForSignInPassword(
-    identifier: String,
-    in app: XCUIApplication,
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) -> Bool {
-    let maxAttempts = 2
-    let message = "Expected sign-in password preparation to finish before entering the password."
-
-    for attempt in 1 ... maxAttempts {
-      if attempt > 1 {
-        dismissRequestTimedOutErrorIfPresent(in: app)
-        dismissAuthIfPresent(in: app)
-        openAuth(in: app, file: file, line: line)
-        enterAuthStartIdentifier(identifier, in: app, file: file, line: line)
-      }
-
-      tap(E2EIdentifier.authStartContinue, in: app, file: file, line: line)
-      waitForAuthStartRequestTimedOutErrorToClear(in: app)
-
-      let result = waitForSignInPasswordPreparationResult(
-        in: app,
-        timeout: Self.authStartSubmissionTimeout
-      )
-      switch result {
-      case .prepared:
-        return true
-      case .requestTimedOut where attempt < maxAttempts,
-           .timedOut where attempt < maxAttempts:
-        dismissRequestTimedOutErrorIfPresent(in: app)
-        continue
-      case .requestTimedOut, .timedOut:
-        let failureMessage = signInPasswordPreparationFailureMessage(message, result: result)
-        attachSignInPasswordPreparationDiagnostics(
-          in: app,
-          reason: failureMessage,
-          attempt: attempt,
-          maxAttempts: maxAttempts
-        )
-        XCTFail(failureMessage, file: file, line: line)
-        return false
-      }
-    }
-
-    return false
-  }
-
-  private func waitForSignInPasswordPreparationResult(
-    in app: XCUIApplication,
-    timeout: TimeInterval
-  ) -> SignInPasswordPreparationResult {
-    let passwordInput = app.descendants(matching: .any)[E2EIdentifier.signInPassword]
-    let timeoutError = authStartRequestTimedOutError(in: app)
-    let deadline = Date().addingTimeInterval(timeout)
-
-    repeat {
-      if passwordInput.exists {
-        return .prepared
-      }
-
-      if timeoutError.exists {
-        return .requestTimedOut
-      }
-
-      dismissVisibleSavePasswordPromptAndRecoverIfNeeded(in: app)
-      RunLoop.current.run(until: Date().addingTimeInterval(0.25))
-    } while Date() < deadline
-
-    if passwordInput.exists {
-      return .prepared
-    }
-
-    if timeoutError.exists {
-      return .requestTimedOut
-    }
-
-    return .timedOut
-  }
-
-  private func signInPasswordPreparationFailureMessage(
-    _ message: String,
-    result: SignInPasswordPreparationResult
-  ) -> String {
-    switch result {
-    case .prepared:
-      message
-    case .requestTimedOut:
-      "\(message) Auth start showed '\(E2EIdentifier.requestTimedOutErrorMessage)' after retrying."
-    case .timedOut:
-      message
-    }
-  }
-
-  private func attachSignInPasswordPreparationDiagnostics(
-    in app: XCUIApplication,
-    reason: String,
-    attempt: Int,
-    maxAttempts: Int
-  ) {
-    let launchEnvironment = app.launchEnvironment
-    let lines = [
-      "reason: \(truncatedDiagnosticValue(reason, limit: 300))",
-      "test: \(name)",
-      "attempt: \(attempt)/\(maxAttempts)",
-      "appState: \(appStateDescription(app.state))",
-      "launchEnvironment:",
-      "  CLERK_E2E_KEY_NAME: \(launchEnvironment["CLERK_E2E_KEY_NAME"] ?? "<missing>")",
-      "  CLERK_E2E_AUTH_MODE: \(launchEnvironment["CLERK_E2E_AUTH_MODE"] ?? "<missing>")",
-      "  CLERK_E2E_KEYCHAIN_SERVICE: \(launchEnvironment["CLERK_E2E_KEYCHAIN_SERVICE"] ?? "<missing>")",
-      "  CLERK_E2E_MODE: \(launchEnvironment["CLERK_E2E_MODE"] ?? "<missing>")",
-      "  CLERK_PUBLISHABLE_KEY: \(redactedPublishableKey(launchEnvironment["CLERK_PUBLISHABLE_KEY"]))",
-      "stateMarkers:",
-      authStartDiagnosticProbe(E2EIdentifier.signedOut, in: app),
-      authStartDiagnosticProbe(E2EIdentifier.signedIn, in: app),
-      authStartDiagnosticProbe(E2EIdentifier.sessionActive, in: app),
-      authStartDiagnosticProbe(E2EIdentifier.sessionPending, in: app),
-      authStartDiagnosticProbe(E2EIdentifier.sessionStatus, in: app),
-      "authStartElements:",
-      authStartDiagnosticProbe(E2EIdentifier.authStartIdentifier, in: app),
-      authStartDiagnosticProbe(E2EIdentifier.authStartContinue, in: app),
-      "signInElements:",
-      authStartDiagnosticProbe(E2EIdentifier.signInPassword, in: app),
-      authStartDiagnosticProbe(E2EIdentifier.signInContinue, in: app),
-      authStartDiagnosticProbe(E2EIdentifier.signInUseAnotherMethod, in: app),
-      "requestTimedOutError: \(authStartRequestTimedOutError(in: app).exists)",
-      "keyboardVisible: \(app.keyboards.firstMatch.exists)",
-      "visibleButtons:",
-      visibleElementSummary(app.buttons),
-      "visibleTextFields:",
-      visibleElementSummary(app.textFields),
-      "visibleSecureTextFields:",
-      visibleElementSummary(app.secureTextFields),
-      "visibleStaticTexts:",
-      visibleElementSummary(app.staticTexts),
-    ]
-
-    let summaryAttachment = XCTAttachment(string: lines.joined(separator: "\n"))
-    summaryAttachment.name = "sign-in-password-diagnostics"
-    summaryAttachment.lifetime = .keepAlways
-    add(summaryAttachment)
-
-    let treeAttachment = XCTAttachment(string: app.debugDescription)
-    treeAttachment.name = "sign-in-password-accessibility-tree"
-    treeAttachment.lifetime = .keepAlways
-    add(treeAttachment)
-
-    let screenshotAttachment = XCTAttachment(screenshot: app.screenshot())
-    screenshotAttachment.name = "sign-in-password-failure"
-    screenshotAttachment.lifetime = .keepAlways
-    add(screenshotAttachment)
   }
 
   private func waitForCodePreparationResult(

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -30,14 +30,8 @@ private enum E2ECleanupCommand {
 
 final class E2EHostE2ETests: XCTestCase {
   private static let defaultPublishableKeyName = "auth-email-code-password"
-  private static let multiMethodsPublishableKeyName = "auth-multi-methods"
   private static let phonePublishableKeyName = "auth-phone-code"
-  private static let usernameUserModelPublishableKeyName = "auth-username-password-user-model"
-  private static let legalConsentPublishableKeyName = "auth-legal-consent"
   private static let sessionTaskSetupMfaPublishableKeyName = "session-task-setup-mfa"
-  private static let sessionTaskChooseOrganizationPublishableKeyName = "session-task-choose-organization"
-  private static let sessionTaskResetPasswordPublishableKeyName = "session-task-reset-password"
-  private static let defaultChooseOrganizationEmailDomain = "clerk.dev"
   private static let authStartSubmissionTimeout: TimeInterval = 75
   private static let passwordChangeCompletionTimeout: TimeInterval = 75
 
@@ -106,86 +100,6 @@ final class E2EHostE2ETests: XCTestCase {
     waitForSignedOut(in: signInApp)
   }
 
-  func testUserProfileSecurityChangesPassword() throws {
-    let publishableKey = try requiredPublishableKey(named: Self.defaultPublishableKeyName)
-    let email = Self.makeUniqueTestEmail()
-    let newPassword = Self.makeUniqueTestPassword()
-    let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
-
-    app = launchApp(
-      authMode: "signUp",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.defaultPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signUpApp = app else { return }
-
-    openAuth(in: signUpApp)
-    completeEmailCodeSignUp(email: email, in: signUpApp)
-    waitForSignedIn(in: signUpApp)
-    waitForSessionActive(in: signUpApp)
-    dismissSavePasswordPromptIfPresent(in: signUpApp)
-
-    openUserProfileSecurity(in: signUpApp)
-    completeUserProfilePasswordChange(newPassword: newPassword, in: signUpApp)
-    cleanupAccountIfNeeded(in: signUpApp)
-  }
-
-  func testUserProfileSecurityAddsTwoStepVerificationWithAuthenticatorApp() throws {
-    let publishableKey = try requiredPublishableKey(named: Self.multiMethodsPublishableKeyName)
-    let email = Self.makeUniqueTestEmail()
-    let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
-
-    app = launchApp(
-      authMode: "signUp",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.multiMethodsPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signUpApp = app else { return }
-
-    openAuth(in: signUpApp)
-    completeEmailCodeSignUp(email: email, in: signUpApp)
-    waitForSignedIn(in: signUpApp)
-    waitForSessionActive(in: signUpApp)
-    dismissSavePasswordPromptIfPresent(in: signUpApp)
-
-    openUserProfileSecurity(in: signUpApp)
-    try completeUserProfileAuthenticatorAppMfaSetup(in: signUpApp)
-    cleanupAccountIfNeeded(in: signUpApp)
-  }
-
-  func testUserProfileSecurityAddsTwoStepVerificationWithSmsCode() throws {
-    let publishableKey = try requiredPublishableKey(named: Self.multiMethodsPublishableKeyName)
-    let email = Self.makeUniqueTestEmail()
-    let phoneNumber = makeTrackedTestPhoneNumber()
-    let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
-
-    try deleteExistingUsersMatchingPhoneNumber(
-      phoneNumber,
-      publishableKey: publishableKey,
-      keyName: Self.multiMethodsPublishableKeyName
-    )
-
-    app = launchApp(
-      authMode: "signUp",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.multiMethodsPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signUpApp = app else { return }
-
-    openAuth(in: signUpApp)
-    completeEmailCodeSignUp(email: email, in: signUpApp)
-    waitForSignedIn(in: signUpApp)
-    waitForSessionActive(in: signUpApp)
-    dismissSavePasswordPromptIfPresent(in: signUpApp)
-
-    openUserProfileSecurity(in: signUpApp)
-    completeUserProfileSmsCodeMfaSetup(phoneNumber: phoneNumber, in: signUpApp)
-    cleanupAccountIfNeeded(in: signUpApp)
-  }
-
   func testUserProfileSecurityDeletesAccount() throws {
     let publishableKey = try requiredPublishableKey(named: Self.defaultPublishableKeyName)
     let email = Self.makeUniqueTestEmail()
@@ -208,119 +122,6 @@ final class E2EHostE2ETests: XCTestCase {
     openUserProfileSecurity(in: signUpApp)
     deleteAccountFromUserProfileSecurity(in: signUpApp)
     waitForSignedOut(in: signUpApp)
-  }
-
-  func testUserProfileAddsAccountThenSwitchesAccounts() throws {
-    let publishableKey = try requiredPublishableKey(named: Self.multiMethodsPublishableKeyName)
-    let firstEmail = Self.makeUniqueTestEmail()
-    let secondEmail = Self.makeUniqueTestEmail()
-    let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
-
-    app = launchApp(
-      authMode: "signUp",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.multiMethodsPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signUpApp = app else { return }
-
-    openAuth(in: signUpApp)
-    completeEmailCodeSignUp(email: firstEmail, in: signUpApp)
-    waitForSignedIn(in: signUpApp)
-    waitForSessionActive(in: signUpApp)
-    dismissSavePasswordPromptIfPresent(in: signUpApp)
-    let firstUserID = try currentUserID(in: signUpApp)
-
-    openUserProfileRoot(in: signUpApp)
-    waitForUserProfileCurrentUser(firstUserID, in: signUpApp)
-    tapWhenHittableAfterScrolling(
-      E2EIdentifier.userProfileAddAccountRow,
-      in: signUpApp,
-      message: "Expected User Profile to show Add account. Enable Dashboard > Sessions > Multi-session handling for auth-multi-methods."
-    )
-    completeEmailCodeSignUp(email: secondEmail, in: signUpApp)
-    waitForSignedIn(in: signUpApp)
-    waitForCurrentUserIDToChange(from: firstUserID, in: signUpApp)
-    waitForSessionActive(in: signUpApp)
-    waitForAddAccountAuthFlowDismissed(in: signUpApp)
-    dismissSavePasswordPromptIfPresent(in: signUpApp, timeout: 10)
-
-    tapWhenHittableAfterScrolling(
-      E2EIdentifier.userProfileSwitchAccountRow,
-      in: signUpApp,
-      timeout: 45,
-      message: "Expected User Profile to show Switch account after adding a second session."
-    )
-    tapWhenHittable(E2EIdentifier.accountSwitcherSession(userID: firstUserID), in: signUpApp, timeout: 45)
-    XCTAssertTrue(
-      signUpApp.descendants(matching: .any)[E2EIdentifier.accountSwitcherSession(userID: firstUserID)]
-        .waitForNonExistence(timeout: 45),
-      "Expected the account switcher to dismiss after switching accounts."
-    )
-    waitForUserProfileCurrentUser(firstUserID, in: signUpApp)
-
-    tapWhenHittable(E2EIdentifier.dismissButton, in: signUpApp)
-    tapWhenHittable(E2EIdentifier.deleteAccount, in: signUpApp)
-    waitForSignedOut(in: signUpApp)
-    signUpApp.terminate()
-
-    app = launchApp(
-      authMode: "signIn",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.multiMethodsPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signInApp = app else { return }
-
-    openAuth(in: signInApp)
-    completePasswordSignIn(email: secondEmail, in: signInApp)
-    waitForSignedIn(in: signInApp)
-    waitForSessionActive(in: signInApp)
-    dismissSavePasswordPromptIfPresent(in: signInApp, timeout: 10)
-    tapWhenHittable(E2EIdentifier.deleteAccount, in: signInApp)
-    waitForSignedOut(in: signInApp)
-  }
-
-  func testMultiMethodsEmailSignUpThenEmailCodeSignInViaUseAnotherMethod() throws {
-    let publishableKey = try requiredPublishableKey(named: Self.multiMethodsPublishableKeyName)
-    let email = Self.makeUniqueTestEmail()
-    let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
-
-    app = launchApp(
-      authMode: "signUp",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.multiMethodsPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signUpApp = app else { return }
-
-    openAuth(in: signUpApp)
-    completeEmailCodeSignUp(email: email, in: signUpApp)
-    waitForSignedIn(in: signUpApp)
-    dismissSavePasswordPromptIfPresent(in: signUpApp)
-
-    tapWhenHittableRecoveringFromSavePasswordPrompt(E2EIdentifier.signOut, in: signUpApp)
-    waitForSignedOut(in: signUpApp)
-    signUpApp.terminate()
-
-    app = launchApp(
-      authMode: "signIn",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.multiMethodsPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signInApp = app else { return }
-
-    openAuth(in: signInApp)
-    submitEmailSignInAndTapUseAnotherMethod(email: email, in: signInApp)
-    tapSignInAlternativeMethod(E2EIdentifier.signInEmailCodeAlternativeMethod, in: signInApp)
-    waitForSignInCodePrepared(in: signInApp)
-    enterVerificationCode(verificationCode, into: E2EIdentifier.signInCode, in: signInApp)
-    waitForSignedIn(in: signInApp)
-    dismissSavePasswordPromptIfPresent(in: signInApp)
-
-    tap(E2EIdentifier.deleteAccount, in: signInApp)
-    waitForSignedOut(in: signInApp)
   }
 
   func testPhoneCodeSignUpThenPhoneCodeSignIn() throws {
@@ -372,123 +173,6 @@ final class E2EHostE2ETests: XCTestCase {
     waitForSignedOut(in: signInApp)
   }
 
-  func testMultiMethodsPhoneSignUpThenPhoneCodeSignInViaUseAnotherMethod() throws {
-    let publishableKey = try requiredPublishableKey(named: Self.multiMethodsPublishableKeyName)
-    let email = Self.makeUniqueTestEmail()
-    let phoneNumber = makeTrackedTestPhoneNumber()
-    let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
-
-    try deleteExistingUsersMatchingPhoneNumber(
-      phoneNumber,
-      publishableKey: publishableKey,
-      keyName: Self.multiMethodsPublishableKeyName
-    )
-
-    app = launchApp(
-      authMode: "signUp",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.multiMethodsPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signUpApp = app else { return }
-
-    openAuth(in: signUpApp)
-    completePhoneCodeSignUp(phoneNumber: phoneNumber, email: email, in: signUpApp)
-    waitForSignedIn(in: signUpApp)
-    dismissSavePasswordPromptIfPresent(in: signUpApp)
-
-    tapWhenHittableRecoveringFromSavePasswordPrompt(E2EIdentifier.signOut, in: signUpApp)
-    waitForSignedOut(in: signUpApp)
-    signUpApp.terminate()
-
-    app = launchApp(
-      authMode: "signIn",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.multiMethodsPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signInApp = app else { return }
-
-    openAuth(in: signInApp)
-    switchToPhoneNumberIdentifier(in: signInApp)
-    enterPhoneNumber(phoneNumber, in: signInApp)
-    submitPhoneSignInAndTapUseAnotherMethod(phoneNumber: phoneNumber, in: signInApp)
-    tapSignInAlternativeMethod(E2EIdentifier.signInPhoneCodeAlternativeMethod, in: signInApp)
-    waitForSignInCodePrepared(in: signInApp)
-    enterVerificationCode(verificationCode, into: E2EIdentifier.signInCode, in: signInApp)
-    waitForSignedIn(in: signInApp)
-    dismissSavePasswordPromptIfPresent(in: signInApp)
-
-    tap(E2EIdentifier.deleteAccount, in: signInApp)
-    waitForSignedOut(in: signInApp)
-  }
-
-  func testUsernamePasswordSignUpThenUsernamePasswordSignInWithRequiredUserModelFields() throws {
-    let publishableKey = try requiredPublishableKey(named: Self.usernameUserModelPublishableKeyName)
-    let username = Self.makeUniqueTestUsername()
-    let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
-
-    app = launchApp(
-      authMode: "signUp",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.usernameUserModelPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signUpApp = app else { return }
-
-    openAuth(in: signUpApp)
-    completeUsernamePasswordUserModelSignUp(username: username, in: signUpApp)
-    waitForSignedIn(in: signUpApp)
-    dismissSavePasswordPromptIfPresent(in: signUpApp)
-
-    tapWhenHittableRecoveringFromSavePasswordPrompt(E2EIdentifier.signOut, in: signUpApp)
-    waitForSignedOut(in: signUpApp)
-    signUpApp.terminate()
-
-    app = launchApp(
-      authMode: "signIn",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.usernameUserModelPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signInApp = app else { return }
-
-    openAuth(in: signInApp)
-    enterAuthStartIdentifier(username, in: signInApp)
-    guard submitAuthStartAndWaitForSignInPassword(identifier: username, in: signInApp) else { return }
-    enterText(testPassword, into: E2EIdentifier.signInPassword, in: signInApp)
-    tap(E2EIdentifier.signInContinue, in: signInApp)
-    waitForSignedIn(in: signInApp)
-    dismissSavePasswordPromptIfPresent(in: signInApp)
-
-    tap(E2EIdentifier.deleteAccount, in: signInApp)
-    waitForSignedOut(in: signInApp)
-  }
-
-  func testEmailCodeSignUpCompletesRequiredLegalConsent() throws {
-    let publishableKey = try requiredPublishableKey(named: Self.legalConsentPublishableKeyName)
-    let email = Self.makeUniqueTestEmail()
-    let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
-
-    app = launchApp(
-      authMode: "signUp",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.legalConsentPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signUpApp = app else { return }
-
-    openAuth(in: signUpApp)
-    completeEmailCodeSignUp(email: email, in: signUpApp)
-    dismissSavePasswordPromptIfPresent(in: signUpApp)
-    completeRequiredLegalConsent(in: signUpApp)
-    waitForSignedIn(in: signUpApp)
-    waitForSessionActive(in: signUpApp)
-
-    tap(E2EIdentifier.deleteAccount, in: signUpApp)
-    waitForSignedOut(in: signUpApp)
-  }
-
   func testSessionTaskSetupMfaSignUpCompletesAuthenticatorAppSetup() throws {
     let publishableKey = try requiredPublishableKey(named: Self.sessionTaskSetupMfaPublishableKeyName)
     let email = Self.makeUniqueTestEmail()
@@ -515,156 +199,6 @@ final class E2EHostE2ETests: XCTestCase {
 
     tap(E2EIdentifier.deleteAccount, in: signUpApp)
     waitForSignedOut(in: signUpApp)
-  }
-
-  func testSessionTaskSetupMfaSignUpCompletesSmsCodeSetup() throws {
-    let publishableKey = try requiredPublishableKey(named: Self.sessionTaskSetupMfaPublishableKeyName)
-    let email = Self.makeUniqueTestEmail()
-    let phoneNumber = makeTrackedTestPhoneNumber()
-    let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
-
-    try deleteExistingUsersMatchingPhoneNumber(
-      phoneNumber,
-      publishableKey: publishableKey,
-      keyName: Self.sessionTaskSetupMfaPublishableKeyName
-    )
-
-    app = launchApp(
-      authMode: "signUp",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.sessionTaskSetupMfaPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signUpApp = app else { return }
-
-    openAuth(in: signUpApp)
-    completeEmailCodeSignUp(email: email, in: signUpApp)
-    waitForSignedIn(in: signUpApp)
-    waitForSessionPending(in: signUpApp)
-    assertPendingTasksContain("setup-mfa", in: signUpApp)
-    dismissSavePasswordPromptIfPresent(in: signUpApp)
-
-    completeSmsCodeMfaSetup(phoneNumber: phoneNumber, in: signUpApp)
-    waitForSessionActive(in: signUpApp)
-    dismissAuthSheetIfNeeded(in: signUpApp)
-
-    tap(E2EIdentifier.deleteAccount, in: signUpApp)
-    waitForSignedOut(in: signUpApp)
-  }
-
-  func testSessionTaskChooseOrganizationSignUpAcceptsInvitationAndSelectsOrganization() throws {
-    let publishableKey = try requiredPublishableKey(named: Self.sessionTaskChooseOrganizationPublishableKeyName)
-    let email = Self.makeUniqueChooseOrganizationTestEmail()
-    let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
-
-    app = launchApp(
-      authMode: "signUp",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.sessionTaskChooseOrganizationPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signUpApp = app else { return }
-
-    openAuth(in: signUpApp)
-    completeEmailCodeSignUp(email: email, in: signUpApp)
-    waitForSignedIn(in: signUpApp)
-    waitForSessionPending(in: signUpApp)
-    assertPendingTasksContain("choose-organization", in: signUpApp)
-    dismissSavePasswordPromptIfPresent(in: signUpApp)
-
-    completeChooseOrganizationByAcceptingInvitation(in: signUpApp)
-    waitForSessionActive(in: signUpApp)
-
-    tap(E2EIdentifier.deleteAccount, in: signUpApp)
-    waitForSignedOut(in: signUpApp)
-  }
-
-  func testSessionTaskChooseOrganizationSignUpCreatesOrganization() throws {
-    let publishableKey = try requiredPublishableKey(named: Self.sessionTaskChooseOrganizationPublishableKeyName)
-    let email = Self.makeUniqueChooseOrganizationTestEmail()
-    let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
-
-    app = launchApp(
-      authMode: "signUp",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.sessionTaskChooseOrganizationPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signUpApp = app else { return }
-
-    openAuth(in: signUpApp)
-    completeEmailCodeSignUp(email: email, in: signUpApp)
-    waitForSignedIn(in: signUpApp)
-    waitForSessionPending(in: signUpApp)
-    assertPendingTasksContain("choose-organization", in: signUpApp)
-    dismissSavePasswordPromptIfPresent(in: signUpApp)
-
-    completeChooseOrganizationByCreatingOrganization(in: signUpApp)
-    waitForSessionActive(in: signUpApp)
-
-    tap(E2EIdentifier.deleteAccount, in: signUpApp)
-    waitForSignedOut(in: signUpApp)
-  }
-
-  func testSessionTaskResetPasswordSignInCompletesPasswordReset() throws {
-    let publishableKey = try requiredPublishableKey(named: Self.sessionTaskResetPasswordPublishableKeyName)
-    let secretKey = try requiredSecretKey(named: Self.sessionTaskResetPasswordPublishableKeyName)
-    let email = Self.makeUniqueTestEmail()
-    let newPassword = Self.makeUniqueTestPassword()
-    let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
-
-    app = launchApp(
-      authMode: "signUp",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.sessionTaskResetPasswordPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signUpApp = app else { return }
-
-    openAuth(in: signUpApp)
-    completeEmailCodeSignUp(email: email, in: signUpApp)
-    waitForSignedIn(in: signUpApp)
-    waitForSessionActive(in: signUpApp)
-    dismissSavePasswordPromptIfPresent(in: signUpApp)
-    let userID = try currentUserID(in: signUpApp)
-
-    tapWhenHittableRecoveringFromSavePasswordPrompt(E2EIdentifier.signOut, in: signUpApp)
-    waitForSignedOut(in: signUpApp)
-    signUpApp.terminate()
-
-    try setUserPasswordCompromised(userID: userID, publishableKey: publishableKey, secretKey: secretKey)
-
-    app = launchApp(
-      authMode: "signIn",
-      publishableKey: publishableKey,
-      publishableKeyName: Self.sessionTaskResetPasswordPublishableKeyName,
-      keychainService: keychainService
-    )
-    guard let signInApp = app else { return }
-
-    openAuth(in: signInApp)
-    enterAuthStartIdentifier(email, in: signInApp)
-    guard submitAuthStartAndWaitForSignInPassword(identifier: email, in: signInApp) else { return }
-    enterText(testPassword, into: E2EIdentifier.signInPassword, in: signInApp)
-    tap(E2EIdentifier.signInContinue, in: signInApp)
-    dismissSavePasswordPromptIfPresent(in: signInApp)
-    tap(E2EIdentifier.signInUseAnotherMethod, in: signInApp)
-    dismissSavePasswordPromptIfPresent(in: signInApp, timeout: 5, recoverByReactivatingApp: true)
-    tapSignInAlternativeMethod(E2EIdentifier.signInEmailCodeAlternativeMethod, in: signInApp)
-    dismissSavePasswordPromptIfPresent(in: signInApp, timeout: 3)
-    waitForSignInCodePrepared(in: signInApp)
-    enterVerificationCode(verificationCode, into: E2EIdentifier.signInCode, in: signInApp)
-    waitForSignedIn(in: signInApp)
-    waitForSessionPending(in: signInApp)
-    assertPendingTasksContain("reset-password", in: signInApp)
-    dismissSavePasswordPromptIfPresent(in: signInApp)
-
-    completeResetPasswordSessionTask(newPassword: newPassword, in: signInApp)
-    waitForSessionActive(in: signInApp)
-    dismissSavePasswordPromptIfPresent(in: signInApp)
-
-    tap(E2EIdentifier.deleteAccount, in: signInApp)
-    waitForSignedOut(in: signInApp)
   }
 
   func testInAppCleanupDeletesPendingUser() throws {
@@ -735,31 +269,15 @@ extension E2EHostE2ETests {
     static let userProfileSwitchAccountRow = "clerk.userProfile.row.switchAccount"
     static let userProfileSecurityRow = "clerk.userProfile.row.security"
     static let userProfileSecurityChangePassword = "clerk.userProfile.security.changePassword"
-    static let userProfileSecurityAddMfa = "clerk.userProfile.security.addMfa"
     static let userProfileSecurityDeleteAccount = "clerk.userProfile.security.deleteAccount"
     static let userProfileChangePasswordCurrentPassword = "clerk.userProfile.changePassword.currentPassword"
     static let userProfileChangePasswordNext = "clerk.userProfile.changePassword.next"
     static let userProfileChangePasswordNewPassword = "clerk.userProfile.changePassword.newPassword"
     static let userProfileChangePasswordConfirmPassword = "clerk.userProfile.changePassword.confirmPassword"
     static let userProfileChangePasswordSave = "clerk.userProfile.changePassword.save"
-    static let userProfileMfaSmsCode = "clerk.userProfile.mfa.smsCode"
-    static let userProfileMfaSmsPhoneNumber = "clerk.userProfile.mfa.sms.phoneNumber"
-    static let userProfileMfaSmsContinue = "clerk.userProfile.mfa.sms.continue"
-    static let userProfileMfaSmsAddPhone = "clerk.userProfile.mfa.sms.addPhone"
-    static let userProfilePhoneNumber = "clerk.userProfile.phone.phoneNumber"
-    static let userProfilePhoneContinue = "clerk.userProfile.phone.continue"
-    static let userProfileMfaAuthenticatorApp = "clerk.userProfile.mfa.authenticatorApp"
-    static let userProfileMfaTotpSecret = "clerk.userProfile.mfa.totp.secret"
-    static let userProfileMfaTotpContinue = "clerk.userProfile.mfa.totp.continue"
-    static let userProfileMfaVerificationCode = "clerk.userProfile.mfa.verificationCode"
-    static let userProfileBackupCodesDone = "clerk.userProfile.backupCodes.done"
     static let userProfileDeleteAccountConfirmation = "clerk.userProfile.deleteAccount.confirmation"
     static let userProfileDeleteAccountConfirm = "clerk.userProfile.deleteAccount.confirm"
-    static let setupMfaSmsCode = "clerk.auth.sessionTask.setupMfa.smsCode"
     static let setupMfaAuthenticatorApp = "clerk.auth.sessionTask.setupMfa.authenticatorApp"
-    static let smsPhoneNumber = "clerk.auth.sessionTask.sms.phoneNumber"
-    static let smsContinue = "clerk.auth.sessionTask.sms.continue"
-    static let smsCode = "clerk.auth.sessionTask.sms.code"
     static let totpSecret = "clerk.auth.sessionTask.totp.secret"
     static let totpContinue = "clerk.auth.sessionTask.totp.continue"
     static let totpCode = "clerk.auth.sessionTask.totp.code"
@@ -826,22 +344,12 @@ extension E2EHostE2ETests {
   private static let approvedTestPhoneNumberSuffixRange = 100 ... 199
   private static let approvedTestPhoneNumberRangeDescription = "5555550100...5555550199"
   private static let approvedTestPhoneNumberSuffixByTestName = [
-    "testUserProfileSecurityAddsTwoStepVerificationWithSmsCode": 110,
     "testPhoneCodeSignUpThenPhoneCodeSignIn": 120,
-    "testMultiMethodsPhoneSignUpThenPhoneCodeSignInViaUseAnotherMethod": 130,
-    "testSessionTaskSetupMfaSignUpCompletesSmsCodeSetup": 140,
   ]
 
   fileprivate static func makeUniqueTestEmail() -> String {
     let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
     return "clerk_ios_e2e+clerk_test_\(suffix)@example.com"
-  }
-
-  fileprivate static func makeUniqueChooseOrganizationTestEmail() -> String {
-    let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
-    let domain = normalized(ProcessInfo.processInfo.environment["CLERK_E2E_CHOOSE_ORG_EMAIL_DOMAIN"])
-      ?? defaultChooseOrganizationEmailDomain
-    return "clerk_ios_e2e+clerk_test_\(suffix)@\(domain)"
   }
 
   fileprivate static func makeUniqueTestPhoneNumber(
@@ -3091,79 +2599,6 @@ extension E2EHostE2ETests {
     add(screenshotAttachment)
   }
 
-  private func completeUserProfileAuthenticatorAppMfaSetup(
-    in app: XCUIApplication,
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) throws {
-    tap(E2EIdentifier.userProfileSecurityAddMfa, in: app, file: file, line: line)
-    tapWhenEnabled(E2EIdentifier.userProfileMfaAuthenticatorApp, in: app, timeout: 45, file: file, line: line)
-
-    let secretElement = app.descendants(matching: .any)[E2EIdentifier.userProfileMfaTotpSecret]
-    XCTAssertTrue(
-      secretElement.waitForExistence(timeout: 45),
-      "Expected the user profile TOTP setup secret.",
-      file: file,
-      line: line
-    )
-    let secret = secretElement.label
-
-    tap(E2EIdentifier.userProfileMfaTotpContinue, in: app, file: file, line: line)
-    try enterCurrentTOTPCode(
-      secret: secret,
-      into: E2EIdentifier.userProfileMfaVerificationCode,
-      in: app,
-      file: file,
-      line: line
-    )
-
-    continueUserProfileBackupCodesIfPresent(in: app)
-    XCTAssertTrue(
-      app.descendants(matching: .any)[E2EIdentifier.userProfileSecurityAddMfa].waitForExistence(timeout: 45),
-      "Expected the user profile Security screen after completing TOTP setup.",
-      file: file,
-      line: line
-    )
-  }
-
-  private func completeUserProfileSmsCodeMfaSetup(
-    phoneNumber: String,
-    in app: XCUIApplication,
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) {
-    tap(E2EIdentifier.userProfileSecurityAddMfa, in: app, file: file, line: line)
-    tapWhenEnabled(E2EIdentifier.userProfileMfaSmsCode, in: app, timeout: 45, file: file, line: line)
-    tap(E2EIdentifier.userProfileMfaSmsAddPhone, in: app, file: file, line: line)
-    enterPhoneNumber(phoneNumber, into: E2EIdentifier.userProfilePhoneNumber, in: app, file: file, line: line)
-    tap(E2EIdentifier.userProfilePhoneContinue, in: app, file: file, line: line)
-    waitForCodePrepared(
-      in: app,
-      codeInputIdentifier: E2EIdentifier.userProfileMfaVerificationCode,
-      message: "Expected user-profile phone verification code preparation to finish before entering the verification code.",
-      file: file,
-      line: line
-    )
-    enterVerificationCode(verificationCode, into: E2EIdentifier.userProfileMfaVerificationCode, in: app, file: file, line: line)
-    tapWhenEnabled(matchingIdentifierPrefix: E2EIdentifier.userProfileMfaSmsPhoneNumber, in: app, timeout: 45, file: file, line: line)
-    tapWhenEnabled(E2EIdentifier.userProfileMfaSmsContinue, in: app, timeout: 45, file: file, line: line)
-
-    continueUserProfileBackupCodesIfPresent(in: app)
-    XCTAssertTrue(
-      app.descendants(matching: .any)[E2EIdentifier.userProfileSecurityAddMfa].waitForExistence(timeout: 45),
-      "Expected the user profile Security screen after completing SMS setup.",
-      file: file,
-      line: line
-    )
-  }
-
-  private func continueUserProfileBackupCodesIfPresent(in app: XCUIApplication) {
-    let backupCodesDone = app.buttons[E2EIdentifier.userProfileBackupCodesDone].firstMatch
-    if backupCodesDone.waitForExistence(timeout: 10) {
-      backupCodesDone.tap()
-    }
-  }
-
   private func deleteAccountFromUserProfileSecurity(
     in app: XCUIApplication,
     file: StaticString = #filePath,
@@ -3194,38 +2629,6 @@ extension E2EHostE2ETests {
     try enterCurrentTOTPCode(secret: secret, into: E2EIdentifier.totpCode, in: app, file: file, line: line)
 
     continueBackupCodesAfterMfaSetup(in: app, file: file, line: line)
-  }
-
-  private func completeSmsCodeMfaSetup(
-    phoneNumber: String,
-    in app: XCUIApplication,
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) {
-    tap(E2EIdentifier.setupMfaSmsCode, in: app, file: file, line: line)
-    enterPhoneNumber(phoneNumber, into: E2EIdentifier.smsPhoneNumber, in: app, file: file, line: line)
-    tap(E2EIdentifier.smsContinue, in: app, file: file, line: line)
-    waitForCodePrepared(
-      in: app,
-      codeInputIdentifier: E2EIdentifier.smsCode,
-      message: "Expected setup-MFA SMS code preparation to finish before entering the verification code.",
-      file: file,
-      line: line
-    )
-    enterVerificationCode(verificationCode, into: E2EIdentifier.smsCode, in: app, file: file, line: line)
-
-    continueBackupCodesIfPresent(in: app, file: file, line: line)
-  }
-
-  private func continueBackupCodesIfPresent(
-    in app: XCUIApplication,
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) {
-    let backupCodesContinue = app.descendants(matching: .any)[E2EIdentifier.backupCodesContinue]
-    if backupCodesContinue.waitForExistence(timeout: 10) {
-      tapWhenHittableAfterScrolling(E2EIdentifier.backupCodesContinue, in: app, timeout: 10, file: file, line: line)
-    }
   }
 
   private func continueBackupCodesAfterMfaSetup(

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -38,6 +38,7 @@ final class E2EHostE2ETests: XCTestCase {
   private static let sessionTaskChooseOrganizationPublishableKeyName = "session-task-choose-organization"
   private static let sessionTaskResetPasswordPublishableKeyName = "session-task-reset-password"
   private static let defaultChooseOrganizationEmailDomain = "clerk.dev"
+  private static let passwordChangeCompletionTimeout: TimeInterval = 75
 
   private let verificationCode = "424242"
   private let testPassword = "ClerkIOS2026E2ETestPassword9!"
@@ -2726,13 +2727,68 @@ extension E2EHostE2ETests {
     dismissSavePasswordPromptIfPresent(in: app, timeout: 10)
     tapWhenEnabled(E2EIdentifier.userProfileChangePasswordSave, in: app, timeout: 45, file: file, line: line)
     dismissSavePasswordPromptIfPresent(in: app, timeout: 10)
+    waitForUserProfilePasswordChangeToFinish(in: app, file: file, line: line)
+  }
 
-    XCTAssertTrue(
-      app.descendants(matching: .any)[E2EIdentifier.userProfileChangePasswordSave].waitForNonExistence(timeout: 45),
-      "Expected the change-password sheet to dismiss after saving.",
-      file: file,
-      line: line
-    )
+  private func waitForUserProfilePasswordChangeToFinish(
+    in app: XCUIApplication,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    let saveButton = app.descendants(matching: .any)[E2EIdentifier.userProfileChangePasswordSave]
+    let deadline = Date().addingTimeInterval(Self.passwordChangeCompletionTimeout)
+
+    repeat {
+      if !saveButton.exists {
+        return
+      }
+
+      dismissVisibleSavePasswordPromptAndRecoverIfNeeded(in: app)
+      RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+    } while Date() < deadline
+
+    if !saveButton.exists {
+      return
+    }
+
+    attachUserProfilePasswordChangeDiagnostics(in: app, reason: "Timed out waiting for the change-password sheet to dismiss.")
+    XCTFail("Expected the change-password sheet to dismiss after saving.", file: file, line: line)
+  }
+
+  private func attachUserProfilePasswordChangeDiagnostics(in app: XCUIApplication, reason: String) {
+    let lines = [
+      "reason: \(truncatedDiagnosticValue(reason, limit: 300))",
+      "test: \(name)",
+      "appState: \(appStateDescription(app.state))",
+      "stateMarkers:",
+      authStartDiagnosticProbe(E2EIdentifier.signedIn, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.sessionActive, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.sessionStatus, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.cleanupInProgress, in: app),
+      "changePasswordControls:",
+      authStartDiagnosticProbe(E2EIdentifier.userProfileChangePasswordSave, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.userProfileChangePasswordNewPassword, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.userProfileChangePasswordConfirmPassword, in: app),
+      "visibleButtons:",
+      visibleElementSummary(app.buttons),
+      "visibleStaticTexts:",
+      visibleElementSummary(app.staticTexts),
+    ]
+
+    let summaryAttachment = XCTAttachment(string: lines.joined(separator: "\n"))
+    summaryAttachment.name = "change-password-diagnostics"
+    summaryAttachment.lifetime = .keepAlways
+    add(summaryAttachment)
+
+    let treeAttachment = XCTAttachment(string: app.debugDescription)
+    treeAttachment.name = "change-password-accessibility-tree"
+    treeAttachment.lifetime = .keepAlways
+    add(treeAttachment)
+
+    let screenshotAttachment = XCTAttachment(screenshot: app.screenshot())
+    screenshotAttachment.name = "change-password-failure"
+    screenshotAttachment.lifetime = .keepAlways
+    add(screenshotAttachment)
   }
 
   private func completeUserProfileAuthenticatorAppMfaSetup(

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -96,7 +96,7 @@ final class E2EHostE2ETests: XCTestCase {
 
     openAuth(in: signInApp)
     enterAuthStartIdentifier(email, in: signInApp)
-    guard submitAuthStartAndWaitForSignInPassword(in: signInApp) else { return }
+    guard submitAuthStartAndWaitForSignInPassword(identifier: email, in: signInApp) else { return }
     enterText(testPassword, into: E2EIdentifier.signInPassword, in: signInApp)
     tap(E2EIdentifier.signInContinue, in: signInApp)
     waitForSignedIn(in: signInApp)
@@ -312,9 +312,7 @@ final class E2EHostE2ETests: XCTestCase {
     guard let signInApp = app else { return }
 
     openAuth(in: signInApp)
-    enterAuthStartIdentifier(email, in: signInApp)
-    tap(E2EIdentifier.authStartContinue, in: signInApp)
-    tap(E2EIdentifier.signInUseAnotherMethod, in: signInApp)
+    submitEmailSignInAndTapUseAnotherMethod(email: email, in: signInApp)
     tapSignInAlternativeMethod(E2EIdentifier.signInEmailCodeAlternativeMethod, in: signInApp)
     waitForSignInCodePrepared(in: signInApp)
     enterVerificationCode(verificationCode, into: E2EIdentifier.signInCode, in: signInApp)
@@ -457,7 +455,7 @@ final class E2EHostE2ETests: XCTestCase {
 
     openAuth(in: signInApp)
     enterAuthStartIdentifier(username, in: signInApp)
-    guard submitAuthStartAndWaitForSignInPassword(in: signInApp) else { return }
+    guard submitAuthStartAndWaitForSignInPassword(identifier: username, in: signInApp) else { return }
     enterText(testPassword, into: E2EIdentifier.signInPassword, in: signInApp)
     tap(E2EIdentifier.signInContinue, in: signInApp)
     waitForSignedIn(in: signInApp)
@@ -646,7 +644,7 @@ final class E2EHostE2ETests: XCTestCase {
 
     openAuth(in: signInApp)
     enterAuthStartIdentifier(email, in: signInApp)
-    guard submitAuthStartAndWaitForSignInPassword(in: signInApp) else { return }
+    guard submitAuthStartAndWaitForSignInPassword(identifier: email, in: signInApp) else { return }
     enterText(testPassword, into: E2EIdentifier.signInPassword, in: signInApp)
     tap(E2EIdentifier.signInContinue, in: signInApp)
     dismissSavePasswordPromptIfPresent(in: signInApp)
@@ -1440,7 +1438,7 @@ extension E2EHostE2ETests {
     line: UInt = #line
   ) {
     enterAuthStartIdentifier(email, in: app, file: file, line: line)
-    guard submitAuthStartAndWaitForSignInPassword(in: app, file: file, line: line) else { return }
+    guard submitAuthStartAndWaitForSignInPassword(identifier: email, in: app, file: file, line: line) else { return }
     enterText(testPassword, into: E2EIdentifier.signInPassword, in: app, file: file, line: line)
     tap(E2EIdentifier.signInContinue, in: app, file: file, line: line)
   }
@@ -1501,6 +1499,36 @@ extension E2EHostE2ETests {
     tapSignInAlternativeMethod(E2EIdentifier.signInPhoneCodeAlternativeMethod, in: app, file: file, line: line)
     waitForSignInCodePrepared(in: app, file: file, line: line)
     enterVerificationCode(verificationCode, into: E2EIdentifier.signInCode, in: app, file: file, line: line)
+  }
+
+  private func submitEmailSignInAndTapUseAnotherMethod(
+    email: String,
+    in app: XCUIApplication,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    let maxAttempts = 2
+
+    for attempt in 1 ... maxAttempts {
+      if attempt > 1 {
+        dismissAuthIfPresent(in: app)
+        openAuth(in: app, file: file, line: line)
+      }
+
+      enterAuthStartIdentifier(email, in: app, file: file, line: line)
+      tap(E2EIdentifier.authStartContinue, in: app, file: file, line: line)
+
+      if let useAnotherMethod = waitForHittableElement(
+        withIdentifier: E2EIdentifier.signInUseAnotherMethod,
+        in: app,
+        timeout: 45
+      ) {
+        useAnotherMethod.tap()
+        return
+      }
+    }
+
+    XCTFail("Expected sign-in alternative methods after submitting the email.", file: file, line: line)
   }
 
   private func submitPhoneSignInAndTapUseAnotherMethod(
@@ -1737,6 +1765,7 @@ extension E2EHostE2ETests {
   }
 
   private func submitAuthStartAndWaitForSignInPassword(
+    identifier: String,
     in app: XCUIApplication,
     file: StaticString = #filePath,
     line: UInt = #line
@@ -1745,6 +1774,13 @@ extension E2EHostE2ETests {
     let message = "Expected sign-in password preparation to finish before entering the password."
 
     for attempt in 1 ... maxAttempts {
+      if attempt > 1 {
+        dismissRequestTimedOutErrorIfPresent(in: app)
+        dismissAuthIfPresent(in: app)
+        openAuth(in: app, file: file, line: line)
+        enterAuthStartIdentifier(identifier, in: app, file: file, line: line)
+      }
+
       tap(E2EIdentifier.authStartContinue, in: app, file: file, line: line)
       waitForAuthStartRequestTimedOutErrorToClear(in: app)
 
@@ -1755,7 +1791,8 @@ extension E2EHostE2ETests {
       switch result {
       case .prepared:
         return true
-      case .requestTimedOut where attempt < maxAttempts:
+      case .requestTimedOut where attempt < maxAttempts,
+           .timedOut where attempt < maxAttempts:
         dismissRequestTimedOutErrorIfPresent(in: app)
         continue
       case .requestTimedOut, .timedOut:

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -581,7 +581,16 @@ extension E2EHostE2ETests {
     let maxAttempts = 4
 
     for attempt in 1 ... maxAttempts {
+      if waitForAuthStartInput(in: app, timeout: 2) {
+        return
+      }
+
       guard let signInButton = waitForHittableElement(withIdentifier: E2EIdentifier.signIn, in: app, timeout: 20) else {
+        if authSheetIsPresented(in: app), attempt < maxAttempts {
+          dismissAuthIfPresent(in: app)
+          continue
+        }
+
         attachAuthStartDiagnostics(
           in: app,
           reason: "Expected the E2EHost sign-in button.",
@@ -804,12 +813,41 @@ extension E2EHostE2ETests {
   }
 
   private func dismissAuthIfPresent(in app: XCUIApplication) {
-    guard let dismissButton = waitForHittableElement(withIdentifier: E2EIdentifier.dismissButton, in: app, timeout: 5) else {
+    guard let dismissButton = waitForHittableDismissButton(in: app, timeout: 5) else {
       return
     }
 
     dismissButton.tap()
-    _ = app.descendants(matching: .any)[E2EIdentifier.signIn].waitForExistence(timeout: 5)
+    _ = waitForHittableElement(withIdentifier: E2EIdentifier.signIn, in: app, timeout: 5)
+  }
+
+  private func authSheetIsPresented(in app: XCUIApplication) -> Bool {
+    app.descendants(matching: .any)[E2EIdentifier.dismissButton].exists
+  }
+
+  private func waitForHittableDismissButton(in app: XCUIApplication, timeout: TimeInterval) -> XCUIElement? {
+    let deadline = Date().addingTimeInterval(timeout)
+
+    repeat {
+      let button = app.buttons[E2EIdentifier.dismissButton]
+      if button.exists, button.isEnabled, button.isHittable {
+        return button
+      }
+
+      if let element = hittableElement(withIdentifier: E2EIdentifier.dismissButton, in: app) {
+        return element
+      }
+
+      dismissVisibleSavePasswordPromptAndRecoverIfNeeded(in: app)
+      RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+    } while Date() < deadline
+
+    let button = app.buttons[E2EIdentifier.dismissButton]
+    if button.exists, button.isEnabled, button.isHittable {
+      return button
+    }
+
+    return hittableElement(withIdentifier: E2EIdentifier.dismissButton, in: app)
   }
 
   private func relaunchSignedOutApp(

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -3446,9 +3446,7 @@ extension E2EHostE2ETests {
     file: StaticString = #filePath,
     line: UInt = #line
   ) throws {
-    guard let secretKey = secretKey(named: keyName) else {
-      return
-    }
+    let secretKey = try requiredSecretKey(named: keyName)
 
     let formattedPhoneNumber = Self.e164TestPhoneNumber(phoneNumber)
     let userIDs = try backendUserIDsMatchingPhoneNumber(

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -3142,10 +3142,13 @@ extension E2EHostE2ETests {
 
   private func waitForStableTOTPWindow() {
     let period: TimeInterval = 30
+    let minimumRemainingTime: TimeInterval = 20
     let elapsed = Date().timeIntervalSince1970.truncatingRemainder(dividingBy: period)
-    guard elapsed > 24 else { return }
+    let remaining = period - elapsed
 
-    Thread.sleep(forTimeInterval: period - elapsed + 1)
+    guard remaining < minimumRemainingTime else { return }
+
+    Thread.sleep(forTimeInterval: remaining + 1)
   }
 
   private static func currentTOTPCode(secret: String, date: Date = Date()) throws -> String {

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -38,6 +38,7 @@ final class E2EHostE2ETests: XCTestCase {
   private static let sessionTaskChooseOrganizationPublishableKeyName = "session-task-choose-organization"
   private static let sessionTaskResetPasswordPublishableKeyName = "session-task-reset-password"
   private static let defaultChooseOrganizationEmailDomain = "clerk.dev"
+  private static let authStartSubmissionTimeout: TimeInterval = 75
   private static let passwordChangeCompletionTimeout: TimeInterval = 75
 
   private let verificationCode = "424242"
@@ -95,7 +96,7 @@ final class E2EHostE2ETests: XCTestCase {
 
     openAuth(in: signInApp)
     enterAuthStartIdentifier(email, in: signInApp)
-    tap(E2EIdentifier.authStartContinue, in: signInApp)
+    guard submitAuthStartAndWaitForSignInPassword(in: signInApp) else { return }
     enterText(testPassword, into: E2EIdentifier.signInPassword, in: signInApp)
     tap(E2EIdentifier.signInContinue, in: signInApp)
     waitForSignedIn(in: signInApp)
@@ -438,7 +439,7 @@ final class E2EHostE2ETests: XCTestCase {
 
     openAuth(in: signInApp)
     enterAuthStartIdentifier(username, in: signInApp)
-    tap(E2EIdentifier.authStartContinue, in: signInApp)
+    guard submitAuthStartAndWaitForSignInPassword(in: signInApp) else { return }
     enterText(testPassword, into: E2EIdentifier.signInPassword, in: signInApp)
     tap(E2EIdentifier.signInContinue, in: signInApp)
     waitForSignedIn(in: signInApp)
@@ -621,7 +622,7 @@ final class E2EHostE2ETests: XCTestCase {
 
     openAuth(in: signInApp)
     enterAuthStartIdentifier(email, in: signInApp)
-    tap(E2EIdentifier.authStartContinue, in: signInApp)
+    guard submitAuthStartAndWaitForSignInPassword(in: signInApp) else { return }
     enterText(testPassword, into: E2EIdentifier.signInPassword, in: signInApp)
     tap(E2EIdentifier.signInContinue, in: signInApp)
     dismissSavePasswordPromptIfPresent(in: signInApp)
@@ -760,6 +761,12 @@ extension E2EHostE2ETests {
   }
 
   private enum CodePreparationResult: Equatable {
+    case prepared
+    case requestTimedOut
+    case timedOut
+  }
+
+  private enum SignInPasswordPreparationResult: Equatable {
     case prepared
     case requestTimedOut
     case timedOut
@@ -1385,11 +1392,16 @@ extension E2EHostE2ETests {
     completePasswordCollectionIfNeeded(in: app)
   }
 
-  private func completePasswordSignIn(email: String, in app: XCUIApplication) {
-    enterAuthStartIdentifier(email, in: app)
-    tap(E2EIdentifier.authStartContinue, in: app)
-    enterText(testPassword, into: E2EIdentifier.signInPassword, in: app)
-    tap(E2EIdentifier.signInContinue, in: app)
+  private func completePasswordSignIn(
+    email: String,
+    in app: XCUIApplication,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    enterAuthStartIdentifier(email, in: app, file: file, line: line)
+    guard submitAuthStartAndWaitForSignInPassword(in: app, file: file, line: line) else { return }
+    enterText(testPassword, into: E2EIdentifier.signInPassword, in: app, file: file, line: line)
+    tap(E2EIdentifier.signInContinue, in: app, file: file, line: line)
   }
 
   private func completePhoneCodeSignUp(phoneNumber: String, email: String, in app: XCUIApplication) {
@@ -1675,6 +1687,149 @@ extension E2EHostE2ETests {
         return
       }
     }
+  }
+
+  private func submitAuthStartAndWaitForSignInPassword(
+    in app: XCUIApplication,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) -> Bool {
+    let maxAttempts = 2
+    let message = "Expected sign-in password preparation to finish before entering the password."
+
+    for attempt in 1 ... maxAttempts {
+      tap(E2EIdentifier.authStartContinue, in: app, file: file, line: line)
+      waitForAuthStartRequestTimedOutErrorToClear(in: app)
+
+      let result = waitForSignInPasswordPreparationResult(
+        in: app,
+        timeout: Self.authStartSubmissionTimeout
+      )
+      switch result {
+      case .prepared:
+        return true
+      case .requestTimedOut where attempt < maxAttempts:
+        dismissRequestTimedOutErrorIfPresent(in: app)
+        continue
+      case .requestTimedOut, .timedOut:
+        let failureMessage = signInPasswordPreparationFailureMessage(message, result: result)
+        attachSignInPasswordPreparationDiagnostics(
+          in: app,
+          reason: failureMessage,
+          attempt: attempt,
+          maxAttempts: maxAttempts
+        )
+        XCTFail(failureMessage, file: file, line: line)
+        return false
+      }
+    }
+
+    return false
+  }
+
+  private func waitForSignInPasswordPreparationResult(
+    in app: XCUIApplication,
+    timeout: TimeInterval
+  ) -> SignInPasswordPreparationResult {
+    let passwordInput = app.descendants(matching: .any)[E2EIdentifier.signInPassword]
+    let timeoutError = authStartRequestTimedOutError(in: app)
+    let deadline = Date().addingTimeInterval(timeout)
+
+    repeat {
+      if passwordInput.exists {
+        return .prepared
+      }
+
+      if timeoutError.exists {
+        return .requestTimedOut
+      }
+
+      dismissVisibleSavePasswordPromptAndRecoverIfNeeded(in: app)
+      RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+    } while Date() < deadline
+
+    if passwordInput.exists {
+      return .prepared
+    }
+
+    if timeoutError.exists {
+      return .requestTimedOut
+    }
+
+    return .timedOut
+  }
+
+  private func signInPasswordPreparationFailureMessage(
+    _ message: String,
+    result: SignInPasswordPreparationResult
+  ) -> String {
+    switch result {
+    case .prepared:
+      message
+    case .requestTimedOut:
+      "\(message) Auth start showed '\(E2EIdentifier.requestTimedOutErrorMessage)' after retrying."
+    case .timedOut:
+      message
+    }
+  }
+
+  private func attachSignInPasswordPreparationDiagnostics(
+    in app: XCUIApplication,
+    reason: String,
+    attempt: Int,
+    maxAttempts: Int
+  ) {
+    let launchEnvironment = app.launchEnvironment
+    let lines = [
+      "reason: \(truncatedDiagnosticValue(reason, limit: 300))",
+      "test: \(name)",
+      "attempt: \(attempt)/\(maxAttempts)",
+      "appState: \(appStateDescription(app.state))",
+      "launchEnvironment:",
+      "  CLERK_E2E_KEY_NAME: \(launchEnvironment["CLERK_E2E_KEY_NAME"] ?? "<missing>")",
+      "  CLERK_E2E_AUTH_MODE: \(launchEnvironment["CLERK_E2E_AUTH_MODE"] ?? "<missing>")",
+      "  CLERK_E2E_KEYCHAIN_SERVICE: \(launchEnvironment["CLERK_E2E_KEYCHAIN_SERVICE"] ?? "<missing>")",
+      "  CLERK_E2E_MODE: \(launchEnvironment["CLERK_E2E_MODE"] ?? "<missing>")",
+      "  CLERK_PUBLISHABLE_KEY: \(redactedPublishableKey(launchEnvironment["CLERK_PUBLISHABLE_KEY"]))",
+      "stateMarkers:",
+      authStartDiagnosticProbe(E2EIdentifier.signedOut, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.signedIn, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.sessionActive, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.sessionPending, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.sessionStatus, in: app),
+      "authStartElements:",
+      authStartDiagnosticProbe(E2EIdentifier.authStartIdentifier, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.authStartContinue, in: app),
+      "signInElements:",
+      authStartDiagnosticProbe(E2EIdentifier.signInPassword, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.signInContinue, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.signInUseAnotherMethod, in: app),
+      "requestTimedOutError: \(authStartRequestTimedOutError(in: app).exists)",
+      "keyboardVisible: \(app.keyboards.firstMatch.exists)",
+      "visibleButtons:",
+      visibleElementSummary(app.buttons),
+      "visibleTextFields:",
+      visibleElementSummary(app.textFields),
+      "visibleSecureTextFields:",
+      visibleElementSummary(app.secureTextFields),
+      "visibleStaticTexts:",
+      visibleElementSummary(app.staticTexts),
+    ]
+
+    let summaryAttachment = XCTAttachment(string: lines.joined(separator: "\n"))
+    summaryAttachment.name = "sign-in-password-diagnostics"
+    summaryAttachment.lifetime = .keepAlways
+    add(summaryAttachment)
+
+    let treeAttachment = XCTAttachment(string: app.debugDescription)
+    treeAttachment.name = "sign-in-password-accessibility-tree"
+    treeAttachment.lifetime = .keepAlways
+    add(treeAttachment)
+
+    let screenshotAttachment = XCTAttachment(screenshot: app.screenshot())
+    screenshotAttachment.name = "sign-in-password-failure"
+    screenshotAttachment.lifetime = .keepAlways
+    add(screenshotAttachment)
   }
 
   private func waitForCodePreparationResult(

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -161,6 +161,12 @@ final class E2EHostE2ETests: XCTestCase {
     let phoneNumber = makeTrackedTestPhoneNumber()
     let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
 
+    try deleteExistingUsersMatchingPhoneNumber(
+      phoneNumber,
+      publishableKey: publishableKey,
+      keyName: Self.multiMethodsPublishableKeyName
+    )
+
     app = launchApp(
       authMode: "signUp",
       publishableKey: publishableKey,
@@ -325,6 +331,12 @@ final class E2EHostE2ETests: XCTestCase {
     let phoneNumber = makeTrackedTestPhoneNumber()
     let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
 
+    try deleteExistingUsersMatchingPhoneNumber(
+      phoneNumber,
+      publishableKey: publishableKey,
+      keyName: Self.phonePublishableKeyName
+    )
+
     app = launchApp(
       authMode: "signUp",
       publishableKey: publishableKey,
@@ -367,6 +379,12 @@ final class E2EHostE2ETests: XCTestCase {
     let email = Self.makeUniqueTestEmail()
     let phoneNumber = makeTrackedTestPhoneNumber()
     let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
+
+    try deleteExistingUsersMatchingPhoneNumber(
+      phoneNumber,
+      publishableKey: publishableKey,
+      keyName: Self.multiMethodsPublishableKeyName
+    )
 
     app = launchApp(
       authMode: "signUp",
@@ -506,6 +524,12 @@ final class E2EHostE2ETests: XCTestCase {
     let email = Self.makeUniqueTestEmail()
     let phoneNumber = makeTrackedTestPhoneNumber()
     let keychainService = "com.clerk.E2EHost.\(UUID().uuidString)"
+
+    try deleteExistingUsersMatchingPhoneNumber(
+      phoneNumber,
+      publishableKey: publishableKey,
+      keyName: Self.sessionTaskSetupMfaPublishableKeyName
+    )
 
     app = launchApp(
       authMode: "signUp",
@@ -762,6 +786,7 @@ extension E2EHostE2ETests {
 
   private enum CodePreparationResult: Equatable {
     case prepared
+    case identifierTaken(String)
     case requestTimedOut
     case timedOut
   }
@@ -784,6 +809,14 @@ extension E2EHostE2ETests {
 
     var description: String {
       "Backend API request failed with status \(statusCode): \(responseBody)"
+    }
+  }
+
+  fileprivate struct BackendAPIResponseError: Error, CustomStringConvertible {
+    let message: String
+
+    var description: String {
+      message
     }
   }
 
@@ -897,6 +930,14 @@ extension E2EHostE2ETests {
   }
 
   private func requiredSecretKey(named keyName: String) throws -> String {
+    if let secretKey = secretKey(named: keyName) {
+      return secretKey
+    }
+
+    throw XCTSkip("Configure '\(keyName).sk' in .keys.json.")
+  }
+
+  private func secretKey(named keyName: String) -> String? {
     let environment = ProcessInfo.processInfo.environment
     let selectedKeyName = Self.publishableKeyName(environment: environment)
 
@@ -908,7 +949,7 @@ extension E2EHostE2ETests {
       return secretKey
     }
 
-    throw XCTSkip("Configure '\(keyName).sk' in .keys.json.")
+    return nil
   }
 
   private static func publishableKeyName(environment: [String: String]) -> String {
@@ -1638,6 +1679,9 @@ extension E2EHostE2ETests {
       switch result {
       case .prepared:
         return
+      case let .identifierTaken(message):
+        XCTFail(message, file: file, line: line)
+        return
       case .requestTimedOut where attempt < maxAttempts:
         continue
       case .requestTimedOut, .timedOut:
@@ -1670,6 +1714,9 @@ extension E2EHostE2ETests {
       )
       switch result {
       case .prepared:
+        return
+      case let .identifierTaken(message):
+        XCTFail(message, file: file, line: line)
         return
       case .requestTimedOut where attempt < maxAttempts:
         dismissRequestTimedOutErrorIfPresent(in: app)
@@ -1842,6 +1889,7 @@ extension E2EHostE2ETests {
       NSPredicate(format: "label CONTAINS %@", "Resend (")
     ).firstMatch
     let timeoutError = authStartRequestTimedOutError(in: app)
+    let identifierTakenError = authStartIdentifierTakenError(in: app)
     let deadline = Date().addingTimeInterval(timeout)
 
     repeat {
@@ -1851,6 +1899,10 @@ extension E2EHostE2ETests {
 
       if resendCooldown.exists {
         return .prepared
+      }
+
+      if identifierTakenError.exists {
+        return .identifierTaken(identifierTakenError.label)
       }
 
       if timeoutError.exists {
@@ -1868,6 +1920,10 @@ extension E2EHostE2ETests {
       return .prepared
     }
 
+    if identifierTakenError.exists {
+      return .identifierTaken(identifierTakenError.label)
+    }
+
     if timeoutError.exists {
       return .requestTimedOut
     }
@@ -1883,11 +1939,16 @@ extension E2EHostE2ETests {
       NSPredicate(format: "label CONTAINS %@", "Resend (")
     ).firstMatch
     let timeoutError = authStartRequestTimedOutError(in: app)
+    let identifierTakenError = authStartIdentifierTakenError(in: app)
     let deadline = Date().addingTimeInterval(timeout)
 
     repeat {
       if resendCooldown.exists {
         return .prepared
+      }
+
+      if identifierTakenError.exists {
+        return .identifierTaken(identifierTakenError.label)
       }
 
       if timeoutError.exists {
@@ -1899,6 +1960,10 @@ extension E2EHostE2ETests {
 
     if resendCooldown.exists {
       return .prepared
+    }
+
+    if identifierTakenError.exists {
+      return .identifierTaken(identifierTakenError.label)
     }
 
     if timeoutError.exists {
@@ -1915,6 +1980,8 @@ extension E2EHostE2ETests {
     switch result {
     case .prepared:
       message
+    case let .identifierTaken(errorMessage):
+      "\(message) Auth start showed: \(errorMessage)"
     case .requestTimedOut:
       "\(message) Auth start showed '\(E2EIdentifier.requestTimedOutErrorMessage)' after retrying."
     case .timedOut:
@@ -1925,6 +1992,12 @@ extension E2EHostE2ETests {
   private func authStartRequestTimedOutError(in app: XCUIApplication) -> XCUIElement {
     app.staticTexts.matching(
       NSPredicate(format: "label == %@", E2EIdentifier.requestTimedOutErrorMessage)
+    ).firstMatch
+  }
+
+  private func authStartIdentifierTakenError(in app: XCUIApplication) -> XCUIElement {
+    app.staticTexts.matching(
+      NSPredicate(format: "label CONTAINS[c] %@", "is taken")
     ).firstMatch
   }
 
@@ -3329,6 +3402,104 @@ extension E2EHostE2ETests {
     )
   }
 
+  private func deleteExistingUsersMatchingPhoneNumber(
+    _ phoneNumber: String,
+    publishableKey: String,
+    keyName: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) throws {
+    guard let secretKey = secretKey(named: keyName) else {
+      return
+    }
+
+    let formattedPhoneNumber = Self.e164TestPhoneNumber(phoneNumber)
+    let userIDs = try backendUserIDsMatchingPhoneNumber(
+      formattedPhoneNumber,
+      publishableKey: publishableKey,
+      secretKey: secretKey,
+      file: file,
+      line: line
+    )
+
+    for userID in userIDs {
+      try deleteBackendUser(
+        userID: userID,
+        publishableKey: publishableKey,
+        secretKey: secretKey,
+        file: file,
+        line: line
+      )
+    }
+  }
+
+  private func backendUserIDsMatchingPhoneNumber(
+    _ phoneNumber: String,
+    publishableKey: String,
+    secretKey: String,
+    file: StaticString,
+    line: UInt
+  ) throws -> [String] {
+    let url = Self.backendAPIBaseURL(publishableKey: publishableKey)
+      .appendingPathComponent("v1")
+      .appendingPathComponent("users")
+    var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    components?.queryItems = [
+      URLQueryItem(name: "phone_number[]", value: phoneNumber),
+      URLQueryItem(name: "limit", value: "100"),
+    ]
+
+    guard let requestURL = components?.url else {
+      throw BackendAPIResponseError(message: "Unable to build Backend API users URL.")
+    }
+
+    let data = try performBackendAPIRequest(
+      method: "GET",
+      url: requestURL,
+      secretKey: secretKey,
+      body: nil,
+      file: file,
+      line: line
+    )
+    let json = try JSONSerialization.jsonObject(with: data)
+    let users: [[String: Any]]
+    if let response = json as? [String: Any],
+       let data = response["data"] as? [[String: Any]]
+    {
+      users = data
+    } else if let data = json as? [[String: Any]] {
+      users = data
+    } else {
+      throw BackendAPIResponseError(message: "Unable to parse Backend API users response.")
+    }
+
+    return users
+      .filter { Self.backendUser($0, matchesPhoneNumber: phoneNumber) }
+      .compactMap { $0["id"] as? String }
+  }
+
+  private func deleteBackendUser(
+    userID: String,
+    publishableKey: String,
+    secretKey: String,
+    file: StaticString,
+    line: UInt
+  ) throws {
+    let url = Self.backendAPIBaseURL(publishableKey: publishableKey)
+      .appendingPathComponent("v1")
+      .appendingPathComponent("users")
+      .appendingPathComponent(userID)
+
+    _ = try performBackendAPIRequest(
+      method: "DELETE",
+      url: url,
+      secretKey: secretKey,
+      body: nil,
+      file: file,
+      line: line
+    )
+  }
+
   private func performBackendAPIPost(
     url: URL,
     secretKey: String,
@@ -3336,12 +3507,33 @@ extension E2EHostE2ETests {
     file: StaticString,
     line: UInt
   ) throws {
+    _ = try performBackendAPIRequest(
+      method: "POST",
+      url: url,
+      secretKey: secretKey,
+      body: body,
+      file: file,
+      line: line
+    )
+  }
+
+  @discardableResult
+  private func performBackendAPIRequest(
+    method: String,
+    url: URL,
+    secretKey: String,
+    body: [String: Any]?,
+    file: StaticString,
+    line: UInt
+  ) throws -> Data {
     var request = URLRequest(url: url)
-    request.httpMethod = "POST"
+    request.httpMethod = method
     request.setValue("Bearer \(secretKey)", forHTTPHeaderField: "Authorization")
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.setValue("2026-05-12", forHTTPHeaderField: "Clerk-API-Version")
-    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+    if let body {
+      request.httpBody = try JSONSerialization.data(withJSONObject: body)
+    }
 
     let expectation = expectation(description: "Backend API request")
     var result: Result<(HTTPURLResponse, Data), Error>?
@@ -3369,6 +3561,27 @@ extension E2EHostE2ETests {
     guard (200 ..< 300).contains(response.statusCode) else {
       let responseBody = String(data: data, encoding: .utf8) ?? ""
       throw BackendAPIError(statusCode: response.statusCode, responseBody: responseBody)
+    }
+
+    return data
+  }
+
+  private static func e164TestPhoneNumber(_ phoneNumber: String) -> String {
+    let digits = phoneNumber.filter(\.isWholeNumber)
+    if digits.hasPrefix("1"), digits.count == 11 {
+      return "+\(digits)"
+    }
+
+    return "+1\(digits)"
+  }
+
+  private static func backendUser(_ user: [String: Any], matchesPhoneNumber phoneNumber: String) -> Bool {
+    guard let phoneNumbers = user["phone_numbers"] as? [[String: Any]] else {
+      return false
+    }
+
+    return phoneNumbers.contains { phoneNumberResource in
+      phoneNumberResource["phone_number"] as? String == phoneNumber
     }
   }
 

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -2263,20 +2263,24 @@ extension E2EHostE2ETests {
       app.typeText(String(digit))
 
       let expectedPrefix = String(digits[...offset])
+      if element.isTextInput {
+        XCTAssertTrue(
+          waitForPhoneNumberDigits(in: element, toHavePrefix: expectedPrefix, timeout: 2),
+          "Expected phone number input to contain '\(expectedPrefix)'. Actual value: '\(phoneNumberInputValue(in: element))'.",
+          file: file,
+          line: line
+        )
+      }
+    }
+
+    if element.isTextInput {
       XCTAssertTrue(
-        waitForPhoneNumberDigits(in: element, toHavePrefix: expectedPrefix, timeout: 2),
-        "Expected phone number input to contain '\(expectedPrefix)'. Actual value: '\(phoneNumberInputValue(in: element))'.",
+        waitForPhoneNumberDigits(in: element, toEqual: digits, timeout: 5),
+        "Expected phone number input to contain '\(digits)' before continuing. Actual value: '\(phoneNumberInputValue(in: element))'.",
         file: file,
         line: line
       )
     }
-
-    XCTAssertTrue(
-      waitForPhoneNumberDigits(in: element, toEqual: digits, timeout: 5),
-      "Expected phone number input to contain '\(digits)' before continuing. Actual value: '\(phoneNumberInputValue(in: element))'.",
-      file: file,
-      line: line
-    )
   }
 
   private func assertApprovedTestPhoneNumber(
@@ -2300,28 +2304,15 @@ extension E2EHostE2ETests {
     file: StaticString,
     line: UInt
   ) -> XCUIElement {
-    let textField = app.textFields[identifier].firstMatch
-    if textField.waitForExistence(timeout: 2) {
-      textField.tap()
-      return textField
+    guard tapInput(identifier, in: app, file: file, line: line) else {
+      return inputElement(withIdentifier: identifier, in: app)
     }
 
-    let container = app.descendants(matching: .any).matching(identifier: identifier).firstMatch
-    XCTAssertTrue(
-      container.waitForExistence(timeout: 30),
-      "Expected phone number input.",
-      file: file,
-      line: line
-    )
-    container.tap()
+    if let focusedInput = focusedTextInput(in: app, timeout: 2) {
+      return focusedInput
+    }
 
-    XCTAssertTrue(
-      textField.waitForExistence(timeout: 10),
-      "Expected focused phone number text field.",
-      file: file,
-      line: line
-    )
-    return textField
+    return inputElement(withIdentifier: identifier, in: app)
   }
 
   private func waitForPhoneNumberDigits(
@@ -2412,7 +2403,11 @@ extension E2EHostE2ETests {
   }
 
   private func phoneNumberInputValue(in element: XCUIElement) -> String {
-    element.value as? String ?? ""
+    if let value = element.value as? String, !value.isEmpty {
+      return value
+    }
+
+    return element.label
   }
 
   private func inputElement(withIdentifier identifier: String, in app: XCUIApplication) -> XCUIElement {
@@ -2479,21 +2474,45 @@ extension E2EHostE2ETests {
   }
 
   private func waitForAnyTextInputFocus(in app: XCUIApplication, timeout: TimeInterval) -> Bool {
-    let focusedElement = app.descendants(matching: .any)
-      .matching(NSPredicate(format: "hasKeyboardFocus == true"))
-      .firstMatch
     let keyboard = app.keyboards.firstMatch
     let deadline = Date().addingTimeInterval(timeout)
 
     repeat {
-      if focusedElement.exists || keyboard.exists {
+      if focusedTextInput(in: app, timeout: 0) != nil || keyboard.exists {
         return true
       }
 
       RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     } while Date() < deadline
 
-    return focusedElement.exists || keyboard.exists
+    return focusedTextInput(in: app, timeout: 0) != nil || keyboard.exists
+  }
+
+  private func focusedTextInput(in app: XCUIApplication, timeout: TimeInterval) -> XCUIElement? {
+    let focusedPredicate = NSPredicate(format: "hasKeyboardFocus == true")
+    let deadline = Date().addingTimeInterval(timeout)
+
+    repeat {
+      let focusedElement = app.descendants(matching: .any)
+        .matching(focusedPredicate)
+        .firstMatch
+
+      if focusedElement.exists, focusedElement.isTextInput {
+        return focusedElement
+      }
+
+      RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+    } while Date() < deadline
+
+    let focusedElement = app.descendants(matching: .any)
+      .matching(focusedPredicate)
+      .firstMatch
+
+    guard focusedElement.exists, focusedElement.isTextInput else {
+      return nil
+    }
+
+    return focusedElement
   }
 
   private func tap(
@@ -3767,6 +3786,17 @@ extension E2EHostE2ETests {
     let cancelButton = app.buttons["Cancel"].firstMatch
     if cancelButton.waitForExistence(timeout: 1) {
       cancelButton.tap()
+    }
+  }
+}
+
+extension XCUIElement {
+  fileprivate var isTextInput: Bool {
+    switch elementType {
+    case .textField, .secureTextField, .textView:
+      true
+    default:
+      false
     }
   }
 }

--- a/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
+++ b/Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift
@@ -2032,6 +2032,22 @@ extension E2EHostE2ETests {
     }
   }
 
+  private func enterCurrentTOTPCode(
+    secret: String,
+    into identifier: String,
+    in app: XCUIApplication,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) throws {
+    let element = inputElement(withIdentifier: identifier, in: app)
+    XCTAssertTrue(element.waitForExistence(timeout: 30), "Expected verification code input '\(identifier)'.", file: file, line: line)
+    guard tapInput(identifier, in: app, file: file, line: line) else { return }
+
+    waitForStableTOTPWindow()
+    let code = try Self.currentTOTPCode(secret: secret)
+    app.typeText(code)
+  }
+
   private func tapInput(
     _ identifier: String,
     in app: XCUIApplication,
@@ -2964,9 +2980,13 @@ extension E2EHostE2ETests {
     let secret = secretElement.label
 
     tap(E2EIdentifier.userProfileMfaTotpContinue, in: app, file: file, line: line)
-    waitForStableTOTPWindow()
-    let code = try Self.currentTOTPCode(secret: secret)
-    enterVerificationCode(code, into: E2EIdentifier.userProfileMfaVerificationCode, in: app, file: file, line: line)
+    try enterCurrentTOTPCode(
+      secret: secret,
+      into: E2EIdentifier.userProfileMfaVerificationCode,
+      in: app,
+      file: file,
+      line: line
+    )
 
     continueUserProfileBackupCodesIfPresent(in: app)
     XCTAssertTrue(
@@ -3042,11 +3062,9 @@ extension E2EHostE2ETests {
     let secret = secretElement.label
 
     tap(E2EIdentifier.totpContinue, in: app, file: file, line: line)
-    waitForStableTOTPWindow()
-    let code = try Self.currentTOTPCode(secret: secret)
-    enterVerificationCode(code, into: E2EIdentifier.totpCode, in: app, file: file, line: line)
+    try enterCurrentTOTPCode(secret: secret, into: E2EIdentifier.totpCode, in: app, file: file, line: line)
 
-    continueBackupCodesIfPresent(in: app, file: file, line: line)
+    continueBackupCodesAfterMfaSetup(in: app, file: file, line: line)
   }
 
   private func completeSmsCodeMfaSetup(
@@ -3079,6 +3097,71 @@ extension E2EHostE2ETests {
     if backupCodesContinue.waitForExistence(timeout: 10) {
       tapWhenHittableAfterScrolling(E2EIdentifier.backupCodesContinue, in: app, timeout: 10, file: file, line: line)
     }
+  }
+
+  private func continueBackupCodesAfterMfaSetup(
+    in app: XCUIApplication,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    let backupCodesContinue = app.descendants(matching: .any)[E2EIdentifier.backupCodesContinue]
+    let didAdvanceToBackupCodes = backupCodesContinue.waitForExistence(timeout: 45)
+
+    if !didAdvanceToBackupCodes {
+      attachAuthenticatorAppSetupDiagnostics(in: app)
+    }
+
+    XCTAssertTrue(
+      didAdvanceToBackupCodes,
+      authenticatorAppSetupFailureMessage(in: app),
+      file: file,
+      line: line
+    )
+
+    guard didAdvanceToBackupCodes else { return }
+
+    tapWhenHittableAfterScrolling(E2EIdentifier.backupCodesContinue, in: app, timeout: 10, file: file, line: line)
+  }
+
+  private func authenticatorAppSetupFailureMessage(in app: XCUIApplication) -> String {
+    let incorrectCode = app.staticTexts.matching(NSPredicate(format: "label == %@", "Incorrect code")).firstMatch
+    if incorrectCode.exists {
+      return "Expected backup codes after submitting the generated TOTP code, but the app displayed Incorrect code."
+    }
+
+    return "Expected backup codes after submitting the generated TOTP code."
+  }
+
+  private func attachAuthenticatorAppSetupDiagnostics(in app: XCUIApplication) {
+    let lines = [
+      "totpControls:",
+      authStartDiagnosticProbe(E2EIdentifier.totpCode, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.backupCodesContinue, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.sessionActive, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.sessionStatus, in: app),
+      authStartDiagnosticProbe(E2EIdentifier.pendingTasks, in: app),
+      "visibleButtons:",
+      visibleElementSummary(app.buttons),
+      "visibleTextFields:",
+      visibleElementSummary(app.textFields),
+      "visibleStaticTexts:",
+      visibleElementSummary(app.staticTexts),
+    ]
+
+    let summaryAttachment = XCTAttachment(string: lines.joined(separator: "\n"))
+    summaryAttachment.name = "authenticator-app-setup-diagnostics"
+    summaryAttachment.lifetime = .keepAlways
+    add(summaryAttachment)
+
+    let treeAttachment = XCTAttachment(string: app.debugDescription)
+    treeAttachment.name = "authenticator-app-setup-accessibility-tree"
+    treeAttachment.lifetime = .keepAlways
+    add(treeAttachment)
+
+    let screenshotAttachment = XCTAttachment(screenshot: app.screenshot())
+    screenshotAttachment.name = "authenticator-app-setup-failure"
+    screenshotAttachment.lifetime = .keepAlways
+    add(screenshotAttachment)
   }
 
   private func dismissAuthSheetIfNeeded(
@@ -3353,7 +3436,7 @@ extension E2EHostE2ETests {
 
   private func waitForStableTOTPWindow() {
     let period: TimeInterval = 30
-    let minimumRemainingTime: TimeInterval = 20
+    let minimumRemainingTime: TimeInterval = 25
     let elapsed = Date().timeIntervalSince1970.truncatingRemainder(dividingBy: period)
     let remaining = period - elapsed
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean setup format format-check lint lint-fix check install-tools install-hooks install-xcode-template-macros create-example-local-secrets-plists set-example-pk test test-ui test-e2e test-integration smoke-macos help create-env install-1password-cli fetch-test-keys sync-test-keys-to-github update-swiftformat update-swiftlint
+.PHONY: all clean setup format format-check lint lint-fix check check-e2e-hooks check-e2e-selectors check-e2e-phone-numbers install-tools install-hooks install-xcode-template-macros create-example-local-secrets-plists set-example-pk test test-ui test-e2e test-integration smoke-macos help create-env install-1password-cli fetch-test-keys sync-test-keys-to-github update-swiftformat update-swiftlint
 
 SWIFTFORMAT := $(CURDIR)/.tools/bin/swiftformat
 SWIFTLINT := $(CURDIR)/.tools/bin/swiftlint
@@ -21,7 +21,10 @@ help:
 	@echo "  make format-check  - Check formatting without modifying files (for CI)"
 	@echo "  make lint          - Run SwiftLint to check code quality"
 	@echo "  make lint-fix      - Run SwiftLint with auto-fix where possible"
-	@echo "  make check         - Run both format-check and lint (for CI)"
+	@echo "  make check         - Run format-check, lint, and E2E hook checks (for CI)"
+	@echo "  make check-e2e-hooks - Verify E2E-only product hooks remain reviewed"
+	@echo "  make check-e2e-selectors - Verify E2E selectors match their source contracts"
+	@echo "  make check-e2e-phone-numbers - Verify E2E phone numbers use the approved test range"
 	@echo "  make test          - Run ClerkKitTests on macOS"
 	@echo "  make test-ui       - Run ClerkKitUI tests on iOS Simulator"
 	@echo "  make test-e2e      - Run E2EHost tests on iOS Simulator"
@@ -150,8 +153,20 @@ lint-fix:
 	@./scripts/install-swiftlint.sh > /dev/null
 	@"$(SWIFTLINT)" --fix
 
-# Run both format-check and lint
-check: format-check lint
+# Verify E2E-only product hooks are limited to reviewed OS automation workarounds
+check-e2e-hooks:
+	@./scripts/check-e2e-hooks.sh
+
+# Verify E2E selectors are backed by product and E2EHost identifier contracts
+check-e2e-selectors:
+	@./scripts/check-e2e-selectors.sh
+
+# Verify E2E phone numbers stay inside the approved Clerk test-number range
+check-e2e-phone-numbers:
+	@./scripts/check-e2e-phone-numbers.sh
+
+# Run format-check, lint, and lightweight repo checks
+check: format-check lint check-e2e-hooks check-e2e-selectors check-e2e-phone-numbers
 	@echo "✅ All checks passed!"
 
 clean:
@@ -226,6 +241,11 @@ test-e2e:
 		echo "   Set CLERK_E2E_PUBLISHABLE_KEY or configure '$$key_name.pk' in .keys.json."; \
 		exit 1; \
 	fi; \
+	if [ "$${CLERK_E2E_SKIP_PREFLIGHT:-}" != "1" ]; then \
+		CLERK_E2E_KEY_NAME="$$key_name" CLERK_E2E_PUBLISHABLE_KEY="$$publishable_key" CLERK_E2E_SECRET_KEY="$$secret_key" ./scripts/validate-e2e-test-instances.sh "$$key_name"; \
+	else \
+		echo "Skipping E2E test instance preflight because CLERK_E2E_SKIP_PREFLIGHT=1."; \
+	fi; \
 	echo "Using E2E test key: $$key_name"; \
 	simulator_id=""; \
 	destination="$(IOS_SIMULATOR_DESTINATION)"; \
@@ -287,7 +307,7 @@ test-e2e:
 	chmod 600 build/reports/E2EHostPublishableKey.txt; \
 	chmod 600 build/reports/E2EHostPublishableKeyName.txt; \
 	trap 'rm -f build/reports/E2EHostPublishableKey.txt build/reports/E2EHostPublishableKeyName.txt' EXIT; \
-	CLERK_E2E_KEY_NAME="$$key_name" CLERK_E2E_PUBLISHABLE_KEY="$$publishable_key" CLERK_PUBLISHABLE_KEY="$$publishable_key" CLERK_E2E_SECRET_KEY="$$secret_key" xcodebuild test -workspace Clerk.xcworkspace -scheme E2EHost -destination "$$destination" $$only_testing_flags -resultBundlePath "$$result_bundle_path"
+	CLERK_E2E_KEY_NAME="$$key_name" CLERK_E2E_PUBLISHABLE_KEY="$$publishable_key" CLERK_PUBLISHABLE_KEY="$$publishable_key" CLERK_E2E_SECRET_KEY="$$secret_key" E2E_SIMULATOR_ID="$$simulator_id" E2E_RESULT_BUNDLE_PATH="$$result_bundle_path" ./scripts/run-e2e-xcodebuild.sh xcodebuild test -workspace Clerk.xcworkspace -scheme E2EHost -destination "$$destination" $$only_testing_flags -resultBundlePath "$$result_bundle_path"
 	@echo "✅ E2EHost tests completed!"
 
 # Run only integration tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean setup format format-check lint lint-fix check check-e2e-hooks check-e2e-selectors check-e2e-phone-numbers install-tools install-hooks install-xcode-template-macros create-example-local-secrets-plists set-example-pk test test-ui test-e2e test-integration smoke-macos help create-env install-1password-cli fetch-test-keys sync-test-keys-to-github update-swiftformat update-swiftlint
+.PHONY: all clean setup format format-check lint lint-fix check check-e2e-hooks check-e2e-selectors check-e2e-phone-numbers check-e2e-runner install-tools install-hooks install-xcode-template-macros create-example-local-secrets-plists set-example-pk test test-ui test-e2e test-integration smoke-macos help create-env install-1password-cli fetch-test-keys sync-test-keys-to-github update-swiftformat update-swiftlint
 
 SWIFTFORMAT := $(CURDIR)/.tools/bin/swiftformat
 SWIFTLINT := $(CURDIR)/.tools/bin/swiftlint
@@ -25,6 +25,7 @@ help:
 	@echo "  make check-e2e-hooks - Verify E2E-only product hooks remain reviewed"
 	@echo "  make check-e2e-selectors - Verify E2E selectors match their source contracts"
 	@echo "  make check-e2e-phone-numbers - Verify E2E phone numbers use the approved test range"
+	@echo "  make check-e2e-runner - Verify E2E xcodebuild retry wrapper behavior"
 	@echo "  make test          - Run ClerkKitTests on macOS"
 	@echo "  make test-ui       - Run ClerkKitUI tests on iOS Simulator"
 	@echo "  make test-e2e      - Run E2EHost tests on iOS Simulator"
@@ -165,8 +166,12 @@ check-e2e-selectors:
 check-e2e-phone-numbers:
 	@./scripts/check-e2e-phone-numbers.sh
 
+# Verify E2E xcodebuild retry wrapper classification behavior
+check-e2e-runner:
+	@./scripts/test-run-e2e-xcodebuild.sh
+
 # Run format-check, lint, and lightweight repo checks
-check: format-check lint check-e2e-hooks check-e2e-selectors check-e2e-phone-numbers
+check: format-check lint check-e2e-hooks check-e2e-selectors check-e2e-phone-numbers check-e2e-runner
 	@echo "✅ All checks passed!"
 
 clean:

--- a/Sources/ClerkKitUI/Common/ClerkE2EEnvironment.swift
+++ b/Sources/ClerkKitUI/Common/ClerkE2EEnvironment.swift
@@ -8,6 +8,11 @@
 import Foundation
 
 enum ClerkE2EEnvironment {
+  /// Enables only narrow UI automation workarounds for E2EHost.
+  ///
+  /// Keep usage limited to OS-level automation interference, such as password
+  /// AutoFill prompts. Do not use this to bypass Clerk validation, routing,
+  /// backend calls, feature flags, session state, or other product behavior.
   static var isEnabled: Bool {
     ProcessInfo.processInfo.environment["CLERK_E2E_MODE"] == "1"
   }

--- a/Tests/Domains/Auth/SignUp/SignUpServiceTests.swift
+++ b/Tests/Domains/Auth/SignUp/SignUpServiceTests.swift
@@ -246,13 +246,14 @@ struct SignUpServiceTests {
       #expect(request.httpMethod == "PATCH")
       #expect(request.urlEncodedFormBody!["first_name"] == "John")
       #expect(request.urlEncodedFormBody!["last_name"] == "Doe")
+      #expect(request.urlEncodedFormBody!["legal_accepted"] == "1")
       requestHandled.setValue(true)
     }
     mock.register()
 
     _ = try await Clerk.shared.dependencies.signUpService.update(
       signUpId: signUp.id,
-      params: .init(firstName: "John", lastName: "Doe")
+      params: .init(firstName: "John", lastName: "Doe", legalAccepted: true)
     )
     #expect(requestHandled.value)
   }

--- a/Tests/Domains/Auth/SignUp/SignUpTests.swift
+++ b/Tests/Domains/Auth/SignUp/SignUpTests.swift
@@ -32,12 +32,13 @@ struct SignUpTests {
 
     configureService(service)
 
-    _ = try await signUp.update(firstName: "John", lastName: "Doe")
+    _ = try await signUp.update(firstName: "John", lastName: "Doe", legalAccepted: true)
 
     let params = try #require(captured.value)
     #expect(params.0 == signUp.id)
     #expect(params.1.firstName == "John")
     #expect(params.1.lastName == "Doe")
+    #expect(params.1.legalAccepted == true)
   }
 
   @Test

--- a/Tests/Domains/User/UserServiceTests.swift
+++ b/Tests/Domains/User/UserServiceTests.swift
@@ -805,6 +805,7 @@ struct UserServiceTests {
 
     mock.onRequestHandler = OnRequestHandler { @Sendable request in
       #expect(request.httpMethod == "POST")
+      #expect(request.urlEncodedFormBody!["current_password"] == "currentPassword123")
       #expect(request.urlEncodedFormBody!["new_password"] == "newPassword123")
       #expect(request.urlEncodedFormBody!["sign_out_of_other_sessions"] == "1")
       requestHandled.setValue(true)
@@ -812,7 +813,42 @@ struct UserServiceTests {
     mock.register()
 
     _ = try await Clerk.shared.dependencies.userService.updatePassword(
-      params: .init(newPassword: "newPassword123", signOutOfOtherSessions: true)
+      params: .init(
+        currentPassword: "currentPassword123",
+        newPassword: "newPassword123",
+        signOutOfOtherSessions: true
+      )
+    )
+    #expect(requestHandled.value)
+  }
+
+  @Test
+  func updatePasswordOmitsCurrentPasswordWhenNil() async throws {
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/me/change_password")!
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(ClientResponse<User>(response: .mock, client: .mock)),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { @Sendable request in
+      #expect(request.httpMethod == "POST")
+      #expect(request.urlEncodedFormBody!["current_password"] == nil)
+      #expect(request.urlEncodedFormBody!["new_password"] == "newPassword123")
+      #expect(request.urlEncodedFormBody!["sign_out_of_other_sessions"] == "0")
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    _ = try await Clerk.shared.dependencies.userService.updatePassword(
+      params: .init(
+        currentPassword: nil,
+        newPassword: "newPassword123",
+        signOutOfOtherSessions: false
+      )
     )
     #expect(requestHandled.value)
   }

--- a/Tests/Domains/User/UserServiceTests.swift
+++ b/Tests/Domains/User/UserServiceTests.swift
@@ -771,13 +771,14 @@ struct UserServiceTests {
   @Test
   func testGetSessions() async throws {
     let user = User.mock
+    let sessions = [Session.mock, Session.mock2]
     let requestHandled = LockIsolated(false)
     let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/me/sessions/active")!
 
     var mock = try Mock(
       url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
       data: [
-        .get: JSONEncoder.clerkEncoder.encode([Session.mock]),
+        .get: JSONEncoder.clerkEncoder.encode(sessions),
       ]
     )
 
@@ -787,8 +788,11 @@ struct UserServiceTests {
     }
     mock.register()
 
-    _ = try await Clerk.shared.dependencies.userService.getSessions(user: user)
+    let fetchedSessions = try await Clerk.shared.dependencies.userService.getSessions(user: user)
+
     #expect(requestHandled.value)
+    #expect(fetchedSessions.map(\.id) == sessions.map(\.id))
+    #expect(Clerk.shared.sessionsByUserId[user.id]?.map(\.id) == sessions.map(\.id))
   }
 
   @Test

--- a/Tests/Domains/User/UserTests.swift
+++ b/Tests/Domains/User/UserTests.swift
@@ -477,9 +477,16 @@ struct UserTests {
 
     configureService(service)
 
-    _ = try await User.mock.updatePassword(.init(newPassword: "newPassword123", signOutOfOtherSessions: true))
+    _ = try await User.mock.updatePassword(
+      .init(
+        currentPassword: "currentPassword123",
+        newPassword: "newPassword123",
+        signOutOfOtherSessions: true
+      )
+    )
 
     let params = try #require(captured.value)
+    #expect(params.currentPassword == "currentPassword123")
     #expect(params.newPassword == "newPassword123")
     #expect(params.signOutOfOtherSessions == true)
   }

--- a/Tests/Middleware/ClerkInvalidAuthResponseMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkInvalidAuthResponseMiddlewareTests.swift
@@ -12,7 +12,7 @@ struct ClerkInvalidAuthResponseMiddlewareTests {
     let clerk = Clerk()
 
     clerk.dependencies = MockDependencyContainer(
-      apiClient: createMockAPIClient(),
+      apiClient: createMockAPIClient(runtimeScope: clerk.runtimeScope),
       clientService: MockClientService(get: {
         refreshCount.withValue { $0 += 1 }
         try await Task.sleep(for: .milliseconds(100))

--- a/Tests/UI/AuthNavigationTests.swift
+++ b/Tests/UI/AuthNavigationTests.swift
@@ -113,6 +113,20 @@ struct AuthNavigationTests {
     #expect(navigation.path == [.signUpCompleteProfile])
   }
 
+  @Test
+  func signUpUsernameMissingRequirementRoutesToCollectUsernameBeforeCompleteProfile() {
+    let navigation = AuthNavigation()
+    let signUp = signUp(
+      missingFields: [.firstName, .legalAccepted, .username],
+      unverifiedFields: [],
+      verifications: [:]
+    )
+
+    navigation.setToStepForStatus(signUp: signUp)
+
+    #expect(navigation.path == [.signUpCollectField(.username)])
+  }
+
   private func session(pendingTasks: [Session.Task]) -> Session {
     var session = Session.mock
     session.tasks = pendingTasks

--- a/Tests/UI/AuthNavigationTests.swift
+++ b/Tests/UI/AuthNavigationTests.swift
@@ -27,6 +27,51 @@ struct AuthNavigationTests {
   }
 
   @Test
+  func routeToSessionTaskStartRoutesResetPasswordTaskOnce() {
+    let navigation = AuthNavigation()
+    let session = session(pendingTasks: [.resetPassword])
+
+    let didRoute = navigation.routeToSessionTaskStartIfNeeded(session: session)
+    let didRouteAgain = navigation.routeToSessionTaskStartIfNeeded(session: session)
+
+    #expect(didRoute)
+    #expect(didRouteAgain)
+    #expect(navigation.path == [.sessionTaskStart(task: .resetPassword)])
+  }
+
+  @Test
+  func routeToSessionTaskStartRoutesChooseOrganizationTask() {
+    let navigation = AuthNavigation()
+    let session = session(pendingTasks: [.chooseOrganization])
+
+    let didRoute = navigation.routeToSessionTaskStartIfNeeded(session: session)
+
+    #expect(didRoute)
+    #expect(navigation.path == [.sessionTaskStart(task: .chooseOrganization)])
+  }
+
+  @Test
+  func handleSessionTaskCompletionRoutesToChooseOrganizationWhenItIsNextPendingTask() {
+    let navigation = AuthNavigation()
+    let session = session(pendingTasks: [.chooseOrganization])
+
+    navigation.handleSessionTaskCompletion(session: session)
+
+    #expect(navigation.path == [.sessionTaskStart(task: .chooseOrganization)])
+    #expect(navigation.allTasksComplete == false)
+  }
+
+  @Test
+  func signInNeedsNewPasswordRoutesToSetNewPassword() {
+    let navigation = AuthNavigation()
+    let signIn = SignIn(id: "sign_in_123", status: .needsNewPassword)
+
+    navigation.setToStepForStatus(signIn: signIn)
+
+    #expect(navigation.path == [.signInSetNewPassword])
+  }
+
+  @Test
   func signUpEmailLinkVerificationRunsBeforeCollectingMissingFields() {
     let navigation = AuthNavigation()
     let signUp = signUp(
@@ -52,6 +97,20 @@ struct AuthNavigationTests {
     navigation.setToStepForStatus(signUp: signUp)
 
     #expect(navigation.path == [.signUpCode(.email("test@example.com"))])
+  }
+
+  @Test
+  func signUpLegalAcceptedMissingRequirementRoutesToCompleteProfile() {
+    let navigation = AuthNavigation()
+    let signUp = signUp(
+      missingFields: [.legalAccepted],
+      unverifiedFields: [],
+      verifications: [:]
+    )
+
+    navigation.setToStepForStatus(signUp: signUp)
+
+    #expect(navigation.path == [.signUpCompleteProfile])
   }
 
   private func session(pendingTasks: [Session.Task]) -> Session {

--- a/Tests/UI/AuthStateConfigurationTests.swift
+++ b/Tests/UI/AuthStateConfigurationTests.swift
@@ -73,6 +73,25 @@ struct AuthStateConfigurationTests {
   }
 
   @Test
+  func initialUsernameUsesIdentifierField() {
+    let defaults = makeUserDefaults()
+    defaults.set("stored@example.com", forKey: AuthState.identifierStorageKey)
+    defaults.set("15555550100", forKey: AuthState.phoneNumberStorageKey)
+    defaults.set(true, forKey: AuthState.phoneNumberFieldIsActiveStorageKey)
+
+    let authState = AuthState(userDefaults: defaults)
+    authState.configure(AuthConfig(
+      initialIdentifier: "clerk_user"
+    ))
+
+    #expect(authState.authStartIdentifier == "clerk_user")
+    #expect(authState.authStartPhoneNumber.isEmpty)
+    #expect(!authState.authStartPhoneNumberFieldIsActive)
+    #expect(defaults.string(forKey: AuthState.identifierStorageKey) == "clerk_user")
+    #expect(!defaults.bool(forKey: AuthState.phoneNumberFieldIsActiveStorageKey))
+  }
+
+  @Test
   func initialNameValuesConfigureSignUpFields() {
     let defaults = makeUserDefaults()
     let authState = AuthState(userDefaults: defaults)
@@ -184,6 +203,29 @@ struct AuthStateConfigurationTests {
     #expect(defaults.string(forKey: AuthState.identifierStorageKey) == nil)
     #expect(defaults.string(forKey: AuthState.phoneNumberStorageKey) == nil)
     #expect(defaults.object(forKey: AuthState.phoneNumberFieldIsActiveStorageKey) == nil)
+  }
+
+  @Test
+  func storeLastUsedIdentifierTypePersistsWhenEnabled() {
+    let defaults = makeUserDefaults()
+    let authState = AuthState(userDefaults: defaults)
+
+    authState.storeLastUsedIdentifierType(.username)
+
+    #expect(LastUsedAuth.retrieveStoredIdentifierType(userDefaults: defaults) == .username)
+  }
+
+  @Test
+  func storeLastUsedIdentifierTypeIsSuppressedWhenPersistenceIsDisabled() {
+    let defaults = makeUserDefaults()
+    let authState = AuthState(userDefaults: defaults)
+    authState.configure(AuthConfig(
+      persistsIdentifiers: false
+    ))
+
+    authState.storeLastUsedIdentifierType(.email)
+
+    #expect(LastUsedAuth.retrieveStoredIdentifierType(userDefaults: defaults) == nil)
   }
 
   @Test

--- a/Tests/UI/SignInFactorSelectionTests.swift
+++ b/Tests/UI/SignInFactorSelectionTests.swift
@@ -153,6 +153,65 @@ struct SignInFactorSelectionTests {
 
     #expect(signIn.startingFirstFactor?.strategy == .password)
   }
+
+  @Test
+  func resetPasswordFactorPrefersMatchingEmailCodeFactor() {
+    let signIn = SignIn(
+      id: "sign_in_123",
+      status: .needsFirstFactor,
+      identifier: "user@example.com",
+      supportedFirstFactors: [
+        Factor(
+          strategy: .resetPasswordPhoneCode,
+          phoneNumberId: "phone_123",
+          safeIdentifier: "+15555550100"
+        ),
+        Factor(
+          strategy: .resetPasswordEmailCode,
+          emailAddressId: "email_other",
+          safeIdentifier: "other@example.com"
+        ),
+        Factor(
+          strategy: .resetPasswordEmailCode,
+          emailAddressId: "email_123",
+          safeIdentifier: "user@example.com"
+        ),
+      ]
+    )
+
+    let factor = signIn.resetPasswordFactor
+
+    #expect(factor?.strategy == .resetPasswordEmailCode)
+    #expect(factor?.emailAddressId == "email_123")
+  }
+
+  @Test
+  func alternativeFirstFactorsKeepEmailCodeAndFilterResetPasswordFactors() {
+    let passwordFactor = Factor(strategy: .password)
+    let signIn = SignIn(
+      id: "sign_in_123",
+      status: .needsFirstFactor,
+      identifier: "user@example.com",
+      supportedFirstFactors: [
+        passwordFactor,
+        Factor(
+          strategy: .emailCode,
+          emailAddressId: "email_123",
+          safeIdentifier: "user@example.com"
+        ),
+        Factor(
+          strategy: .resetPasswordEmailCode,
+          emailAddressId: "email_123",
+          safeIdentifier: "user@example.com"
+        ),
+      ]
+    )
+
+    let factors = signIn.alternativeFirstFactors(currentFactor: passwordFactor)
+
+    #expect(factors.map(\.strategy) == [.emailCode])
+    #expect(factors.first?.emailAddressId == "email_123")
+  }
 }
 
 #endif

--- a/Tests/UI/SignInFactorSelectionTests.swift
+++ b/Tests/UI/SignInFactorSelectionTests.swift
@@ -212,6 +212,47 @@ struct SignInFactorSelectionTests {
     #expect(factors.map(\.strategy) == [.emailCode])
     #expect(factors.first?.emailAddressId == "email_123")
   }
+
+  @Test
+  func alternativeFirstFactorsKeepCodeAlternativesAndFilterNonInlineMethods() {
+    let passwordFactor = Factor(strategy: .password)
+    let signIn = SignIn(
+      id: "sign_in_123",
+      status: .needsFirstFactor,
+      identifier: "user@example.com",
+      supportedFirstFactors: [
+        passwordFactor,
+        Factor(
+          strategy: .emailCode,
+          emailAddressId: "email_123",
+          safeIdentifier: "user@example.com"
+        ),
+        Factor(
+          strategy: .phoneCode,
+          phoneNumberId: "phone_123",
+          safeIdentifier: "+15555550100"
+        ),
+        Factor(
+          strategy: .resetPasswordEmailCode,
+          emailAddressId: "email_123",
+          safeIdentifier: "user@example.com"
+        ),
+        Factor(strategy: .oauth(.google)),
+        Factor(strategy: .enterpriseSSO),
+        Factor(strategy: .saml),
+      ]
+    )
+
+    let strategies = signIn.alternativeFirstFactors(currentFactor: passwordFactor).map(\.strategy)
+
+    #expect(strategies.contains(.emailCode))
+    #expect(strategies.contains(.phoneCode))
+    #expect(!strategies.contains(.password))
+    #expect(!strategies.contains(.resetPasswordEmailCode))
+    #expect(!strategies.contains(.oauth(.google)))
+    #expect(!strategies.contains(.enterpriseSSO))
+    #expect(!strategies.contains(.saml))
+  }
 }
 
 #endif

--- a/scripts/check-e2e-hooks.sh
+++ b/scripts/check-e2e-hooks.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+failure_count=0
+
+report_error() {
+  local file="$1"
+  local line="$2"
+  local message="$3"
+
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    printf '::error file=%s,line=%s::%s\n' "$file" "$line" "$message"
+  else
+    printf 'error: %s:%s: %s\n' "$file" "$line" "$message" >&2
+  fi
+
+  failure_count=$((failure_count + 1))
+}
+
+scan_sources_for() {
+  local needle="$1"
+
+  find Sources -type f -name '*.swift' -print0 | xargs -0 grep -nF "$needle" 2>/dev/null || true
+}
+
+is_allowed_e2e_usage_file() {
+  case "$1" in
+    Sources/ClerkKitUI/Components/Auth/SignIn/SignInFactorOnePasswordView.swift | \
+      Sources/ClerkKitUI/Components/Auth/SignUp/SignUpCollectFieldView.swift | \
+      Sources/ClerkKitUI/Components/UserProfile/UserProfileChangePasswordView.swift | \
+      Sources/ClerkKitUI/Extensions/View+HiddenTextField.swift)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+reviewed_usage_count=0
+expected_reviewed_usage_count=6
+
+while IFS=: read -r file line _; do
+  if [ -z "$file" ]; then
+    continue
+  fi
+
+  if is_allowed_e2e_usage_file "$file"; then
+    reviewed_usage_count=$((reviewed_usage_count + 1))
+  else
+    report_error "$file" "$line" "Unexpected ClerkE2EEnvironment usage. E2E hooks must stay limited to reviewed OS automation workarounds."
+  fi
+done < <(scan_sources_for "ClerkE2EEnvironment.isEnabled")
+
+if [ "$reviewed_usage_count" -ne "$expected_reviewed_usage_count" ]; then
+  report_error "scripts/check-e2e-hooks.sh" 1 "Expected $expected_reviewed_usage_count reviewed ClerkE2EEnvironment call sites, found $reviewed_usage_count. Update this allowlist only after reviewing the E2E-only behavior."
+fi
+
+while IFS=: read -r file line _; do
+  if [ -z "$file" ]; then
+    continue
+  fi
+
+  if [ "$file" != "Sources/ClerkKitUI/Common/ClerkE2EEnvironment.swift" ]; then
+    report_error "$file" "$line" "Read CLERK_E2E_MODE through ClerkE2EEnvironment instead of directly accessing the environment."
+  fi
+done < <(scan_sources_for "CLERK_E2E_MODE")
+
+while IFS=: read -r file line _; do
+  if [ -z "$file" ]; then
+    continue
+  fi
+
+  if [ "$file" != "Sources/ClerkKitUI/Common/ClerkE2EEnvironment.swift" ]; then
+    report_error "$file" "$line" "Direct CLERK_E2E_MODE environment access is not allowed outside ClerkE2EEnvironment."
+  fi
+done < <(scan_sources_for 'ProcessInfo.processInfo.environment["CLERK_E2E_MODE"]')
+
+if [ "$failure_count" -gt 0 ]; then
+  printf 'E2E hook check failed with %s issue(s).\n' "$failure_count" >&2
+  exit 1
+fi
+
+printf 'E2E hook check passed: %s reviewed call sites.\n' "$reviewed_usage_count"

--- a/scripts/check-e2e-phone-numbers.sh
+++ b/scripts/check-e2e-phone-numbers.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+APPROVED_RANGE = 5_555_550_100..5_555_550_199
+E2E_SOURCES = [
+  "Examples/E2EHost",
+].freeze
+
+failure_count = 0
+
+def report_error(file, line, message)
+  if ENV["GITHUB_ACTIONS"]
+    puts "::error file=#{file},line=#{line}::#{message}"
+  else
+    warn "error: #{file}:#{line}: #{message}"
+  end
+end
+
+def normalized_phone_digits(value)
+  digits = value.gsub(/\D/, "")
+  digits = digits[1..] if digits.length == 11 && digits.start_with?("1")
+  digits
+end
+
+Dir.glob(E2E_SOURCES.map { |source| File.join(source, "**/*.swift") }).each do |file|
+  File.readlines(file, chomp: true).each_with_index do |line, index|
+    line.scan(/\+?1?555555\d{4}/).each do |candidate|
+      digits = normalized_phone_digits(candidate)
+      next if digits.length == 10 && APPROVED_RANGE.cover?(digits.to_i)
+
+      report_error(
+        file,
+        index + 1,
+        "E2E phone number '#{candidate}' is outside the approved 5555550100...5555550199 test-number range."
+      )
+      failure_count += 1
+    end
+  end
+end
+
+if failure_count.positive?
+  warn "E2E phone-number check failed with #{failure_count} issue(s)."
+  exit 1
+end
+
+puts "E2E phone-number check passed: approved range 5555550100...5555550199."

--- a/scripts/check-e2e-phone-numbers.sh
+++ b/scripts/check-e2e-phone-numbers.sh
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 APPROVED_RANGE = 5_555_550_100..5_555_550_199
+PHONE_NUMBER_PATTERN = /(?<!\d)\+?1?(?:[\s().-]*)555(?:[\s().-]*)555(?:[\s().-]*)\d{4}(?!\d)/
 E2E_SOURCES = [
   "Examples/E2EHost",
 ].freeze
@@ -24,7 +25,7 @@ end
 
 Dir.glob(E2E_SOURCES.map { |source| File.join(source, "**/*.swift") }).each do |file|
   File.readlines(file, chomp: true).each_with_index do |line, index|
-    line.scan(/\+?1?555555\d{4}/).each do |candidate|
+    line.scan(PHONE_NUMBER_PATTERN).each do |candidate|
       digits = normalized_phone_digits(candidate)
       next if digits.length == 10 && APPROVED_RANGE.cover?(digits.to_i)
 

--- a/scripts/check-e2e-selectors.sh
+++ b/scripts/check-e2e-selectors.sh
@@ -16,6 +16,18 @@ VISIBLE_TEXT_SELECTOR_EXCEPTIONS = Set[
   "Cancel",
 ].freeze
 
+VISIBLE_TEXT_SELECTOR_QUERIES = %w[
+  alerts
+  buttons
+  cells
+  images
+  otherElements
+  secureTextFields
+  staticTexts
+  switches
+  textFields
+].freeze
+
 SelectorLiteral = Struct.new(:value, :file, :line, keyword_init: true)
 
 def source_lines(relative_path)
@@ -78,7 +90,7 @@ quoted_literals(E2E_TEST_SOURCE, prefix: "e2e.").each do |literal|
 end
 
 source_lines(E2E_TEST_SOURCE).each_with_index do |line, index|
-  line.scan(/app\.(?:buttons|staticTexts|textFields|secureTextFields)\["([^"]+)"\]/).flatten.each do |visible_text|
+  line.scan(/app\.(?:#{VISIBLE_TEXT_SELECTOR_QUERIES.join("|")})\["([^"]+)"\]/).flatten.each do |visible_text|
     next if VISIBLE_TEXT_SELECTOR_EXCEPTIONS.include?(visible_text)
 
     failures << [

--- a/scripts/check-e2e-selectors.sh
+++ b/scripts/check-e2e-selectors.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "set"
+
+ROOT = File.expand_path("..", __dir__)
+PRODUCT_IDENTIFIER_SOURCE = "Sources/ClerkKitUI/Components/Auth/ClerkAccessibilityIdentifiers.swift"
+HOST_IDENTIFIER_SOURCE = "Examples/E2EHost/E2EHost/E2EIdentifiers.swift"
+E2E_TEST_SOURCE = "Examples/E2EHost/E2EHostE2ETests/E2EHostE2ETests.swift"
+
+NON_SELECTOR_CLERK_LITERALS = Set[
+  "clerk.dev",
+].freeze
+
+VISIBLE_TEXT_SELECTOR_EXCEPTIONS = Set[
+  "Cancel",
+].freeze
+
+SelectorLiteral = Struct.new(:value, :file, :line, keyword_init: true)
+
+def source_lines(relative_path)
+  File.readlines(File.join(ROOT, relative_path), chomp: true)
+end
+
+def quoted_literals(relative_path, prefix:)
+  source_lines(relative_path).each_with_index.flat_map do |line, index|
+    line.scan(/"((?:\\.|[^"\\])*)"/).flatten.select { |value| value.start_with?(prefix) }.map do |value|
+      SelectorLiteral.new(value: value, file: relative_path, line: index + 1)
+    end
+  end
+end
+
+def literal_pattern(value)
+  pieces = value.split(/\\\([^)]*\)/, -1)
+  Regexp.new("\\A#{pieces.map { |piece| Regexp.escape(piece) }.join(".+")}\\z")
+end
+
+def backed_by_contract?(value, exact_values, patterns)
+  exact_values.include?(value) || patterns.any? { |pattern| pattern.match?(value) }
+end
+
+def report_error(file, line, message)
+  if ENV["GITHUB_ACTIONS"]
+    puts "::error file=#{file},line=#{line}::#{message}"
+  else
+    warn "error: #{file}:#{line}: #{message}"
+  end
+end
+
+product_literals = quoted_literals(PRODUCT_IDENTIFIER_SOURCE, prefix: "clerk.")
+product_exact_values = product_literals.map(&:value).to_set
+product_patterns = product_literals.map { |literal| literal_pattern(literal.value) }
+
+host_literals = quoted_literals(HOST_IDENTIFIER_SOURCE, prefix: "e2e.")
+host_exact_values = host_literals.map(&:value).to_set
+
+failures = []
+
+quoted_literals(E2E_TEST_SOURCE, prefix: "clerk.").each do |literal|
+  next if NON_SELECTOR_CLERK_LITERALS.include?(literal.value)
+  next if backed_by_contract?(literal.value, product_exact_values, product_patterns)
+
+  failures << [
+    literal.file,
+    literal.line,
+    "E2E product selector '#{literal.value}' is not backed by #{PRODUCT_IDENTIFIER_SOURCE}.",
+  ]
+end
+
+quoted_literals(E2E_TEST_SOURCE, prefix: "e2e.").each do |literal|
+  next if host_exact_values.include?(literal.value)
+
+  failures << [
+    literal.file,
+    literal.line,
+    "E2EHost selector '#{literal.value}' is not backed by #{HOST_IDENTIFIER_SOURCE}.",
+  ]
+end
+
+source_lines(E2E_TEST_SOURCE).each_with_index do |line, index|
+  line.scan(/app\.(?:buttons|staticTexts|textFields|secureTextFields)\["([^"]+)"\]/).flatten.each do |visible_text|
+    next if VISIBLE_TEXT_SELECTOR_EXCEPTIONS.include?(visible_text)
+
+    failures << [
+      E2E_TEST_SOURCE,
+      index + 1,
+      "Use an accessibility identifier instead of visible text selector '#{visible_text}', or add a reviewed exception.",
+    ]
+  end
+end
+
+failures.each do |file, line, message|
+  report_error(file, line, message)
+end
+
+if failures.any?
+  warn "E2E selector check failed with #{failures.count} issue(s)."
+  exit 1
+end
+
+puts "E2E selector check passed: #{product_literals.count} product selectors, #{host_literals.count} E2EHost selectors."

--- a/scripts/run-e2e-xcodebuild.sh
+++ b/scripts/run-e2e-xcodebuild.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -eq 0 ]]; then
+  echo "Usage: scripts/run-e2e-xcodebuild.sh <xcodebuild command...>" >&2
+  exit 64
+fi
+
+attempts="${E2E_XCODEBUILD_ATTEMPTS:-1}"
+if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [[ "$attempts" -lt 1 ]]; then
+  attempts=1
+fi
+
+log_path="${E2E_XCODEBUILD_LOG_PATH:-}"
+if [[ -z "$log_path" ]]; then
+  if [[ -n "${E2E_RESULT_BUNDLE_PATH:-}" ]]; then
+    log_path="${E2E_RESULT_BUNDLE_PATH%.xcresult}.xcodebuild.log"
+  else
+    log_path="build/reports/E2EHost.xcodebuild.log"
+  fi
+fi
+
+mkdir -p "$(dirname "$log_path")"
+
+attempt_log_path() {
+  local path="$1"
+  local attempt="$2"
+
+  if [[ "$path" == *.* ]]; then
+    printf "%s-attempt-%s.%s" "${path%.*}" "$attempt" "${path##*.}"
+  else
+    printf "%s-attempt-%s" "$path" "$attempt"
+  fi
+}
+
+log_has_test_assertion_failure() {
+  local log_file="$1"
+
+  grep -Eiq \
+    "Test Case '.*' failed|Failing tests:|Assertion Failure:|XCTFail|XCTAssert" \
+    "$log_file"
+}
+
+log_has_known_infrastructure_failure() {
+  local log_file="$1"
+
+  grep -Eiq \
+    "Failed to start test runner|test runner failed to initialize|Test runner never began executing tests|Lost connection to test manager|Early unexpected exit.*bootstrapping|DTXProxyChannel|iOSSimulatorErrorDomain|CoreSimulator.*(failed|timed out|unavailable|crashed)|Timed out waiting for.*boot|Unable to boot|Failed to boot|Failed to install.*test runner|Failed to launch.*test runner|result bundle.*(failed|could not|unable)" \
+    "$log_file"
+}
+
+prepare_simulator_for_retry() {
+  local simulator_id="${E2E_SIMULATOR_ID:-}"
+
+  if [[ -z "$simulator_id" ]]; then
+    return
+  fi
+
+  echo "Preparing simulator $simulator_id before retry."
+  xcrun simctl shutdown "$simulator_id" >/dev/null 2>&1 || true
+  xcrun simctl boot "$simulator_id" >/dev/null 2>&1 || true
+  xcrun simctl bootstatus "$simulator_id" -b >/dev/null 2>&1 || true
+}
+
+attempt=1
+while true; do
+  attempt_log="$(attempt_log_path "$log_path" "$attempt")"
+  echo "Running E2E xcodebuild attempt $attempt/$attempts..."
+
+  set +e
+  "$@" 2>&1 | tee "$attempt_log"
+  status=${PIPESTATUS[0]}
+  set -e
+
+  cp "$attempt_log" "$log_path"
+
+  if [[ "$status" -eq 0 ]]; then
+    exit 0
+  fi
+
+  if [[ "$attempt" -lt "$attempts" ]] &&
+    log_has_known_infrastructure_failure "$attempt_log" &&
+    ! log_has_test_assertion_failure "$attempt_log"; then
+    echo "E2E xcodebuild failed with a known infrastructure signature; retrying."
+    if [[ -n "${E2E_RESULT_BUNDLE_PATH:-}" ]]; then
+      rm -rf "$E2E_RESULT_BUNDLE_PATH"
+    fi
+    prepare_simulator_for_retry
+    attempt=$((attempt + 1))
+    continue
+  fi
+
+  if [[ "$attempt" -lt "$attempts" ]]; then
+    echo "E2E xcodebuild failed without a retryable infrastructure signature; not retrying."
+  fi
+
+  exit "$status"
+done

--- a/scripts/run-e2e-xcodebuild.sh
+++ b/scripts/run-e2e-xcodebuild.sh
@@ -56,7 +56,7 @@ log_has_known_infrastructure_failure() {
   local log_file="$1"
 
   grep -Eiq \
-    "Failed to start test runner|test runner failed to initialize|Test runner never began executing tests|Lost connection to test manager|Early unexpected exit.*bootstrapping|DTXProxyChannel|iOSSimulatorErrorDomain|CoreSimulator.*(failed|timed out|unavailable|crashed)|Timed out waiting for.*boot|Unable to boot|Failed to boot|Failed to install.*test runner|Failed to launch.*test runner|result bundle.*(failed|could not|unable)" \
+    "Failed to start test runner|test runner failed to initialize|Test runner never began executing tests|Lost connection to test manager|Early unexpected exit.*bootstrapping|DTXProxyChannel|iOSSimulatorErrorDomain|CoreSimulator.*(failed|timed out|unavailable|crashed)|Timed out waiting for.*boot|Unable to boot|Failed to boot|Failed to install.*test runner|Failed to launch.*test runner|result bundle.*(failed|could not|unable)|Asynchronous wait failed: Exceeded timeout.*Backend API request|HTTP load failed.*error code: -1200|failed to connect 3:-9816" \
     "$log_file"
 }
 

--- a/scripts/run-e2e-xcodebuild.sh
+++ b/scripts/run-e2e-xcodebuild.sh
@@ -60,6 +60,27 @@ log_has_known_infrastructure_failure() {
     "$log_file"
 }
 
+log_has_retryable_test_infrastructure_failure() {
+  local log_file="$1"
+
+  grep -Eiq \
+    "Asynchronous wait failed: Exceeded timeout.*Backend API request|HTTP load failed.*error code: -1200|failed to connect 3:-9816" \
+    "$log_file"
+}
+
+should_retry_attempt() {
+  local log_file="$1"
+
+  log_has_known_infrastructure_failure "$log_file" || return 1
+
+  if log_has_test_assertion_failure "$log_file" &&
+    ! log_has_retryable_test_infrastructure_failure "$log_file"; then
+    return 1
+  fi
+
+  return 0
+}
+
 prepare_simulator_for_retry() {
   local simulator_id="${E2E_SIMULATOR_ID:-}"
 
@@ -90,8 +111,7 @@ while true; do
   fi
 
   if [[ "$attempt" -lt "$attempts" ]] &&
-    log_has_known_infrastructure_failure "$attempt_log" &&
-    ! log_has_test_assertion_failure "$attempt_log"; then
+    should_retry_attempt "$attempt_log"; then
     echo "E2E xcodebuild failed with a known infrastructure signature; retrying."
     if [[ -n "${E2E_RESULT_BUNDLE_PATH:-}" ]]; then
       rm -rf "$E2E_RESULT_BUNDLE_PATH"

--- a/scripts/run-e2e-xcodebuild.sh
+++ b/scripts/run-e2e-xcodebuild.sh
@@ -25,11 +25,22 @@ mkdir -p "$(dirname "$log_path")"
 attempt_log_path() {
   local path="$1"
   local attempt="$2"
+  local directory
+  local filename
 
-  if [[ "$path" == *.* ]]; then
-    printf "%s-attempt-%s.%s" "${path%.*}" "$attempt" "${path##*.}"
+  directory="$(dirname "$path")"
+  filename="$(basename "$path")"
+
+  if [[ "$filename" == *.* ]]; then
+    filename="${filename%.*}-attempt-${attempt}.${filename##*.}"
   else
-    printf "%s-attempt-%s" "$path" "$attempt"
+    filename="${filename}-attempt-${attempt}"
+  fi
+
+  if [[ "$directory" == "." ]]; then
+    printf "%s" "$filename"
+  else
+    printf "%s/%s" "$directory" "$filename"
   fi
 }
 

--- a/scripts/test-run-e2e-xcodebuild.sh
+++ b/scripts/test-run-e2e-xcodebuild.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+runner="$script_dir/run-e2e-xcodebuild.sh"
+tmpdir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+assert_file_exists() {
+  local path="$1"
+  [[ -f "$path" ]] || fail "expected file to exist: $path"
+}
+
+assert_file_missing() {
+  local path="$1"
+  [[ ! -e "$path" ]] || fail "expected file to be missing: $path"
+}
+
+assert_contains() {
+  local path="$1"
+  local pattern="$2"
+  grep -Eq "$pattern" "$path" || fail "expected $path to contain pattern: $pattern"
+}
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  [[ "$expected" == "$actual" ]] || fail "expected '$expected', got '$actual'"
+}
+
+write_fake_xcrun() {
+  mkdir -p "$tmpdir/bin"
+  cat > "$tmpdir/bin/xcrun" <<'SH'
+#!/usr/bin/env bash
+echo "$*" >> "${FAKE_XCRUN_LOG:?}"
+exit 0
+SH
+  chmod +x "$tmpdir/bin/xcrun"
+}
+
+write_success_command() {
+  local path="$1"
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+echo "xcodebuild completed"
+exit 0
+SH
+  chmod +x "$path"
+}
+
+write_assertion_failure_command() {
+  local path="$1"
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+count="$(cat "${FAKE_COUNTER:?}" 2>/dev/null || echo 0)"
+count="$((count + 1))"
+echo "$count" > "$FAKE_COUNTER"
+echo "Assertion Failure: product assertion failed"
+exit 42
+SH
+  chmod +x "$path"
+}
+
+write_infrastructure_flake_command() {
+  local path="$1"
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+count="$(cat "${FAKE_COUNTER:?}" 2>/dev/null || echo 0)"
+count="$((count + 1))"
+echo "$count" > "$FAKE_COUNTER"
+
+if [[ "$count" -eq 1 ]]; then
+  echo "Lost connection to test manager"
+  exit 42
+fi
+
+echo "xcodebuild completed after retry"
+exit 0
+SH
+  chmod +x "$path"
+}
+
+write_persistent_infrastructure_failure_command() {
+  local path="$1"
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+count="$(cat "${FAKE_COUNTER:?}" 2>/dev/null || echo 0)"
+count="$((count + 1))"
+echo "$count" > "$FAKE_COUNTER"
+echo "CoreSimulator failed to boot"
+exit 42
+SH
+  chmod +x "$path"
+}
+
+run_success_log_path_test() {
+  local command="$tmpdir/success.sh"
+  local output="$tmpdir/success.out"
+  local log_path="$tmpdir/logs/E2EHost.xcodebuild.log"
+
+  write_success_command "$command"
+
+  env E2E_XCODEBUILD_LOG_PATH="$log_path" "$runner" "$command" > "$output" 2>&1
+
+  assert_file_exists "$tmpdir/logs/E2EHost.xcodebuild-attempt-1.log"
+  assert_file_exists "$log_path"
+  assert_contains "$log_path" "xcodebuild completed"
+}
+
+run_infrastructure_retry_test() {
+  local command="$tmpdir/infra-flake.sh"
+  local output="$tmpdir/infra-flake.out"
+  local log_path="$tmpdir/logs/infra.log"
+  local counter="$tmpdir/infra-counter"
+  local xcrun_log="$tmpdir/xcrun.log"
+
+  write_fake_xcrun
+  write_infrastructure_flake_command "$command"
+
+  env \
+    PATH="$tmpdir/bin:$PATH" \
+    FAKE_COUNTER="$counter" \
+    FAKE_XCRUN_LOG="$xcrun_log" \
+    E2E_XCODEBUILD_ATTEMPTS=2 \
+    E2E_XCODEBUILD_LOG_PATH="$log_path" \
+    E2E_RESULT_BUNDLE_PATH="$tmpdir/result.xcresult" \
+    E2E_SIMULATOR_ID="SIM-123" \
+    "$runner" "$command" > "$output" 2>&1
+
+  assert_equals "2" "$(cat "$counter")"
+  assert_contains "$output" "known infrastructure signature; retrying"
+  assert_contains "$xcrun_log" "simctl shutdown SIM-123"
+  assert_contains "$xcrun_log" "simctl boot SIM-123"
+  assert_contains "$xcrun_log" "simctl bootstatus SIM-123 -b"
+  assert_file_exists "$tmpdir/logs/infra-attempt-1.log"
+  assert_file_exists "$tmpdir/logs/infra-attempt-2.log"
+}
+
+run_assertion_failure_no_retry_test() {
+  local command="$tmpdir/assertion-failure.sh"
+  local output="$tmpdir/assertion-failure.out"
+  local counter="$tmpdir/assertion-counter"
+  local status
+
+  write_assertion_failure_command "$command"
+
+  set +e
+  env \
+    FAKE_COUNTER="$counter" \
+    E2E_XCODEBUILD_ATTEMPTS=2 \
+    E2E_XCODEBUILD_LOG_PATH="$tmpdir/logs/assertion.log" \
+    "$runner" "$command" > "$output" 2>&1
+  status="$?"
+  set -e
+
+  assert_equals "42" "$status"
+  assert_equals "1" "$(cat "$counter")"
+  assert_contains "$output" "failed without a retryable infrastructure signature"
+  assert_file_missing "$tmpdir/logs/assertion-attempt-2.log"
+}
+
+run_invalid_attempts_fallback_test() {
+  local command="$tmpdir/persistent-infra.sh"
+  local output="$tmpdir/invalid-attempts.out"
+  local counter="$tmpdir/invalid-attempts-counter"
+  local status
+
+  write_persistent_infrastructure_failure_command "$command"
+
+  set +e
+  env \
+    FAKE_COUNTER="$counter" \
+    E2E_XCODEBUILD_ATTEMPTS=invalid \
+    E2E_XCODEBUILD_LOG_PATH="$tmpdir/logs/invalid.log" \
+    "$runner" "$command" > "$output" 2>&1
+  status="$?"
+  set -e
+
+  assert_equals "42" "$status"
+  assert_equals "1" "$(cat "$counter")"
+  assert_contains "$output" "Running E2E xcodebuild attempt 1/1"
+  assert_file_missing "$tmpdir/logs/invalid-attempt-2.log"
+}
+
+run_success_log_path_test
+run_infrastructure_retry_test
+run_assertion_failure_no_retry_test
+run_invalid_attempts_fallback_test
+
+echo "run-e2e-xcodebuild tests passed."

--- a/scripts/test-run-e2e-xcodebuild.sh
+++ b/scripts/test-run-e2e-xcodebuild.sh
@@ -210,6 +210,9 @@ run_infrastructure_signature_matrix_test() {
     "Failed to launch XCTest test runner"
     "result bundle could not be written"
     "result bundle unable to open"
+    "Asynchronous wait failed: Exceeded timeout of 30 seconds, with unfulfilled expectations: \"Backend API request\"."
+    "HTTP load failed, 0/0 bytes (error code: -1200 [3:-9816])"
+    "Connection 1: failed to connect 3:-9816, reason -1"
   )
   local index=0
 

--- a/scripts/test-run-e2e-xcodebuild.sh
+++ b/scripts/test-run-e2e-xcodebuild.sh
@@ -129,6 +129,35 @@ run_success_log_path_test() {
   assert_contains "$log_path" "xcodebuild completed"
 }
 
+run_success_log_path_without_extension_test() {
+  local command="$tmpdir/success-no-extension.sh"
+  local output="$tmpdir/success-no-extension.out"
+  local log_path="$tmpdir/logs/E2EHost"
+
+  write_success_command "$command"
+
+  env E2E_XCODEBUILD_LOG_PATH="$log_path" "$runner" "$command" > "$output" 2>&1
+
+  assert_file_exists "$tmpdir/logs/E2EHost-attempt-1"
+  assert_file_exists "$log_path"
+  assert_contains "$log_path" "xcodebuild completed"
+}
+
+run_success_log_path_with_dotted_directory_test() {
+  local command="$tmpdir/success-dotted-directory.sh"
+  local output="$tmpdir/success-dotted-directory.out"
+  local log_path="$tmpdir/logs.v2/E2EHost"
+
+  write_success_command "$command"
+
+  env E2E_XCODEBUILD_LOG_PATH="$log_path" "$runner" "$command" > "$output" 2>&1
+
+  assert_file_exists "$tmpdir/logs.v2/E2EHost-attempt-1"
+  assert_file_missing "$tmpdir/logs-attempt-1.v2/E2EHost"
+  assert_file_exists "$log_path"
+  assert_contains "$log_path" "xcodebuild completed"
+}
+
 run_infrastructure_retry_test() {
   local command="$tmpdir/infra-flake.sh"
   local output="$tmpdir/infra-flake.out"
@@ -274,6 +303,8 @@ run_invalid_attempts_fallback_test() {
 }
 
 run_success_log_path_test
+run_success_log_path_without_extension_test
+run_success_log_path_with_dotted_directory_test
 run_infrastructure_retry_test
 run_infrastructure_signature_matrix_test
 run_assertion_failure_no_retry_test

--- a/scripts/test-run-e2e-xcodebuild.sh
+++ b/scripts/test-run-e2e-xcodebuild.sh
@@ -79,7 +79,7 @@ count="$((count + 1))"
 echo "$count" > "$FAKE_COUNTER"
 
 if [[ "$count" -eq 1 ]]; then
-  echo "Lost connection to test manager"
+  echo "${FAKE_FAILURE_MESSAGE:-Lost connection to test manager}"
   exit 42
 fi
 
@@ -97,6 +97,19 @@ count="$(cat "${FAKE_COUNTER:?}" 2>/dev/null || echo 0)"
 count="$((count + 1))"
 echo "$count" > "$FAKE_COUNTER"
 echo "CoreSimulator failed to boot"
+exit 42
+SH
+  chmod +x "$path"
+}
+
+write_unclassified_failure_command() {
+  local path="$1"
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+count="$(cat "${FAKE_COUNTER:?}" 2>/dev/null || echo 0)"
+count="$((count + 1))"
+echo "$count" > "$FAKE_COUNTER"
+echo "The build failed for an unrelated reason"
 exit 42
 SH
   chmod +x "$path"
@@ -122,9 +135,12 @@ run_infrastructure_retry_test() {
   local log_path="$tmpdir/logs/infra.log"
   local counter="$tmpdir/infra-counter"
   local xcrun_log="$tmpdir/xcrun.log"
+  local result_bundle_path="$tmpdir/result.xcresult"
 
   write_fake_xcrun
   write_infrastructure_flake_command "$command"
+  mkdir -p "$result_bundle_path"
+  touch "$result_bundle_path/Info.plist"
 
   env \
     PATH="$tmpdir/bin:$PATH" \
@@ -132,7 +148,7 @@ run_infrastructure_retry_test() {
     FAKE_XCRUN_LOG="$xcrun_log" \
     E2E_XCODEBUILD_ATTEMPTS=2 \
     E2E_XCODEBUILD_LOG_PATH="$log_path" \
-    E2E_RESULT_BUNDLE_PATH="$tmpdir/result.xcresult" \
+    E2E_RESULT_BUNDLE_PATH="$result_bundle_path" \
     E2E_SIMULATOR_ID="SIM-123" \
     "$runner" "$command" > "$output" 2>&1
 
@@ -143,6 +159,49 @@ run_infrastructure_retry_test() {
   assert_contains "$xcrun_log" "simctl bootstatus SIM-123 -b"
   assert_file_exists "$tmpdir/logs/infra-attempt-1.log"
   assert_file_exists "$tmpdir/logs/infra-attempt-2.log"
+  assert_file_missing "$result_bundle_path"
+}
+
+run_infrastructure_signature_matrix_test() {
+  local signatures=(
+    "Failed to start test runner"
+    "test runner failed to initialize"
+    "Test runner never began executing tests"
+    "Lost connection to test manager"
+    "Early unexpected exit while bootstrapping"
+    "DTXProxyChannel disconnected"
+    "iOSSimulatorErrorDomain returned code 146"
+    "CoreSimulator timed out"
+    "CoreSimulator unavailable"
+    "CoreSimulator crashed"
+    "Timed out waiting for device to boot"
+    "Unable to boot simulator"
+    "Failed to boot simulator"
+    "Failed to install XCTest test runner"
+    "Failed to launch XCTest test runner"
+    "result bundle could not be written"
+    "result bundle unable to open"
+  )
+  local index=0
+
+  for signature in "${signatures[@]}"; do
+    index="$((index + 1))"
+    local command="$tmpdir/infra-signature-$index.sh"
+    local output="$tmpdir/infra-signature-$index.out"
+    local counter="$tmpdir/infra-signature-$index-counter"
+
+    write_infrastructure_flake_command "$command"
+
+    env \
+      FAKE_COUNTER="$counter" \
+      FAKE_FAILURE_MESSAGE="$signature" \
+      E2E_XCODEBUILD_ATTEMPTS=2 \
+      E2E_XCODEBUILD_LOG_PATH="$tmpdir/logs/infra-signature-$index.log" \
+      "$runner" "$command" > "$output" 2>&1
+
+    assert_equals "2" "$(cat "$counter")"
+    assert_contains "$output" "known infrastructure signature; retrying"
+  done
 }
 
 run_assertion_failure_no_retry_test() {
@@ -166,6 +225,29 @@ run_assertion_failure_no_retry_test() {
   assert_equals "1" "$(cat "$counter")"
   assert_contains "$output" "failed without a retryable infrastructure signature"
   assert_file_missing "$tmpdir/logs/assertion-attempt-2.log"
+}
+
+run_unclassified_failure_no_retry_test() {
+  local command="$tmpdir/unclassified-failure.sh"
+  local output="$tmpdir/unclassified-failure.out"
+  local counter="$tmpdir/unclassified-counter"
+  local status
+
+  write_unclassified_failure_command "$command"
+
+  set +e
+  env \
+    FAKE_COUNTER="$counter" \
+    E2E_XCODEBUILD_ATTEMPTS=2 \
+    E2E_XCODEBUILD_LOG_PATH="$tmpdir/logs/unclassified.log" \
+    "$runner" "$command" > "$output" 2>&1
+  status="$?"
+  set -e
+
+  assert_equals "42" "$status"
+  assert_equals "1" "$(cat "$counter")"
+  assert_contains "$output" "failed without a retryable infrastructure signature"
+  assert_file_missing "$tmpdir/logs/unclassified-attempt-2.log"
 }
 
 run_invalid_attempts_fallback_test() {
@@ -193,7 +275,9 @@ run_invalid_attempts_fallback_test() {
 
 run_success_log_path_test
 run_infrastructure_retry_test
+run_infrastructure_signature_matrix_test
 run_assertion_failure_no_retry_test
+run_unclassified_failure_no_retry_test
 run_invalid_attempts_fallback_test
 
 echo "run-e2e-xcodebuild tests passed."

--- a/scripts/test-run-e2e-xcodebuild.sh
+++ b/scripts/test-run-e2e-xcodebuild.sh
@@ -89,6 +89,28 @@ SH
   chmod +x "$path"
 }
 
+write_backend_api_infrastructure_flake_command() {
+  local path="$1"
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+count="$(cat "${FAKE_COUNTER:?}" 2>/dev/null || echo 0)"
+count="$((count + 1))"
+echo "$count" > "$FAKE_COUNTER"
+
+if [[ "$count" -eq 1 ]]; then
+  echo "<unknown>:0: error: -[E2EHostE2ETests.E2EHostE2ETests testPhoneCodeSignUpThenPhoneCodeSignIn] : Asynchronous wait failed: Exceeded timeout of 30 seconds, with unfulfilled expectations: \"Backend API request\"."
+  echo "Test Case '-[E2EHostE2ETests.E2EHostE2ETests testPhoneCodeSignUpThenPhoneCodeSignIn]' failed (31.334 seconds)."
+  echo "Failing tests:"
+  echo "HTTP load failed, 0/0 bytes (error code: -1200 [3:-9816])"
+  exit 42
+fi
+
+echo "xcodebuild completed after backend API retry"
+exit 0
+SH
+  chmod +x "$path"
+}
+
 write_persistent_infrastructure_failure_command() {
   local path="$1"
   cat > "$path" <<'SH'
@@ -236,6 +258,24 @@ run_infrastructure_signature_matrix_test() {
   done
 }
 
+run_backend_api_test_failure_retry_test() {
+  local command="$tmpdir/backend-api-infra-flake.sh"
+  local output="$tmpdir/backend-api-infra-flake.out"
+  local counter="$tmpdir/backend-api-infra-counter"
+
+  write_backend_api_infrastructure_flake_command "$command"
+
+  env \
+    FAKE_COUNTER="$counter" \
+    E2E_XCODEBUILD_ATTEMPTS=2 \
+    E2E_XCODEBUILD_LOG_PATH="$tmpdir/logs/backend-api-infra.log" \
+    "$runner" "$command" > "$output" 2>&1
+
+  assert_equals "2" "$(cat "$counter")"
+  assert_contains "$output" "known infrastructure signature; retrying"
+  assert_file_exists "$tmpdir/logs/backend-api-infra-attempt-2.log"
+}
+
 run_assertion_failure_no_retry_test() {
   local command="$tmpdir/assertion-failure.sh"
   local output="$tmpdir/assertion-failure.out"
@@ -310,6 +350,7 @@ run_success_log_path_without_extension_test
 run_success_log_path_with_dotted_directory_test
 run_infrastructure_retry_test
 run_infrastructure_signature_matrix_test
+run_backend_api_test_failure_retry_test
 run_assertion_failure_no_retry_test
 run_unclassified_failure_no_retry_test
 run_invalid_attempts_fallback_test

--- a/scripts/validate-e2e-test-instances.sh
+++ b/scripts/validate-e2e-test-instances.sh
@@ -154,6 +154,11 @@ REQUIREMENTS_BY_KEY_NAME = {
   ],
 }.freeze
 
+SECRET_KEY_REQUIRED_KEY_NAMES = [
+  "auth-phone-code",
+  "session-task-reset-password",
+].freeze
+
 options = {
   keys_file: ".keys.json",
   timeout: 20,
@@ -275,7 +280,7 @@ key_names.each do |key_name|
     next
   end
 
-  if key_name == "session-task-reset-password" && blank?(secret_key_for(keys, key_name))
+  if SECRET_KEY_REQUIRED_KEY_NAMES.include?(key_name) && blank?(secret_key_for(keys, key_name))
     failures << "#{key_name}: missing secret key"
   end
 

--- a/scripts/validate-e2e-test-instances.sh
+++ b/scripts/validate-e2e-test-instances.sh
@@ -206,9 +206,13 @@ def publishable_key_for(keys, key_name, allow_global_env_override: false)
   key_entry(keys, key_name)["pk"].to_s.strip
 end
 
-def secret_key_for(keys, key_name)
+def secret_key_for(keys, key_name, allow_global_env_override: false)
   selected_key_name = ENV["CLERK_E2E_KEY_NAME"]
   if selected_key_name == key_name && !blank?(ENV["CLERK_E2E_SECRET_KEY"])
+    return ENV["CLERK_E2E_SECRET_KEY"].strip
+  end
+
+  if allow_global_env_override && blank?(selected_key_name) && !blank?(ENV["CLERK_E2E_SECRET_KEY"])
     return ENV["CLERK_E2E_SECRET_KEY"].strip
   end
 
@@ -229,7 +233,7 @@ def frontend_api_url_for(publishable_key)
   raise "publishable key does not decode to a frontend API host" if blank?(host)
 
   URI("https://#{host}")
-rescue KeyError, ArgumentError
+rescue KeyError, ArgumentError, IndexError
   raise "publishable key could not be decoded"
 end
 
@@ -282,7 +286,12 @@ key_names.each do |key_name|
     next
   end
 
-  if SECRET_KEY_REQUIRED_KEY_NAMES.include?(key_name) && blank?(secret_key_for(keys, key_name))
+  secret_key = secret_key_for(
+    keys,
+    key_name,
+    allow_global_env_override: key_names.length == 1
+  )
+  if SECRET_KEY_REQUIRED_KEY_NAMES.include?(key_name) && blank?(secret_key)
     failures << "#{key_name}: missing secret key"
   end
 

--- a/scripts/validate-e2e-test-instances.sh
+++ b/scripts/validate-e2e-test-instances.sh
@@ -9,11 +9,7 @@ require "uri"
 
 DEFAULT_KEY_NAMES = [
   "auth-email-code-password",
-  "auth-multi-methods",
   "auth-phone-code",
-  "auth-username-password-user-model",
-  "session-task-choose-organization",
-  "session-task-reset-password",
   "session-task-setup-mfa",
 ].freeze
 

--- a/scripts/validate-e2e-test-instances.sh
+++ b/scripts/validate-e2e-test-instances.sh
@@ -130,6 +130,7 @@ REQUIREMENTS_BY_KEY_NAME = {
   ],
   "auth-phone-code" => [
     require_first_factor("phone_number"),
+    require_delete_self,
   ],
   "auth-username-password-user-model" => [
     require_first_factor("username"),
@@ -151,6 +152,7 @@ REQUIREMENTS_BY_KEY_NAME = {
     require_first_factor("email_address"),
     require_second_factor("authenticator_app"),
     require_second_factor("phone_number"),
+    require_delete_self,
   ],
 }.freeze
 

--- a/scripts/validate-e2e-test-instances.sh
+++ b/scripts/validate-e2e-test-instances.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "base64"
+require "json"
+require "net/http"
+require "optparse"
+require "uri"
+
+DEFAULT_KEY_NAMES = [
+  "auth-email-code-password",
+  "auth-multi-methods",
+  "auth-phone-code",
+  "auth-username-password-user-model",
+  "session-task-choose-organization",
+  "session-task-reset-password",
+  "session-task-setup-mfa",
+].freeze
+
+Requirement = Struct.new(:description, :predicate, keyword_init: true)
+
+def requirement(description, &predicate)
+  Requirement.new(description: description, predicate: predicate)
+end
+
+def blank?(value)
+  value.nil? || value.to_s.strip.empty?
+end
+
+def attribute(environment, name)
+  environment.dig("user_settings", "attributes", name) || {}
+end
+
+def require_environment_shape
+  requirement("environment payload includes auth_config, user_settings, and display_config") do |environment|
+    environment["auth_config"].is_a?(Hash) &&
+      environment["user_settings"].is_a?(Hash) &&
+      environment["display_config"].is_a?(Hash)
+  end
+end
+
+def require_public_sign_up
+  requirement("public sign-up is enabled") do |environment|
+    environment.dig("user_settings", "sign_up", "mode") == "public"
+  end
+end
+
+def require_first_factor(name)
+  requirement("#{name} is enabled as a first factor") do |environment|
+    config = attribute(environment, name)
+    config["enabled"] == true && config["used_for_first_factor"] == true
+  end
+end
+
+def require_attribute_enabled(name)
+  requirement("#{name} is enabled") do |environment|
+    attribute(environment, name)["enabled"] == true
+  end
+end
+
+def require_attribute_required(name)
+  requirement("#{name} is required") do |environment|
+    config = attribute(environment, name)
+    config["enabled"] == true && config["required"] == true
+  end
+end
+
+def require_second_factor(name)
+  requirement("#{name} is enabled as a second factor") do |environment|
+    config = attribute(environment, name)
+    config["enabled"] == true && config["used_for_second_factor"] == true
+  end
+end
+
+def require_multi_session
+  requirement("multi-session mode is enabled") do |environment|
+    environment.dig("auth_config", "single_session_mode") == false
+  end
+end
+
+def require_delete_self
+  requirement("self-serve account deletion is enabled") do |environment|
+    environment.dig("user_settings", "actions", "delete_self") == true
+  end
+end
+
+def require_legal_consent
+  requirement("legal consent is enabled for sign-up") do |environment|
+    environment.dig("user_settings", "sign_up", "legal_consent_enabled") == true
+  end
+end
+
+def require_organizations
+  requirement("organizations are enabled") do |environment|
+    environment.dig("organization_settings", "enabled") == true
+  end
+end
+
+def require_force_organization_selection
+  requirement("force organization selection is enabled") do |environment|
+    environment.dig("organization_settings", "force_organization_selection") == true
+  end
+end
+
+def require_organization_creation
+  requirement("organization creation is enabled") do |environment|
+    environment.dig("organization_settings", "organization_creation_defaults", "enabled") == true
+  end
+end
+
+BASE_REQUIREMENTS = [
+  require_environment_shape,
+  require_public_sign_up,
+].freeze
+
+REQUIREMENTS_BY_KEY_NAME = {
+  "auth-email-code-password" => [
+    require_first_factor("email_address"),
+    require_attribute_enabled("password"),
+    require_delete_self,
+  ],
+  "auth-legal-consent" => [
+    require_first_factor("email_address"),
+    require_attribute_enabled("password"),
+    require_legal_consent,
+  ],
+  "auth-multi-methods" => [
+    require_first_factor("email_address"),
+    require_first_factor("phone_number"),
+    require_attribute_enabled("password"),
+    require_second_factor("authenticator_app"),
+    require_second_factor("phone_number"),
+    require_multi_session,
+  ],
+  "auth-phone-code" => [
+    require_first_factor("phone_number"),
+  ],
+  "auth-username-password-user-model" => [
+    require_first_factor("username"),
+    require_attribute_enabled("password"),
+    require_attribute_required("first_name"),
+    require_attribute_required("last_name"),
+  ],
+  "session-task-choose-organization" => [
+    require_first_factor("email_address"),
+    require_organizations,
+    require_force_organization_selection,
+    require_organization_creation,
+  ],
+  "session-task-reset-password" => [
+    require_first_factor("email_address"),
+    require_attribute_enabled("password"),
+  ],
+  "session-task-setup-mfa" => [
+    require_first_factor("email_address"),
+    require_second_factor("authenticator_app"),
+    require_second_factor("phone_number"),
+  ],
+}.freeze
+
+options = {
+  keys_file: ".keys.json",
+  timeout: 20,
+}
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: scripts/validate-e2e-test-instances.sh [options] [key-name ...]"
+  parser.on("--keys-file PATH", "Path to .keys.json") { |value| options[:keys_file] = value }
+  parser.on("--timeout SECONDS", Integer, "HTTP timeout per instance") { |value| options[:timeout] = value }
+end.parse!
+
+key_names = ARGV.empty? ? DEFAULT_KEY_NAMES : ARGV
+key_names = key_names.reject { |key_name| blank?(key_name) }.uniq
+
+if key_names.empty?
+  warn "No E2E key names were provided."
+  exit 1
+end
+
+keys = {}
+if File.exist?(options[:keys_file])
+  keys = JSON.parse(File.read(options[:keys_file]))
+elsif key_names.length > 1 || blank?(ENV["CLERK_E2E_PUBLISHABLE_KEY"])
+  warn "Missing #{options[:keys_file]}. Run make fetch-test-keys or provide CLERK_E2E_PUBLISHABLE_KEY for a single key."
+  exit 1
+end
+
+def key_entry(keys, key_name)
+  entry = keys[key_name]
+  entry.is_a?(Hash) ? entry : {}
+end
+
+def publishable_key_for(keys, key_name)
+  selected_key_name = ENV["CLERK_E2E_KEY_NAME"]
+  if (blank?(selected_key_name) || selected_key_name == key_name) && !blank?(ENV["CLERK_E2E_PUBLISHABLE_KEY"])
+    return ENV["CLERK_E2E_PUBLISHABLE_KEY"].strip
+  end
+
+  key_entry(keys, key_name)["pk"].to_s.strip
+end
+
+def secret_key_for(keys, key_name)
+  selected_key_name = ENV["CLERK_E2E_KEY_NAME"]
+  if selected_key_name == key_name && !blank?(ENV["CLERK_E2E_SECRET_KEY"])
+    return ENV["CLERK_E2E_SECRET_KEY"].strip
+  end
+
+  key_entry(keys, key_name)["sk"].to_s.strip
+end
+
+def frontend_api_url_for(publishable_key)
+  unless publishable_key.start_with?("pk_test_", "pk_live_")
+    raise "publishable key has an invalid prefix"
+  end
+
+  encoded = publishable_key.split("_", 3).fetch(2)
+  encoded = encoded.delete_suffix("$")
+  padding = (4 - encoded.length % 4) % 4
+  decoded = Base64.urlsafe_decode64(encoded + ("=" * padding))
+  host = decoded.delete_suffix("$")
+
+  raise "publishable key does not decode to a frontend API host" if blank?(host)
+
+  URI("https://#{host}")
+rescue KeyError, ArgumentError
+  raise "publishable key could not be decoded"
+end
+
+def fetch_environment(frontend_api_url, timeout)
+  uri = frontend_api_url.dup
+  uri.path = "/v1/environment"
+  uri.query = "_is_native=true"
+
+  response = Net::HTTP.start(
+    uri.host,
+    uri.port,
+    use_ssl: uri.scheme == "https",
+    open_timeout: timeout,
+    read_timeout: timeout
+  ) do |http|
+    request = Net::HTTP::Get.new(uri)
+    request["Accept"] = "application/json"
+    http.request(request)
+  end
+
+  unless response.is_a?(Net::HTTPSuccess)
+    raise "GET /v1/environment failed with HTTP #{response.code}"
+  end
+
+  JSON.parse(response.body)
+end
+
+def requirements_for(key_name)
+  BASE_REQUIREMENTS + (REQUIREMENTS_BY_KEY_NAME[key_name] || [])
+end
+
+def report_failure(failure)
+  if ENV["GITHUB_ACTIONS"] == "true"
+    warn "::error::#{failure}"
+  else
+    warn "  - #{failure}"
+  end
+end
+
+failures = []
+
+key_names.each do |key_name|
+  publishable_key = publishable_key_for(keys, key_name)
+  if blank?(publishable_key)
+    failures << "#{key_name}: missing publishable key"
+    next
+  end
+
+  if key_name == "session-task-reset-password" && blank?(secret_key_for(keys, key_name))
+    failures << "#{key_name}: missing secret key"
+  end
+
+  begin
+    frontend_api_url = frontend_api_url_for(publishable_key)
+    environment = fetch_environment(frontend_api_url, options[:timeout])
+  rescue StandardError => error
+    failures << "#{key_name}: #{error.message}"
+    next
+  end
+
+  missing_requirements = requirements_for(key_name).reject { |requirement| requirement.predicate.call(environment) }
+  if missing_requirements.empty?
+    puts "✅ #{key_name}: frontend environment preflight passed"
+  else
+    missing_requirements.each do |requirement|
+      failures << "#{key_name}: #{requirement.description}"
+    end
+  end
+
+  unless REQUIREMENTS_BY_KEY_NAME.key?(key_name)
+    warn "⚠️  #{key_name}: no key-specific capability map exists; validated fetch/decode only"
+  end
+end
+
+if failures.empty?
+  puts "✅ E2E test instance preflight passed"
+else
+  warn "❌ E2E test instance preflight failed:"
+  failures.each { |failure| report_failure(failure) }
+  exit 1
+end

--- a/scripts/validate-e2e-test-instances.sh
+++ b/scripts/validate-e2e-test-instances.sh
@@ -190,9 +190,13 @@ def key_entry(keys, key_name)
   entry.is_a?(Hash) ? entry : {}
 end
 
-def publishable_key_for(keys, key_name)
+def publishable_key_for(keys, key_name, allow_global_env_override: false)
   selected_key_name = ENV["CLERK_E2E_KEY_NAME"]
-  if (blank?(selected_key_name) || selected_key_name == key_name) && !blank?(ENV["CLERK_E2E_PUBLISHABLE_KEY"])
+  if selected_key_name == key_name && !blank?(ENV["CLERK_E2E_PUBLISHABLE_KEY"])
+    return ENV["CLERK_E2E_PUBLISHABLE_KEY"].strip
+  end
+
+  if allow_global_env_override && blank?(selected_key_name) && !blank?(ENV["CLERK_E2E_PUBLISHABLE_KEY"])
     return ENV["CLERK_E2E_PUBLISHABLE_KEY"].strip
   end
 
@@ -265,7 +269,11 @@ end
 failures = []
 
 key_names.each do |key_name|
-  publishable_key = publishable_key_for(keys, key_name)
+  publishable_key = publishable_key_for(
+    keys,
+    key_name,
+    allow_global_env_override: key_names.length == 1
+  )
   if blank?(publishable_key)
     failures << "#{key_name}: missing publishable key"
     next


### PR DESCRIPTION
## Summary
- Split iOS E2E CI into required smoke and extended shards
- Add E2E preflight and guardrail checks for instances, selectors, hooks, phone numbers, and xcodebuild retry behavior
- Improve E2EHost cleanup diagnostics and reduce MFA TOTP timing flakiness

## Testing
- make check
- CLERK_E2E_KEY_NAME=session-task-setup-mfa E2E_ONLY_TESTING='E2EHostE2ETests/E2EHostE2ETests/testSessionTaskSetupMfaSignUpCompletesAuthenticatorAppSetup()' make test-e2e