### PR TITLE
fix: resolve `ASWebAuthenticationSession` continuation leak and robust presentation anchors

### DIFF
--- a/Sources/ClerkKit/Utils/WebAuthentication.swift
+++ b/Sources/ClerkKit/Utils/WebAuthentication.swift
@@ -64,7 +64,7 @@ final class WebAuthentication: NSObject {
   static var fallbackAnchor: AnyObject?
 
   /// Whether a web authentication session is currently active.
-  /// Internal for `@testable` test access.
+  /// Internal for @testable test access.
   static func hasActiveSession() -> Bool {
     currentSession != nil || currentAuthInstance != nil
   }
@@ -172,7 +172,11 @@ extension WebAuthentication: ASWebAuthenticationPresentationContextProviding {
     if let window = foregroundWindows.first(where: \.isKeyWindow) ?? foregroundWindows.first {
       return window
     }
-    let fallbackWindow = UIWindow(frame: UIScreen.main.bounds)
+    let fallbackScene = UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .first
+    let fallbackWindow = fallbackScene.map { UIWindow(windowScene: $0) }
+      ?? UIWindow(frame: UIScreen.main.bounds)
     fallbackWindow.isHidden = false
     Self.fallbackAnchor = fallbackWindow
     return fallbackWindow

--- a/Sources/ClerkKit/Utils/WebAuthentication.swift
+++ b/Sources/ClerkKit/Utils/WebAuthentication.swift
@@ -59,9 +59,9 @@ final class WebAuthentication: NSObject {
   let url: URL
   let prefersEphemeralWebBrowserSession: Bool
 
-  private static var currentSession: ASWebAuthenticationSession?
-  private static var currentAuthInstance: WebAuthentication?
-  private static var fallbackAnchor: AnyObject?
+  static var currentSession: ASWebAuthenticationSession?
+  static var currentAuthInstance: WebAuthentication?
+  static var fallbackAnchor: AnyObject?
 
   /// Whether a web authentication session is currently active.
   /// Internal for `@testable` test access.

--- a/Sources/ClerkKit/Utils/WebAuthentication.swift
+++ b/Sources/ClerkKit/Utils/WebAuthentication.swift
@@ -53,7 +53,7 @@ actor WebAuthLifecycleRefreshManager {
 @available(tvOS 16.0, watchOS 6.2, *)
 @MainActor
 final class WebAuthentication: NSObject {
-  private static let continuationManager = WebAuthContinuationManager()
+  static let continuationManager = WebAuthContinuationManager()
   private static let lifecycleRefreshManager = WebAuthLifecycleRefreshManager()
 
   let url: URL
@@ -61,6 +61,19 @@ final class WebAuthentication: NSObject {
 
   private static var currentSession: ASWebAuthenticationSession?
   private static var currentAuthInstance: WebAuthentication?
+  private static var fallbackAnchor: AnyObject?
+
+  /// Whether a web authentication session is currently active.
+  /// Internal for `@testable` test access.
+  static func hasActiveSession() -> Bool {
+    currentSession != nil || currentAuthInstance != nil
+  }
+
+  private static func clearSession() {
+    currentSession = nil
+    currentAuthInstance = nil
+    fallbackAnchor = nil
+  }
 
   init(url: URL, prefersEphemeralWebBrowserSession: Bool = false) {
     self.url = url
@@ -78,6 +91,7 @@ final class WebAuthentication: NSObject {
               #if os(macOS)
               await WebAuthentication.lifecycleRefreshManager.markPendingForegroundRefreshSuppression()
               #endif
+              await MainActor.run { WebAuthentication.clearSession() }
               await WebAuthentication.continuationManager.completeSession(with: url, error: error)
             }
           }
@@ -100,6 +114,7 @@ final class WebAuthentication: NSObject {
           let didStart = session.start()
 
           if !didStart {
+            Self.clearSession()
             let startError = NSError(
               domain: "ClerkAuthError",
               code: -1,
@@ -119,14 +134,13 @@ final class WebAuthentication: NSObject {
       #if os(macOS)
       await lifecycleRefreshManager.markPendingForegroundRefreshSuppression()
       #endif
-      await continuationManager.completeSession(with: url, error: nil)
 
       #if targetEnvironment(macCatalyst)
-      currentSession?.cancel()
+      await MainActor.run { currentSession?.cancel() }
       #endif
 
-      currentSession = nil
-      currentAuthInstance = nil
+      await MainActor.run { clearSession() }
+      await continuationManager.completeSession(with: url, error: nil)
     }
   }
 
@@ -135,8 +149,7 @@ final class WebAuthentication: NSObject {
     currentSession?.cancel()
     #endif
 
-    currentSession = nil
-    currentAuthInstance = nil
+    clearSession()
 
     await continuationManager.cancelSessionIfNeeded()
   }
@@ -151,13 +164,17 @@ extension WebAuthentication: ASWebAuthenticationPresentationContextProviding {
   @MainActor
   func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
     #if os(iOS)
-    if let activeScene = UIApplication.shared.connectedScenes.filter({ $0.activationState == .foregroundActive }).first as? UIWindowScene,
-       let window = activeScene.windows.first(where: \.isKeyWindow) ?? activeScene.windows.first
-    {
-        return window
+    let foregroundWindows = UIApplication.shared.connectedScenes
+      .filter { $0.activationState == .foregroundActive }
+      .compactMap { $0 as? UIWindowScene }
+      .flatMap(\.windows)
+
+    if let window = foregroundWindows.first(where: \.isKeyWindow) ?? foregroundWindows.first {
+      return window
     }
     let fallbackWindow = UIWindow(frame: UIScreen.main.bounds)
     fallbackWindow.isHidden = false
+    Self.fallbackAnchor = fallbackWindow
     return fallbackWindow
 
     #elseif os(macOS)
@@ -172,6 +189,7 @@ extension WebAuthentication: ASWebAuthenticationPresentationContextProviding {
       defer: false
     )
     tempWindow.makeKeyAndOrderFront(nil)
+    Self.fallbackAnchor = tempWindow
     return tempWindow
 
     #else

--- a/Sources/ClerkKit/Utils/WebAuthentication.swift
+++ b/Sources/ClerkKit/Utils/WebAuthentication.swift
@@ -58,7 +58,9 @@ final class WebAuthentication: NSObject {
 
   let url: URL
   let prefersEphemeralWebBrowserSession: Bool
+
   private static var currentSession: ASWebAuthenticationSession?
+  private static var currentAuthInstance: WebAuthentication?
 
   init(url: URL, prefersEphemeralWebBrowserSession: Bool = false) {
     self.url = url
@@ -90,8 +92,24 @@ final class WebAuthentication: NSObject {
         #endif
 
         Self.currentSession = session
+        Self.currentAuthInstance = self
+
         await WebAuthentication.continuationManager.setContinuation(continuation)
-        session.start()
+
+        await MainActor.run {
+          let didStart = session.start()
+
+          if !didStart {
+            let startError = NSError(
+              domain: "ClerkAuthError",
+              code: -1,
+              userInfo: [NSLocalizedDescriptionKey: "ASWebAuthenticationSession failed to start. Window context may be invalid."]
+            )
+            Task {
+              await WebAuthentication.continuationManager.completeSession(with: nil, error: startError)
+            }
+          }
+        }
       }
     }
   }
@@ -104,12 +122,11 @@ final class WebAuthentication: NSObject {
       await continuationManager.completeSession(with: url, error: nil)
 
       #if targetEnvironment(macCatalyst)
-      // mac catalyst web auth window doesn't close without
-      // this when the callback is intercepted as a universal link
       currentSession?.cancel()
       #endif
 
       currentSession = nil
+      currentAuthInstance = nil
     }
   }
 
@@ -119,6 +136,7 @@ final class WebAuthentication: NSObject {
     #endif
 
     currentSession = nil
+    currentAuthInstance = nil
 
     await continuationManager.cancelSessionIfNeeded()
   }
@@ -132,8 +150,33 @@ final class WebAuthentication: NSObject {
 extension WebAuthentication: ASWebAuthenticationPresentationContextProviding {
   @MainActor
   func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
-    PresentationAnchorProvider.current
+    #if os(iOS)
+    if let activeScene = UIApplication.shared.connectedScenes.filter({ $0.activationState == .foregroundActive }).first as? UIWindowScene,
+       let window = activeScene.windows.first(where: \.isKeyWindow) ?? activeScene.windows.first
+    {
+        return window
+    }
+    let fallbackWindow = UIWindow(frame: UIScreen.main.bounds)
+    fallbackWindow.isHidden = false
+    return fallbackWindow
+
+    #elseif os(macOS)
+    if let keyWindow = NSApp.keyWindow { return keyWindow }
+    if let mainWindow = NSApp.mainWindow { return mainWindow }
+    if let visibleWindow = NSApp.windows.first(where: { $0.isVisible && $0.className != "NSStatusBarWindow" }) { return visibleWindow }
+
+    let tempWindow = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 1, height: 1),
+      styleMask: .borderless,
+      backing: .buffered,
+      defer: false
+    )
+    tempWindow.makeKeyAndOrderFront(nil)
+    return tempWindow
+
+    #else
+    return ASPresentationAnchor()
+    #endif
   }
 }
-
 #endif

--- a/Tests/Utils/WebAuthenticationTests.swift
+++ b/Tests/Utils/WebAuthenticationTests.swift
@@ -1,0 +1,125 @@
+//
+//  WebAuthenticationTests.swift
+//
+
+@testable import ClerkKit
+import Foundation
+import Testing
+
+// MARK: - WebAuthContinuationManager Tests
+
+@Suite(.serialized)
+struct WebAuthContinuationManagerTests {
+  @Test
+  func completesSessionWithURL() async throws {
+    let manager = WebAuthContinuationManager()
+    let expected = try #require(URL(string: "https://example.com/callback"))
+
+    let result: URL = try await withCheckedThrowingContinuation { continuation in
+      Task {
+        await manager.setContinuation(continuation)
+        await manager.completeSession(with: expected, error: nil)
+      }
+    }
+
+    #expect(result == expected)
+  }
+
+  @Test
+  func completesSessionWithError() async {
+    let manager = WebAuthContinuationManager()
+
+    await #expect(throws: ClerkClientError.self) {
+      try await withCheckedThrowingContinuation { continuation in
+        Task {
+          await manager.setContinuation(continuation)
+          await manager.completeSession(with: nil, error: nil)
+        }
+      } as URL
+    }
+  }
+
+  @Test
+  func completesSessionWithExplicitError() async {
+    let manager = WebAuthContinuationManager()
+
+    await #expect(throws: (any Error).self) {
+      try await withCheckedThrowingContinuation { continuation in
+        Task {
+          await manager.setContinuation(continuation)
+          let error = NSError(domain: "Test", code: -1)
+          await manager.completeSession(with: nil, error: error)
+        }
+      } as URL
+    }
+  }
+
+  @Test
+  func cancelSessionIfNeededResumesCancellation() async {
+    let manager = WebAuthContinuationManager()
+
+    await #expect(throws: CancellationError.self) {
+      try await withCheckedThrowingContinuation { continuation in
+        Task {
+          await manager.setContinuation(continuation)
+          await manager.cancelSessionIfNeeded()
+        }
+      } as URL
+    }
+  }
+
+  @Test
+  func duplicateCompletionIsIgnored() async throws {
+    let manager = WebAuthContinuationManager()
+    let expected = try #require(URL(string: "https://example.com/callback"))
+
+    let result: URL = try await withCheckedThrowingContinuation { continuation in
+      Task {
+        await manager.setContinuation(continuation)
+        await manager.completeSession(with: expected, error: nil)
+        // Second call should be silently ignored (no crash).
+        await manager.completeSession(with: nil, error: nil)
+      }
+    }
+
+    #expect(result == expected)
+  }
+}
+
+// MARK: - WebAuthentication State Cleanup Tests
+
+@Suite(.serialized)
+struct WebAuthenticationCleanupTests {
+  @Test
+  @MainActor
+  func finishWithDeeplinkUrlClearsSessionBeforeCompletion() async throws {
+    let url = try #require(URL(string: "https://example.com/callback"))
+
+    // Simulate a pending auth session by running a continuation that
+    // will be completed by `finishWithDeeplinkUrl`.
+    let task = Task { @MainActor in
+      try await withCheckedThrowingContinuation { continuation in
+        Task {
+          await WebAuthentication.continuationManager.setContinuation(continuation)
+
+          // Trigger deeplink completion.
+          WebAuthentication.finishWithDeeplinkUrl(url: url)
+        }
+      } as URL
+    }
+
+    let result = try await task.value
+    #expect(result == url)
+
+    // After the deeplink finishes, session state must already be cleared.
+    #expect(WebAuthentication.hasActiveSession() == false)
+  }
+
+  @Test
+  @MainActor
+  func cancelCurrentSessionClearsState() async {
+    // After cancel, session state should be cleared.
+    await WebAuthentication.cancelCurrentSession()
+    #expect(WebAuthentication.hasActiveSession() == false)
+  }
+}

--- a/Tests/Utils/WebAuthenticationTests.swift
+++ b/Tests/Utils/WebAuthenticationTests.swift
@@ -2,14 +2,20 @@
 //  WebAuthenticationTests.swift
 //
 
+import AuthenticationServices
 @testable import ClerkKit
 import Foundation
 import Testing
 
 // MARK: - WebAuthContinuationManager Tests
 
+@MainActor
 @Suite(.serialized)
 struct WebAuthContinuationManagerTests {
+  init() {
+    configureClerkForTesting()
+  }
+
   @Test
   func completesSessionWithURL() async throws {
     let manager = WebAuthContinuationManager()
@@ -40,18 +46,25 @@ struct WebAuthContinuationManagerTests {
   }
 
   @Test
-  func completesSessionWithExplicitError() async {
+  func completesSessionWithExplicitError() async throws {
     let manager = WebAuthContinuationManager()
+    let expectedError = NSError(domain: "Test", code: -1)
 
-    await #expect(throws: (any Error).self) {
-      try await withCheckedThrowingContinuation { continuation in
+    var thrownError: (any Error)?
+    do {
+      _ = try await withCheckedThrowingContinuation { continuation in
         Task {
           await manager.setContinuation(continuation)
-          let error = NSError(domain: "Test", code: -1)
-          await manager.completeSession(with: nil, error: error)
+          await manager.completeSession(with: nil, error: expectedError)
         }
       } as URL
+    } catch {
+      thrownError = error
     }
+
+    let nsError = try #require(thrownError as? NSError)
+    #expect(nsError.domain == "Test")
+    #expect(nsError.code == -1)
   }
 
   @Test
@@ -88,12 +101,24 @@ struct WebAuthContinuationManagerTests {
 
 // MARK: - WebAuthentication State Cleanup Tests
 
+@MainActor
 @Suite(.serialized)
 struct WebAuthenticationCleanupTests {
+  init() {
+    configureClerkForTesting()
+  }
+
   @Test
-  @MainActor
   func finishWithDeeplinkUrlClearsSessionBeforeCompletion() async throws {
     let url = try #require(URL(string: "https://example.com/callback"))
+
+    // Seed active session
+    let dummySession = ASWebAuthenticationSession(url: url, callbackURLScheme: "test") { _, _ in }
+    let auth = WebAuthentication(url: url)
+    WebAuthentication.currentSession = dummySession
+    WebAuthentication.currentAuthInstance = auth
+
+    #expect(WebAuthentication.hasActiveSession() == true)
 
     // Simulate a pending auth session by running a continuation that
     // will be completed by `finishWithDeeplinkUrl`.
@@ -116,10 +141,40 @@ struct WebAuthenticationCleanupTests {
   }
 
   @Test
-  @MainActor
-  func cancelCurrentSessionClearsState() async {
+  func cancelCurrentSessionClearsState() async throws {
+    let url = try #require(URL(string: "https://example.com/callback"))
+
+    // Seed active session
+    let dummySession = ASWebAuthenticationSession(url: url, callbackURLScheme: "test") { _, _ in }
+    let auth = WebAuthentication(url: url)
+    WebAuthentication.currentSession = dummySession
+    WebAuthentication.currentAuthInstance = auth
+
+    #expect(WebAuthentication.hasActiveSession() == true)
+
+    // Signal so we know the continuation has been set before we cancel.
+    let (signal, signalContinuation) = AsyncStream<Void>.makeStream()
+
+    let task = Task {
+      await #expect(throws: CancellationError.self) {
+        try await withCheckedThrowingContinuation { continuation in
+          Task {
+            await WebAuthentication.continuationManager.setContinuation(continuation)
+            signalContinuation.yield()
+            signalContinuation.finish()
+          }
+        } as URL
+      }
+    }
+
+    // Wait until the continuation is actually set.
+    for await _ in signal {}
+
     // After cancel, session state should be cleared.
     await WebAuthentication.cancelCurrentSession()
     #expect(WebAuthentication.hasActiveSession() == false)
+
+    // Await the task to ensure the continuation completed with cancellation.
+    _ = await task.result
   }
 }


### PR DESCRIPTION
# Summary

This PR fixes a critical bug where ASWebAuthenticationSession failing to start leaves the async continuation unresumed, permanently freezing the calling task. It also includes defensive improvements to presentation anchor handling.

---

# Discovery

This issue was discovered while debugging Google Sign-In in Palmier Pro, which uses Clerk iOS for authentication. The app hit a SWIFT TASK CONTINUATION MISUSE: start() leaked its continuation without resuming it failure on macOS. Tracing the authentication flow into Clerk (.build/checkouts/clerk-ios) led to WebAuthentication.swift, where the ASWebAuthenticationSession.start() return value was ignored — if start() returns false, the continuation is never resumed, leaving callers suspended indefinitely.

---

# Verified Fix: Continuation Leak

## The Problem

session.start() returns a boolean indicating whether the session launched. Previously, this return value was ignored. If it returned false (often due to missing or invalid window context), the CheckedContinuation was never resumed — permanently suspending the caller.

## The Fix

- **Continuation safety:** Captured the session.start() return value. If false, the continuation is explicitly resumed with an error via WebAuthentication.continuationManager so the caller can recover instead of hanging.

- **Thread safety:** Wrapped the session presentation logic inside await MainActor.run, since iOS requires UI presentations to originate from the main thread.

- **State cleanup:** Introduced a centralized clearSession() method that nils currentSession, currentAuthInstance, and fallbackAnchor in a single call. All completion paths (completion handler, deeplink finish, failed start, and cancellation) now clear session state before resuming the continuation, preventing stale references from leaking across auth attempts.

- **Memory retention:** Added currentAuthInstance to strongly retain the WebAuthentication instance (the presentationContextProvider) until the session completes or cancels. ASWebAuthenticationSession holds only a weak reference to its provider, so without this the provider could be deallocated mid-session.

---

# Defensive Improvements: Anchor Handling

> **NOTE**
>
> These changes are preventive hardening for plausible failure modes in scene-based apps. They are not driven by a specific verified reproduction. Happy to split into a separate PR if preferred.

- **Multi-scene key window selection:** The iOS anchor lookup now flattens windows across all foreground UIWindowScene instances and prefers the global key window, instead of stopping at the first active scene.

- **Scene-backed fallback window:** The fallback UIWindow is now derived from an available UIWindowScene via UIWindow(windowScene:), rather than the scene-less UIWindow(frame:) initializer which may be rejected as an invalid ASPresentationAnchor in scene-based apps.

- **Fallback anchor retention:** The fallback UIWindow/NSWindow created in presentationAnchor(for:) is held via a static fallbackAnchor property, preventing premature deallocation while the auth session is active. It is released alongside the other session state in clearSession().

---

# Tests Added

Added WebAuthenticationTests.swift covering:

- WebAuthContinuationManagerTests (5 tests) — URL completion, missing-URL error, explicit NSError propagation (asserts exact domain and code), cancellation, and duplicate-completion safety.

- WebAuthenticationCleanupTests (2 tests) — Verifies finishWithDeeplinkUrl and cancelCurrentSession transition hasActiveSession() from true → false by seeding real session state before asserting cleanup.

---

# How to Test

1. Trigger a web authentication flow (e.g., Google Sign-In) on macOS without a prominently active key window.

2. Verify the session either successfully launches using the fallback window, or safely rejects the attempt and throws an error without leaking the Task continuation.

3. Trigger the flow on an iOS Simulator using a multi-scene SwiftUI app to verify the browser sheet successfully anchors and appears.