### PR TITLE
Update Expo release Slack notification

### DIFF
--- a/.github/workflows/bump-javascript-expo-ios-sdk.yml
+++ b/.github/workflows/bump-javascript-expo-ios-sdk.yml
@@ -206,4 +206,5 @@ jobs:
       release_tag: ${{ github.event.release.tag_name }}
       release_url: ${{ github.event.release.html_url }}
       expo_bump_pr_url: ${{ needs.open-pr.outputs.pr_url }}
-    secrets: inherit
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/bump-javascript-expo-ios-sdk.yml
+++ b/.github/workflows/bump-javascript-expo-ios-sdk.yml
@@ -25,6 +25,8 @@ jobs:
       JAVASCRIPT_REPO: clerk/javascript
       RAW_IOS_VERSION: ${{ github.event.release.tag_name || inputs.version }}
       RELEASE_URL: ${{ github.event.release.html_url }}
+    outputs:
+      pr_url: ${{ steps.pull_request.outputs.pr_url }}
 
     steps:
       - name: Prepare version metadata
@@ -193,58 +195,15 @@ jobs:
               --body-file "$pr_body")"
           fi
 
-          gh pr edit "$pr_url" --add-reviewer clerk/team-sdk
           echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
 
-      - name: Notify Slack
-        if: steps.update.outputs.should_open == 'true' && steps.pull_request.outputs.pr_url != ''
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          IOS_VERSION: ${{ steps.version.outputs.ios_version }}
-          RELEASE_URL: ${{ steps.version.outputs.release_url }}
-          PR_URL: ${{ steps.pull_request.outputs.pr_url }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "$SLACK_WEBHOOK_URL" ]; then
-            echo "::warning::SLACK_WEBHOOK_URL is not configured; skipping Slack notification"
-            exit 0
-          fi
-
-          PAYLOAD=$(jq -n \
-            --arg version "$IOS_VERSION" \
-            --arg release_url "$RELEASE_URL" \
-            --arg pr_url "$PR_URL" \
-            '{
-              text: "Clerk iOS SDK \($version) Expo bump PR is ready",
-              blocks: [
-                {
-                  type: "section",
-                  text: {
-                    type: "mrkdwn",
-                    text: "*Clerk iOS SDK \($version) Expo bump PR is ready*"
-                  }
-                },
-                {
-                  type: "context",
-                  elements: [
-                    {
-                      type: "mrkdwn",
-                      text: "<\($pr_url)|View the JavaScript PR> · <\($release_url)|View the iOS release>"
-                    }
-                  ]
-                }
-              ]
-            }')
-
-          curl --fail-with-body \
-            --connect-timeout 10 \
-            --max-time 30 \
-            --retry 3 \
-            --retry-delay 5 \
-            --retry-max-time 60 \
-            --retry-all-errors \
-            --request POST \
-            --header "Content-type: application/json" \
-            --data "$PAYLOAD" \
-            "$SLACK_WEBHOOK_URL"
+  notify-slack-release:
+    name: Notify Slack of release
+    needs: open-pr
+    if: ${{ always() && github.event_name == 'release' }}
+    uses: ./.github/workflows/notify-slack-release.yml
+    with:
+      release_tag: ${{ github.event.release.tag_name }}
+      release_url: ${{ github.event.release.html_url }}
+      expo_bump_pr_url: ${{ needs.open-pr.outputs.pr_url }}
+    secrets: inherit

--- a/.github/workflows/notify-slack-release.yml
+++ b/.github/workflows/notify-slack-release.yml
@@ -1,8 +1,25 @@
 name: Notify Slack of release
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Release tag to announce.
+        required: true
+        type: string
+      release_url:
+        description: GitHub release URL.
+        required: false
+        type: string
+        default: ""
+      expo_bump_pr_url:
+        description: Optional @clerk/expo bump PR URL.
+        required: false
+        type: string
+        default: ""
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: false
 
 permissions:
   contents: read
@@ -15,8 +32,9 @@ jobs:
       - name: Notify Slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_URL: ${{ inputs.release_url }}
+          EXPO_BUMP_PR_URL: ${{ inputs.expo_bump_pr_url }}
         run: |
           set -euo pipefail
 
@@ -30,9 +48,14 @@ jobs:
             release_url="https://github.com/$GITHUB_REPOSITORY/releases/tag/$RELEASE_TAG"
           fi
 
+          context_links="<${release_url}|View the GitHub release>"
+          if [ -n "$EXPO_BUMP_PR_URL" ]; then
+            context_links="$context_links · <$EXPO_BUMP_PR_URL|View the Expo bump PR>"
+          fi
+
           PAYLOAD=$(jq -n \
             --arg tag "$RELEASE_TAG" \
-            --arg release_url "$release_url" \
+            --arg context_links "$context_links" \
             '{
               text: "Clerk iOS SDK \($tag) has been released",
               blocks: [
@@ -48,7 +71,7 @@ jobs:
                   elements: [
                     {
                       type: "mrkdwn",
-                      text: "<\($release_url)|View the GitHub release>"
+                      text: $context_links
                     }
                   ]
                 }


### PR DESCRIPTION
## Summary

This updates the release-triggered Expo bump flow so Slack gets a single release message instead of a separate follow-up message for the JavaScript bump PR.

The bump workflow now exposes the generated PR URL and calls the existing release Slack notifier after the PR job. The release notifier is reusable and appends a `View the Expo bump PR` link when that URL is available, while still posting the normal release link if no bump PR is opened. This also leaves out Team SDK assignment or review requests.

Checked with `git diff --check`, YAML parsing for both workflow files, and a scan confirming the old bump-ready Slack payload plus Team SDK reviewer hook are gone.
