### PR TITLE
Add modal-first passkey sign-in to AuthStart

### DIFF
--- a/Sources/ClerkKit/Core/Auth.swift
+++ b/Sources/ClerkKit/Core/Auth.swift
@@ -279,13 +279,22 @@ public struct Auth {
 
   // Signs in with a passkey.
   //
+  // - Parameters:
+  //   - autofill: Whether to use the AutoFill-assisted passkey flow.
+  //   - preferImmediatelyAvailableCredentials: Whether to show UI only for locally available credentials.
   // - Returns: A `SignIn` object representing the sign-in attempt.
   // - Throws: An error if the passkey sign-in fails.
   #if canImport(AuthenticationServices) && !os(watchOS) && !os(tvOS)
   @discardableResult
-  public func signInWithPasskey() async throws -> SignIn {
+  public func signInWithPasskey(
+    autofill: Bool = false,
+    preferImmediatelyAvailableCredentials: Bool = true
+  ) async throws -> SignIn {
     let signIn = try await signInService.create(params: .init(strategy: .passkey))
-    return try await signIn.authenticateWithPasskey()
+    return try await signIn.authenticateWithPasskey(
+      autofill: autofill,
+      preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
+    )
   }
   #endif
 

--- a/Sources/ClerkKit/Core/Auth.swift
+++ b/Sources/ClerkKit/Core/Auth.swift
@@ -277,24 +277,31 @@ public struct Auth {
   }
   #endif
 
-  // Signs in with a passkey.
-  //
-  // - Parameters:
-  //   - autofill: Whether to use the AutoFill-assisted passkey flow.
-  //   - preferImmediatelyAvailableCredentials: Whether to show UI only for locally available credentials.
-  // - Returns: A `SignIn` object representing the sign-in attempt.
-  // - Throws: An error if the passkey sign-in fails.
   #if canImport(AuthenticationServices) && !os(watchOS) && !os(tvOS)
+  /// Creates a passkey sign-in attempt.
+  ///
+  /// Use this when you need to control how an existing passkey sign-in attempt is
+  /// authenticated, such as trying a modal request before falling back to
+  /// AutoFill-assisted passkey suggestions.
+  ///
+  /// - Returns: A `SignIn` object representing the passkey sign-in attempt.
+  /// - Throws: An error if the passkey sign-in attempt cannot be created.
   @discardableResult
-  public func signInWithPasskey(
-    autofill: Bool = false,
-    preferImmediatelyAvailableCredentials: Bool = true
-  ) async throws -> SignIn {
-    let signIn = try await signInService.create(params: .init(strategy: .passkey))
-    return try await signIn.authenticateWithPasskey(
-      autofill: autofill,
-      preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
-    )
+  public func createPasskeySignIn() async throws -> SignIn {
+    try await signInService.create(params: .init(strategy: .passkey))
+  }
+
+  /// Signs in with a passkey.
+  ///
+  /// This is a one-shot convenience method that creates a passkey sign-in
+  /// attempt and authenticates it immediately.
+  ///
+  /// - Returns: A `SignIn` object representing the sign-in attempt.
+  /// - Throws: An error if the passkey sign-in fails.
+  @discardableResult
+  public func signInWithPasskey() async throws -> SignIn {
+    let signIn = try await createPasskeySignIn()
+    return try await signIn.authenticateWithPasskey()
   }
   #endif
 

--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -160,6 +160,18 @@ public final class Clerk {
     }
   }
 
+  package struct EnvironmentRefreshCheckpoint: Equatable {
+    fileprivate let revision: Int
+  }
+
+  private var environmentRefreshRevision = 0
+  private var environmentRefreshTask: Task<Environment, Error>?
+  private var environmentRefreshTaskID: UUID?
+
+  package var environmentRefreshCheckpoint: EnvironmentRefreshCheckpoint {
+    .init(revision: environmentRefreshRevision)
+  }
+
   /// The configuration options for this Clerk instance.
   public var options: Clerk.Options {
     dependencies.configurationManager.options
@@ -484,11 +496,40 @@ extension Clerk {
   /// Refreshes the current environment from the API.
   @discardableResult
   public func refreshEnvironment() async throws -> Environment {
+    if let environmentRefreshTask {
+      return try await environmentRefreshTask.value
+    }
+
     let runtime = runtimeScope
-    let environment = try await dependencies.environmentService.get()
-    try runtime.validateStableRuntime()
-    self.environment = environment
-    return environment
+    let taskID = UUID()
+    let task = Task { @MainActor in
+      defer {
+        if self.environmentRefreshTaskID == taskID {
+          self.environmentRefreshTask = nil
+          self.environmentRefreshTaskID = nil
+        }
+      }
+
+      let environment = try await self.dependencies.environmentService.get()
+      try Task.checkCancellation()
+      try runtime.validateStableRuntime()
+      self.environment = environment
+      self.environmentRefreshRevision += 1
+      return environment
+    }
+
+    environmentRefreshTask = task
+    environmentRefreshTaskID = taskID
+    return try await task.value
+  }
+
+  @discardableResult
+  package func ensureEnvironmentRefreshed(after checkpoint: EnvironmentRefreshCheckpoint) async throws -> Environment {
+    if environmentRefreshRevision > checkpoint.revision, let environment {
+      return environment
+    }
+
+    return try await refreshEnvironment()
   }
 
   private static let startupRefreshRetryPolicy = RetryPolicy(
@@ -848,6 +889,7 @@ extension Clerk {
     watchSyncRefreshTask = nil
     urlHandlingCoordinator.cancelAll()
 
+    cancelEnvironmentRefreshTask()
     // Stop SDK-owned tasks before draining the cache to prevent in-flight refreshes
     // from enqueuing new writes during the drain.
     await taskCoordinator?.cancelAllAndWait()
@@ -862,9 +904,21 @@ extension Clerk {
     if finishAuthEventStreams {
       authEventEmitter.finish()
     }
+    resetEnvironmentRefreshState()
     callbackContinuation = nil
     lastAppliedClientResponseSequence = nil
     lastClientServerFetchDate = nil
+  }
+
+  private func cancelEnvironmentRefreshTask() {
+    environmentRefreshTask?.cancel()
+    environmentRefreshTask = nil
+    environmentRefreshTaskID = nil
+  }
+
+  private func resetEnvironmentRefreshState() {
+    cancelEnvironmentRefreshTask()
+    environmentRefreshRevision = 0
   }
 
   private func teardownNonCacheManagers() {

--- a/Sources/ClerkKit/Helpers/PasskeyHelper.swift
+++ b/Sources/ClerkKit/Helpers/PasskeyHelper.swift
@@ -86,11 +86,9 @@ final class PasskeyHelper: NSObject {
   }
 
   @MainActor
-  func signIn(
-    challenge: Data,
-    relyingPartyIdentifier: String? = nil,
-    allowedCredentialIDs: [Data] = [],
-    preferImmediatelyAvailableCredentials: Bool
+  private func performAuthorization(
+    requests: [ASAuthorizationRequest],
+    start: @escaping @MainActor (ASAuthorizationController) -> Void
   ) async throws -> ASAuthorization {
     try Task.checkCancellation()
     Self.cancelCurrentAuthorization()
@@ -102,43 +100,54 @@ final class PasskeyHelper: NSObject {
         self.continuation = continuation
         Self.activeHelper = self
 
-        let assertionRequest = credentialAssertionRequest(
-          challenge: challenge,
-          relyingPartyIdentifier: relyingPartyIdentifier,
-          allowedCredentialIDs: allowedCredentialIDs
-        )
-
-        // Pass in any mix of supported sign-in request types.
-        let authController = ASAuthorizationController(authorizationRequests: [assertionRequest])
+        let authController = ASAuthorizationController(authorizationRequests: requests)
         authController.delegate = self
         authController.presentationContextProvider = self
         Self.controller = authController
 
-        #if !os(tvOS)
-
-        if preferImmediatelyAvailableCredentials {
-          // If credentials are available, presents a modal sign-in sheet.
-          // If there are no locally saved credentials, no UI appears and
-          // the system passes ASAuthorizationError.Code.canceled to call
-          // `AccountManager.authorizationController(controller:didCompleteWithError:)`.
-          authController.performRequests(options: .preferImmediatelyAvailableCredentials)
-        } else {
-          // If credentials are available, presents a modal sign-in sheet.
-          // If there are no locally saved credentials, the system presents a QR code to allow signing in with a
-          // passkey from a nearby device.
-          authController.performRequests()
-        }
-
-        #else
-
-        authController.performRequests()
-
-        #endif
+        start(authController)
       }
     } onCancel: {
       Task { @MainActor in
         Self.cancelAuthorization(for: helperID)
       }
+    }
+  }
+
+  @MainActor
+  func signIn(
+    challenge: Data,
+    relyingPartyIdentifier: String? = nil,
+    allowedCredentialIDs: [Data] = [],
+    preferImmediatelyAvailableCredentials: Bool
+  ) async throws -> ASAuthorization {
+    let assertionRequest = credentialAssertionRequest(
+      challenge: challenge,
+      relyingPartyIdentifier: relyingPartyIdentifier,
+      allowedCredentialIDs: allowedCredentialIDs
+    )
+
+    return try await performAuthorization(requests: [assertionRequest]) { authController in
+      #if !os(tvOS)
+
+      if preferImmediatelyAvailableCredentials {
+        // If credentials are available, presents a modal sign-in sheet.
+        // If there are no locally saved credentials, no UI appears and
+        // the system passes ASAuthorizationError.Code.canceled to call
+        // `AccountManager.authorizationController(controller:didCompleteWithError:)`.
+        authController.performRequests(options: .preferImmediatelyAvailableCredentials)
+      } else {
+        // If credentials are available, presents a modal sign-in sheet.
+        // If there are no locally saved credentials, the system presents a QR code to allow signing in with a
+        // passkey from a nearby device.
+        authController.performRequests()
+      }
+
+      #else
+
+      authController.performRequests()
+
+      #endif
     }
   }
 
@@ -149,34 +158,14 @@ final class PasskeyHelper: NSObject {
     relyingPartyIdentifier: String? = nil,
     allowedCredentialIDs: [Data] = []
   ) async throws -> ASAuthorization {
-    try Task.checkCancellation()
-    Self.cancelCurrentAuthorization()
-    let helperID = ObjectIdentifier(self)
+    let assertionRequest = credentialAssertionRequest(
+      challenge: challenge,
+      relyingPartyIdentifier: relyingPartyIdentifier,
+      allowedCredentialIDs: allowedCredentialIDs
+    )
 
-    return try await withTaskCancellationHandler {
-      try Task.checkCancellation()
-      return try await withCheckedThrowingContinuation { continuation in
-        self.continuation = continuation
-        Self.activeHelper = self
-
-        let assertionRequest = credentialAssertionRequest(
-          challenge: challenge,
-          relyingPartyIdentifier: relyingPartyIdentifier,
-          allowedCredentialIDs: allowedCredentialIDs
-        )
-
-        // AutoFill-assisted requests only support ASAuthorizationPlatformPublicKeyCredentialAssertionRequest.
-        let authController = ASAuthorizationController(authorizationRequests: [assertionRequest])
-        authController.delegate = self
-        authController.presentationContextProvider = self
-        Self.controller = authController
-
-        authController.performAutoFillAssistedRequests()
-      }
-    } onCancel: {
-      Task { @MainActor in
-        Self.cancelAuthorization(for: helperID)
-      }
+    return try await performAuthorization(requests: [assertionRequest]) { authController in
+      authController.performAutoFillAssistedRequests()
     }
   }
   #endif
@@ -188,39 +177,18 @@ final class PasskeyHelper: NSObject {
     userId: Data,
     relyingPartyIdentifier: String? = nil
   ) async throws -> ASAuthorization {
-    try Task.checkCancellation()
-    Self.cancelCurrentAuthorization()
-    let helperID = ObjectIdentifier(self)
+    let publicKeyCredentialProvider = publicKeyCredentialProvider(
+      relyingPartyIdentifier: relyingPartyIdentifier
+    )
 
-    return try await withTaskCancellationHandler {
-      try Task.checkCancellation()
-      return try await withCheckedThrowingContinuation { continuation in
-        self.continuation = continuation
-        Self.activeHelper = self
+    let registrationRequest = publicKeyCredentialProvider.createCredentialRegistrationRequest(
+      challenge: challenge,
+      name: name,
+      userID: userId
+    )
 
-        let publicKeyCredentialProvider = publicKeyCredentialProvider(
-          relyingPartyIdentifier: relyingPartyIdentifier
-        )
-
-        let registrationRequest = publicKeyCredentialProvider.createCredentialRegistrationRequest(
-          challenge: challenge,
-          name: name,
-          userID: userId
-        )
-
-        // Use only ASAuthorizationPlatformPublicKeyCredentialRegistrationRequests or
-        // ASAuthorizationSecurityKeyPublicKeyCredentialRegistrationRequests here.
-        let authController = ASAuthorizationController(authorizationRequests: [registrationRequest])
-        authController.delegate = self
-        authController.presentationContextProvider = self
-        Self.controller = authController
-
-        authController.performRequests()
-      }
-    } onCancel: {
-      Task { @MainActor in
-        Self.cancelAuthorization(for: helperID)
-      }
+    return try await performAuthorization(requests: [registrationRequest]) { authController in
+      authController.performRequests()
     }
   }
 

--- a/Sources/ClerkKit/Helpers/PasskeyHelper.swift
+++ b/Sources/ClerkKit/Helpers/PasskeyHelper.swift
@@ -31,6 +31,12 @@ final class PasskeyHelper: NSObject {
   }
 
   @MainActor
+  private static func cancelAuthorization(for helperID: ObjectIdentifier) {
+    guard let activeHelper, ObjectIdentifier(activeHelper) == helperID else { return }
+    cancelCurrentAuthorization()
+  }
+
+  @MainActor
   private var defaultRelyingPartyIdentifier: String {
     guard let urlComponents = URLComponents(string: Clerk.shared.frontendApiUrl) else {
       return ""
@@ -86,44 +92,53 @@ final class PasskeyHelper: NSObject {
     allowedCredentialIDs: [Data] = [],
     preferImmediatelyAvailableCredentials: Bool
   ) async throws -> ASAuthorization {
+    try Task.checkCancellation()
     Self.cancelCurrentAuthorization()
+    let helperID = ObjectIdentifier(self)
 
-    return try await withCheckedThrowingContinuation { continuation in
-      self.continuation = continuation
-      Self.activeHelper = self
+    return try await withTaskCancellationHandler {
+      try Task.checkCancellation()
+      return try await withCheckedThrowingContinuation { continuation in
+        self.continuation = continuation
+        Self.activeHelper = self
 
-      let assertionRequest = credentialAssertionRequest(
-        challenge: challenge,
-        relyingPartyIdentifier: relyingPartyIdentifier,
-        allowedCredentialIDs: allowedCredentialIDs
-      )
+        let assertionRequest = credentialAssertionRequest(
+          challenge: challenge,
+          relyingPartyIdentifier: relyingPartyIdentifier,
+          allowedCredentialIDs: allowedCredentialIDs
+        )
 
-      // Pass in any mix of supported sign-in request types.
-      let authController = ASAuthorizationController(authorizationRequests: [assertionRequest])
-      authController.delegate = self
-      authController.presentationContextProvider = self
-      Self.controller = authController
+        // Pass in any mix of supported sign-in request types.
+        let authController = ASAuthorizationController(authorizationRequests: [assertionRequest])
+        authController.delegate = self
+        authController.presentationContextProvider = self
+        Self.controller = authController
 
-      #if !os(tvOS)
+        #if !os(tvOS)
 
-      if preferImmediatelyAvailableCredentials {
-        // If credentials are available, presents a modal sign-in sheet.
-        // If there are no locally saved credentials, no UI appears and
-        // the system passes ASAuthorizationError.Code.canceled to call
-        // `AccountManager.authorizationController(controller:didCompleteWithError:)`.
-        authController.performRequests(options: .preferImmediatelyAvailableCredentials)
-      } else {
-        // If credentials are available, presents a modal sign-in sheet.
-        // If there are no locally saved credentials, the system presents a QR code to allow signing in with a
-        // passkey from a nearby device.
+        if preferImmediatelyAvailableCredentials {
+          // If credentials are available, presents a modal sign-in sheet.
+          // If there are no locally saved credentials, no UI appears and
+          // the system passes ASAuthorizationError.Code.canceled to call
+          // `AccountManager.authorizationController(controller:didCompleteWithError:)`.
+          authController.performRequests(options: .preferImmediatelyAvailableCredentials)
+        } else {
+          // If credentials are available, presents a modal sign-in sheet.
+          // If there are no locally saved credentials, the system presents a QR code to allow signing in with a
+          // passkey from a nearby device.
+          authController.performRequests()
+        }
+
+        #else
+
         authController.performRequests()
+
+        #endif
       }
-
-      #else
-
-      authController.performRequests()
-
-      #endif
+    } onCancel: {
+      Task { @MainActor in
+        Self.cancelAuthorization(for: helperID)
+      }
     }
   }
 
@@ -134,25 +149,34 @@ final class PasskeyHelper: NSObject {
     relyingPartyIdentifier: String? = nil,
     allowedCredentialIDs: [Data] = []
   ) async throws -> ASAuthorization {
+    try Task.checkCancellation()
     Self.cancelCurrentAuthorization()
+    let helperID = ObjectIdentifier(self)
 
-    return try await withCheckedThrowingContinuation { continuation in
-      self.continuation = continuation
-      Self.activeHelper = self
+    return try await withTaskCancellationHandler {
+      try Task.checkCancellation()
+      return try await withCheckedThrowingContinuation { continuation in
+        self.continuation = continuation
+        Self.activeHelper = self
 
-      let assertionRequest = credentialAssertionRequest(
-        challenge: challenge,
-        relyingPartyIdentifier: relyingPartyIdentifier,
-        allowedCredentialIDs: allowedCredentialIDs
-      )
+        let assertionRequest = credentialAssertionRequest(
+          challenge: challenge,
+          relyingPartyIdentifier: relyingPartyIdentifier,
+          allowedCredentialIDs: allowedCredentialIDs
+        )
 
-      // AutoFill-assisted requests only support ASAuthorizationPlatformPublicKeyCredentialAssertionRequest.
-      let authController = ASAuthorizationController(authorizationRequests: [assertionRequest])
-      authController.delegate = self
-      authController.presentationContextProvider = self
-      Self.controller = authController
+        // AutoFill-assisted requests only support ASAuthorizationPlatformPublicKeyCredentialAssertionRequest.
+        let authController = ASAuthorizationController(authorizationRequests: [assertionRequest])
+        authController.delegate = self
+        authController.presentationContextProvider = self
+        Self.controller = authController
 
-      authController.performAutoFillAssistedRequests()
+        authController.performAutoFillAssistedRequests()
+      }
+    } onCancel: {
+      Task { @MainActor in
+        Self.cancelAuthorization(for: helperID)
+      }
     }
   }
   #endif
@@ -164,30 +188,39 @@ final class PasskeyHelper: NSObject {
     userId: Data,
     relyingPartyIdentifier: String? = nil
   ) async throws -> ASAuthorization {
+    try Task.checkCancellation()
     Self.cancelCurrentAuthorization()
+    let helperID = ObjectIdentifier(self)
 
-    return try await withCheckedThrowingContinuation { continuation in
-      self.continuation = continuation
-      Self.activeHelper = self
+    return try await withTaskCancellationHandler {
+      try Task.checkCancellation()
+      return try await withCheckedThrowingContinuation { continuation in
+        self.continuation = continuation
+        Self.activeHelper = self
 
-      let publicKeyCredentialProvider = publicKeyCredentialProvider(
-        relyingPartyIdentifier: relyingPartyIdentifier
-      )
+        let publicKeyCredentialProvider = publicKeyCredentialProvider(
+          relyingPartyIdentifier: relyingPartyIdentifier
+        )
 
-      let registrationRequest = publicKeyCredentialProvider.createCredentialRegistrationRequest(
-        challenge: challenge,
-        name: name,
-        userID: userId
-      )
+        let registrationRequest = publicKeyCredentialProvider.createCredentialRegistrationRequest(
+          challenge: challenge,
+          name: name,
+          userID: userId
+        )
 
-      // Use only ASAuthorizationPlatformPublicKeyCredentialRegistrationRequests or
-      // ASAuthorizationSecurityKeyPublicKeyCredentialRegistrationRequests here.
-      let authController = ASAuthorizationController(authorizationRequests: [registrationRequest])
-      authController.delegate = self
-      authController.presentationContextProvider = self
-      Self.controller = authController
+        // Use only ASAuthorizationPlatformPublicKeyCredentialRegistrationRequests or
+        // ASAuthorizationSecurityKeyPublicKeyCredentialRegistrationRequests here.
+        let authController = ASAuthorizationController(authorizationRequests: [registrationRequest])
+        authController.delegate = self
+        authController.presentationContextProvider = self
+        Self.controller = authController
 
-      authController.performRequests()
+        authController.performRequests()
+      }
+    } onCancel: {
+      Task { @MainActor in
+        Self.cancelAuthorization(for: helperID)
+      }
     }
   }
 

--- a/Sources/ClerkKit/Helpers/PasskeyHelper.swift
+++ b/Sources/ClerkKit/Helpers/PasskeyHelper.swift
@@ -86,7 +86,9 @@ final class PasskeyHelper: NSObject {
     allowedCredentialIDs: [Data] = [],
     preferImmediatelyAvailableCredentials: Bool
   ) async throws -> ASAuthorization {
-    try await withCheckedThrowingContinuation { continuation in
+    Self.cancelCurrentAuthorization()
+
+    return try await withCheckedThrowingContinuation { continuation in
       self.continuation = continuation
       Self.activeHelper = self
 
@@ -132,7 +134,9 @@ final class PasskeyHelper: NSObject {
     relyingPartyIdentifier: String? = nil,
     allowedCredentialIDs: [Data] = []
   ) async throws -> ASAuthorization {
-    try await withCheckedThrowingContinuation { continuation in
+    Self.cancelCurrentAuthorization()
+
+    return try await withCheckedThrowingContinuation { continuation in
       self.continuation = continuation
       Self.activeHelper = self
 
@@ -160,7 +164,9 @@ final class PasskeyHelper: NSObject {
     userId: Data,
     relyingPartyIdentifier: String? = nil
   ) async throws -> ASAuthorization {
-    try await withCheckedThrowingContinuation { continuation in
+    Self.cancelCurrentAuthorization()
+
+    return try await withCheckedThrowingContinuation { continuation in
       self.continuation = continuation
       Self.activeHelper = self
 

--- a/Sources/ClerkKitUI/Common/SocialButton.swift
+++ b/Sources/ClerkKitUI/Common/SocialButton.swift
@@ -17,6 +17,7 @@ struct SocialButton: View {
   let transferable: Bool
   let unsafeMetadata: JSON?
   let showsTitle: Bool
+  var onStart: (() -> Void)?
   var action: (() async -> Void)?
   var result: Result<Void, Error>?
   var onSuccess: ((TransferFlowResult) -> Void)?
@@ -102,6 +103,7 @@ struct SocialButton: View {
     transferable: Bool = true,
     unsafeMetadata: JSON? = nil,
     showsTitle: Bool = true,
+    onStart: (() -> Void)? = nil,
     onSuccess: ((TransferFlowResult) -> Void)? = nil,
     onError: ((Error) -> Void)? = nil
   ) {
@@ -109,6 +111,7 @@ struct SocialButton: View {
     self.transferable = transferable
     self.unsafeMetadata = unsafeMetadata
     self.showsTitle = showsTitle
+    self.onStart = onStart
     self.onSuccess = onSuccess
     self.onError = onError
   }
@@ -116,6 +119,7 @@ struct SocialButton: View {
   var body: some View {
     AsyncButton {
       do {
+        onStart?()
         if let action {
           await action()
         } else {

--- a/Sources/ClerkKitUI/Common/SocialButton.swift
+++ b/Sources/ClerkKitUI/Common/SocialButton.swift
@@ -22,6 +22,7 @@ struct SocialButton: View {
   var result: Result<Void, Error>?
   var onSuccess: ((TransferFlowResult) -> Void)?
   var onError: ((Error) -> Void)?
+  var onCancel: (() -> Void)?
 
   private var fallbackProviderText: some View {
     ViewThatFits(in: .horizontal) {
@@ -105,7 +106,8 @@ struct SocialButton: View {
     showsTitle: Bool = true,
     onStart: (() -> Void)? = nil,
     onSuccess: ((TransferFlowResult) -> Void)? = nil,
-    onError: ((Error) -> Void)? = nil
+    onError: ((Error) -> Void)? = nil,
+    onCancel: (() -> Void)? = nil
   ) {
     self.provider = provider
     self.transferable = transferable
@@ -114,6 +116,7 @@ struct SocialButton: View {
     self.onStart = onStart
     self.onSuccess = onSuccess
     self.onError = onError
+    self.onCancel = onCancel
   }
 
   var body: some View {
@@ -127,6 +130,7 @@ struct SocialButton: View {
         }
       } catch {
         if error.isUserCancelledError {
+          onCancel?()
           return
         } else {
           onError?(error)

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -222,7 +222,8 @@ struct AuthStartView: View {
     }
     #if os(iOS) && !targetEnvironment(macCatalyst)
     .task(id: passkeySignInIsEnabled) {
-      guard passkeySignInIsEnabled else { return }
+      guard passkeySignInIsEnabled, !authState.automaticPasskeySignInHasStarted else { return }
+      authState.automaticPasskeySignInHasStarted = true
       await startPasskeySignIn()
     }
     #endif

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -23,6 +23,7 @@ struct AuthStartView: View {
 
   @State private var fieldError: Error?
   @State private var generalError: Error?
+  @State private var automaticPasskeySignInTask: Task<Void, Never>?
 
   // MARK: - Configuration
 
@@ -227,9 +228,16 @@ struct AuthStartView: View {
     }
     #if os(iOS) && !targetEnvironment(macCatalyst)
     .task(id: passkeySignInIsEnabled) {
-      guard passkeySignInIsEnabled, !authState.automaticPasskeySignInHasStarted else { return }
+      guard passkeySignInIsEnabled, !authState.automaticPasskeySignInHasStarted, navigation.path.isEmpty else { return }
       authState.automaticPasskeySignInHasStarted = true
-      await startPasskeySignIn()
+      let task = Task { await startPasskeySignIn() }
+      automaticPasskeySignInTask = task
+      await withTaskCancellationHandler {
+        await task.value
+      } onCancel: {
+        task.cancel()
+      }
+      automaticPasskeySignInTask = nil
     }
     #endif
   }
@@ -331,12 +339,9 @@ extension AuthStartView {
         SocialButton(
           provider: lastUsedProvider,
           transferable: authState.transferable,
-          unsafeMetadata: authState.unsafeMetadata
-        ) { result in
-          handleTransferFlowResult(result)
-        } onError: { error in
-          generalError = error
-        }
+          unsafeMetadata: authState.unsafeMetadata,
+          action: { await signInWithSocialProvider(lastUsedProvider) }
+        )
         .lastUsedAuthBadgeOverlay(true)
         .simultaneousGesture(TapGesture())
       }
@@ -348,12 +353,9 @@ extension AuthStartView {
               provider: provider,
               transferable: authState.transferable,
               unsafeMetadata: authState.unsafeMetadata,
-              showsTitle: socialProvidersMinusLastUsed.count == 1
-            ) { result in
-              handleTransferFlowResult(result)
-            } onError: { error in
-              generalError = error
-            }
+              showsTitle: socialProvidersMinusLastUsed.count == 1,
+              action: { await signInWithSocialProvider(provider) }
+            )
             .simultaneousGesture(TapGesture())
           }
         }
@@ -372,12 +374,46 @@ extension AuthStartView {
   }
 
   func startAuth() async {
+    cancelAutomaticPasskeySignIn()
     dismissKeyboard()
 
     switch authState.mode {
     case .signInOrUp: await signIn(withSignUp: true)
     case .signIn: await signIn(withSignUp: false)
     case .signUp: await signUp()
+    }
+  }
+
+  private func cancelAutomaticPasskeySignIn() {
+    automaticPasskeySignInTask?.cancel()
+    automaticPasskeySignInTask = nil
+  }
+
+  private func signInWithSocialProvider(_ provider: OAuthProvider) async {
+    cancelAutomaticPasskeySignIn()
+
+    do {
+      let result: TransferFlowResult
+      if provider == .apple {
+        let appleTransferable = SocialButton.shouldTransferAppleSignIn(
+          transferable: authState.transferable,
+          environment: clerk.environment
+        )
+        result = try await clerk.auth.signInWithApple(
+          transferable: appleTransferable,
+          unsafeMetadata: authState.unsafeMetadata
+        )
+      } else {
+        result = try await clerk.auth.signInWithOAuth(
+          provider: provider,
+          transferable: authState.transferable,
+          unsafeMetadata: authState.unsafeMetadata
+        )
+      }
+      handleTransferFlowResult(result)
+    } catch {
+      if error.isUserCancelledError { return }
+      generalError = error
     }
   }
 
@@ -420,11 +456,13 @@ extension AuthStartView {
       )
 
       generalError = nil
+      guard navigation.path.isEmpty else { return .stopped }
       navigation.setToStepForStatus(signIn: signIn)
       return .completed
     } catch {
       if Task.isCancelled || error.isCancellationError { return .stopped }
       if error.isUserCancelledError { return .continueWithAutofill }
+      guard navigation.path.isEmpty else { return .stopped }
 
       generalError = error
       if autofill {
@@ -438,6 +476,8 @@ extension AuthStartView {
 
   #if os(iOS) && !targetEnvironment(macCatalyst)
   private func startPasskeySignIn() async {
+    guard navigation.path.isEmpty else { return }
+
     if passkeyAutomaticModalIsEnabled {
       let result = await signInWithPasskey(
         autofill: false,
@@ -446,6 +486,7 @@ extension AuthStartView {
       guard case .continueWithAutofill = result else { return }
     }
 
+    guard navigation.path.isEmpty else { return }
     await signInWithPasskey(
       autofill: true,
       preferImmediatelyAvailableCredentials: true

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -124,6 +124,14 @@ struct AuthStartView: View {
     #endif
   }
 
+  var passkeyAutoFillFallbackIsEnabled: Bool {
+    #if os(iOS) && !targetEnvironment(macCatalyst)
+    passkeySignInIsAvailable && showIdentifierField
+    #else
+    false
+    #endif
+  }
+
   private var passkeySignInTaskID: Int? {
     passkeySignInTaskIsEnabled ? automaticPasskeySignInRestartID : nil
   }
@@ -522,9 +530,10 @@ extension AuthStartView {
       guard case .continueWithAutofill = result else { return }
     }
 
-    guard navigation.path.isEmpty else { return }
+    guard passkeyAutoFillFallbackIsEnabled, navigation.path.isEmpty else { return }
     // Clerk's AutoFill setting gates the automatic modal above; this keeps
-    // iOS text-field AutoFill available.
+    // iOS text-field AutoFill available when a visible identifier field can
+    // surface suggestions.
     await authenticateWithPasskey(
       signIn: signIn,
       autofill: true,

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -79,6 +79,23 @@ struct AuthStartView: View {
     return false
   }
 
+  var passkeySignInIsAvailable: Bool {
+    switch authState.mode {
+    case .signIn, .signInOrUp:
+      clerk.environment?.passkeyIsEnabled == true
+    case .signUp:
+      false
+    }
+  }
+
+  var passkeySignInIsEnabled: Bool {
+    #if os(iOS) && !targetEnvironment(macCatalyst)
+    passkeySignInIsAvailable
+    #else
+    false
+    #endif
+  }
+
   private var socialProvidersMinusLastUsed: [OAuthProvider] {
     let providers = clerk.environment?.authenticatableSocialProviders ?? []
     guard let lastUsedSocialProvider = lastUsedAuth?.socialProvider else { return providers }
@@ -192,6 +209,12 @@ struct AuthStartView: View {
         authState.authStartPhoneNumberFieldIsActive = true
       }
     }
+    #if os(iOS) && !targetEnvironment(macCatalyst)
+    .task(id: passkeySignInIsEnabled) {
+      guard passkeySignInIsEnabled else { return }
+      await startPasskeySignIn()
+    }
+    #endif
   }
 }
 
@@ -362,6 +385,47 @@ extension AuthStartView {
       }
     }
   }
+
+  private func signInWithPasskey(
+    autofill: Bool,
+    preferImmediatelyAvailableCredentials: Bool
+  ) async -> Bool {
+    do {
+      let signIn = try await clerk.auth.signInWithPasskey(
+        autofill: autofill,
+        preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
+      )
+
+      generalError = nil
+      navigation.setToStepForStatus(signIn: signIn)
+      return true
+    } catch {
+      if error.isUserCancelledError || error.isCancellationError { return false }
+
+      generalError = error
+      if autofill {
+        ClerkLogger.error("Failed to authenticate with passkey autofill", error: error)
+      } else {
+        ClerkLogger.error("Failed to authenticate with passkey", error: error)
+      }
+      return false
+    }
+  }
+
+  #if os(iOS) && !targetEnvironment(macCatalyst)
+  private func startPasskeySignIn() async {
+    let completedWithModal = await signInWithPasskey(
+      autofill: false,
+      preferImmediatelyAvailableCredentials: true
+    )
+    guard !completedWithModal else { return }
+
+    await signInWithPasskey(
+      autofill: true,
+      preferImmediatelyAvailableCredentials: true
+    )
+  }
+  #endif
 
   private func signUp() async {
     fieldError = nil

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -82,10 +82,15 @@ struct AuthStartView: View {
   var passkeySignInIsAvailable: Bool {
     switch authState.mode {
     case .signIn, .signInOrUp:
-      clerk.environment?.passkeyIsEnabled == true
+      clerk.environment?.passkeyIsEnabled == true &&
+        !lockedInitialIdentifierIsActive
     case .signUp:
       false
     }
+  }
+
+  var lockedInitialIdentifierIsActive: Bool {
+    authState.prefilledFieldsAreLocked && authState.hasInitialIdentifier
   }
 
   var passkeyAutomaticModalIsEnabled: Bool {

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -82,7 +82,7 @@ struct AuthStartView: View {
   var passkeySignInIsAvailable: Bool {
     switch authState.mode {
     case .signIn, .signInOrUp:
-      clerk.environment?.passkeyIsEnabled == true &&
+      clerk.environment?.enabledFirstFactorAttributes.contains("passkey") == true &&
         !lockedInitialIdentifierIsActive
     case .signUp:
       false

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -93,15 +93,11 @@ struct AuthStartView: View {
     authState.prefilledFieldsAreLocked && authState.hasInitialIdentifier
   }
 
-  var passkeyAutomaticModalIsEnabled: Bool {
+  var automaticPasskeySignInIsEnabled: Bool {
+    #if os(iOS) && !targetEnvironment(macCatalyst)
     guard let environment = clerk.environment else { return false }
     return passkeySignInIsAvailable &&
       environment.userSettings.passkeySettings?.allowAutofill == true
-  }
-
-  var passkeySignInIsEnabled: Bool {
-    #if os(iOS) && !targetEnvironment(macCatalyst)
-    passkeySignInIsAvailable
     #else
     false
     #endif
@@ -221,8 +217,8 @@ struct AuthStartView: View {
       }
     }
     #if os(iOS) && !targetEnvironment(macCatalyst)
-    .task(id: passkeySignInIsEnabled) {
-      guard passkeySignInIsEnabled, !authState.automaticPasskeySignInHasStarted else { return }
+    .task(id: automaticPasskeySignInIsEnabled) {
+      guard automaticPasskeySignInIsEnabled, !authState.automaticPasskeySignInHasStarted else { return }
       authState.automaticPasskeySignInHasStarted = true
       await startPasskeySignIn()
     }
@@ -360,6 +356,12 @@ extension AuthStartView {
 // MARK: - Actions
 
 extension AuthStartView {
+  private enum PasskeySignInResult {
+    case completed
+    case retryWithAutofill
+    case failed
+  }
+
   func startAuth() async {
     dismissKeyboard()
 
@@ -401,7 +403,7 @@ extension AuthStartView {
   private func signInWithPasskey(
     autofill: Bool,
     preferImmediatelyAvailableCredentials: Bool
-  ) async -> Bool {
+  ) async -> PasskeySignInResult {
     do {
       let signIn = try await clerk.auth.signInWithPasskey(
         autofill: autofill,
@@ -410,9 +412,9 @@ extension AuthStartView {
 
       generalError = nil
       navigation.setToStepForStatus(signIn: signIn)
-      return true
+      return .completed
     } catch {
-      if error.isUserCancelledError || error.isCancellationError { return false }
+      if error.isUserCancelledError || error.isCancellationError { return .retryWithAutofill }
 
       generalError = error
       if autofill {
@@ -420,19 +422,17 @@ extension AuthStartView {
       } else {
         ClerkLogger.error("Failed to authenticate with passkey", error: error)
       }
-      return false
+      return .failed
     }
   }
 
   #if os(iOS) && !targetEnvironment(macCatalyst)
   private func startPasskeySignIn() async {
-    if passkeyAutomaticModalIsEnabled {
-      let completedWithModal = await signInWithPasskey(
-        autofill: false,
-        preferImmediatelyAvailableCredentials: true
-      )
-      guard !completedWithModal else { return }
-    }
+    let result = await signInWithPasskey(
+      autofill: false,
+      preferImmediatelyAvailableCredentials: true
+    )
+    guard case .retryWithAutofill = result else { return }
 
     await signInWithPasskey(
       autofill: true,

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -84,9 +84,13 @@ struct AuthStartView: View {
   }
 
   var passkeySignInIsAvailable: Bool {
+    passkeySignInIsAvailable(environment: clerk.environment)
+  }
+
+  func passkeySignInIsAvailable(environment: Clerk.Environment?) -> Bool {
     switch authState.mode {
     case .signIn, .signInOrUp:
-      clerk.environment?.passkeyIsEnabled == true &&
+      environment?.passkeyIsEnabled == true &&
         !lockedInitialIdentifierIsActive
     case .signUp:
       false
@@ -97,11 +101,10 @@ struct AuthStartView: View {
     authState.prefilledFieldsAreLocked && authState.hasInitialIdentifier
   }
 
-  var passkeyAutomaticModalIsEnabled: Bool {
+  func passkeyAutomaticModalIsEnabled(environment: Clerk.Environment) -> Bool {
     #if os(iOS) && !targetEnvironment(macCatalyst)
-    guard let environment = clerk.environment else { return false }
     // Clerk's AutoFill setting controls the no-interaction modal, not iOS's text-field AutoFill request.
-    return passkeySignInIsAvailable &&
+    return passkeySignInIsAvailable(environment: environment) &&
       environment.userSettings.passkeySettings?.allowAutofill == true
     #else
     false
@@ -125,8 +128,15 @@ struct AuthStartView: View {
   }
 
   var passkeyAutoFillFallbackIsEnabled: Bool {
+    passkeyAutoFillFallbackIsEnabled(environment: clerk.environment)
+  }
+
+  func passkeyAutoFillFallbackIsEnabled(environment: Clerk.Environment?) -> Bool {
     #if os(iOS) && !targetEnvironment(macCatalyst)
-    passkeySignInIsAvailable && !phoneNumberInputIsActive && (emailIsEnabled || usernameIsEnabled)
+    let enabledAttributes = environment?.enabledFirstFactorAttributes ?? []
+    return passkeySignInIsAvailable(environment: environment) &&
+      !phoneNumberInputIsActive &&
+      (enabledAttributes.contains("email_address") || enabledAttributes.contains("username"))
     #else
     false
     #endif
@@ -520,8 +530,13 @@ extension AuthStartView {
   #if os(iOS) && !targetEnvironment(macCatalyst)
   private func startPasskeySignIn(includeAutomaticModal: Bool) async {
     guard navigation.path.isEmpty else { return }
-    let shouldPresentAutomaticModal = includeAutomaticModal && passkeyAutomaticModalIsEnabled
-    guard shouldPresentAutomaticModal || passkeyAutoFillFallbackIsEnabled else { return }
+    let checkpoint = authState.environmentRefreshCheckpoint(for: clerk)
+    guard let environment = try? await clerk.ensureEnvironmentRefreshed(after: checkpoint) else { return }
+    guard !Task.isCancelled, navigation.path.isEmpty else { return }
+
+    let shouldPresentAutomaticModal = includeAutomaticModal && passkeyAutomaticModalIsEnabled(environment: environment)
+    let shouldStartAutoFillFallback = passkeyAutoFillFallbackIsEnabled(environment: environment)
+    guard shouldPresentAutomaticModal || shouldStartAutoFillFallback else { return }
 
     guard let signIn = await createPasskeySignIn() else { return }
     guard !Task.isCancelled, navigation.path.isEmpty else { return }
@@ -535,7 +550,7 @@ extension AuthStartView {
       guard case .continueWithAutofill = result else { return }
     }
 
-    guard passkeyAutoFillFallbackIsEnabled, navigation.path.isEmpty else { return }
+    guard shouldStartAutoFillFallback, navigation.path.isEmpty else { return }
     // Clerk's AutoFill setting gates the automatic modal above; this keeps
     // iOS text-field AutoFill available when a visible identifier field can
     // surface suggestions.

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -24,8 +24,15 @@ struct AuthStartView: View {
   @State private var fieldError: Error?
   @State private var generalError: Error?
   @State private var automaticPasskeySignInTask: Task<Void, Never>?
+  @State private var automaticPasskeySignInTaskGeneration = 0
+  @State private var automaticPasskeySignInRestartID = 0
 
   // MARK: - Configuration
+
+  private struct PasskeySignInTaskID: Equatable {
+    let isEnabled: Bool
+    let restartID: Int
+  }
 
   var emailIsEnabled: Bool {
     clerk.environment?.enabledFirstFactorAttributes
@@ -119,6 +126,10 @@ struct AuthStartView: View {
     #else
     false
     #endif
+  }
+
+  private var passkeySignInTaskID: PasskeySignInTaskID {
+    .init(isEnabled: passkeySignInTaskIsEnabled, restartID: automaticPasskeySignInRestartID)
   }
 
   private var socialProvidersMinusLastUsed: [OAuthProvider] {
@@ -235,10 +246,12 @@ struct AuthStartView: View {
       }
     }
     #if os(iOS) && !targetEnvironment(macCatalyst)
-    .task(id: passkeySignInTaskIsEnabled) {
-      guard passkeySignInTaskIsEnabled else { return }
+    .task(id: passkeySignInTaskID) {
+      guard passkeySignInTaskID.isEnabled else { return }
       let includeAutomaticModal = !authState.automaticPasskeySignInHasStarted
       authState.automaticPasskeySignInHasStarted = true
+      automaticPasskeySignInTaskGeneration += 1
+      let taskGeneration = automaticPasskeySignInTaskGeneration
       let task = Task { await startPasskeySignIn(includeAutomaticModal: includeAutomaticModal) }
       automaticPasskeySignInTask = task
       await withTaskCancellationHandler {
@@ -246,7 +259,9 @@ struct AuthStartView: View {
       } onCancel: {
         task.cancel()
       }
-      automaticPasskeySignInTask = nil
+      if automaticPasskeySignInTaskGeneration == taskGeneration {
+        automaticPasskeySignInTask = nil
+      }
     }
     #endif
   }
@@ -351,7 +366,11 @@ extension AuthStartView {
           unsafeMetadata: authState.unsafeMetadata,
           onStart: cancelAutomaticPasskeySignIn,
           onSuccess: handleTransferFlowResult,
-          onError: { generalError = $0 }
+          onError: { error in
+            generalError = error
+            restartAutomaticPasskeySignInIfNeeded()
+          },
+          onCancel: restartAutomaticPasskeySignInIfNeeded
         )
         .lastUsedAuthBadgeOverlay(true)
         .simultaneousGesture(TapGesture())
@@ -367,7 +386,11 @@ extension AuthStartView {
               showsTitle: socialProvidersMinusLastUsed.count == 1,
               onStart: cancelAutomaticPasskeySignIn,
               onSuccess: handleTransferFlowResult,
-              onError: { generalError = $0 }
+              onError: { error in
+                generalError = error
+                restartAutomaticPasskeySignInIfNeeded()
+              },
+              onCancel: restartAutomaticPasskeySignInIfNeeded
             )
             .simultaneousGesture(TapGesture())
           }
@@ -390,19 +413,29 @@ extension AuthStartView {
     cancelAutomaticPasskeySignIn()
     dismissKeyboard()
 
-    switch authState.mode {
+    let shouldRestartPasskeySignIn = switch authState.mode {
     case .signInOrUp: await signIn(withSignUp: true)
     case .signIn: await signIn(withSignUp: false)
     case .signUp: await signUp()
     }
+
+    if shouldRestartPasskeySignIn {
+      restartAutomaticPasskeySignInIfNeeded()
+    }
   }
 
   private func cancelAutomaticPasskeySignIn() {
+    automaticPasskeySignInTaskGeneration += 1
     automaticPasskeySignInTask?.cancel()
     automaticPasskeySignInTask = nil
   }
 
-  private func signIn(withSignUp: Bool) async {
+  private func restartAutomaticPasskeySignInIfNeeded() {
+    guard passkeySignInTaskIsEnabled else { return }
+    automaticPasskeySignInRestartID += 1
+  }
+
+  private func signIn(withSignUp: Bool) async -> Bool {
     fieldError = nil
 
     do {
@@ -417,15 +450,17 @@ extension AuthStartView {
           unsafeMetadata: authState.unsafeMetadata
         )
         handleTransferFlowResult(result)
-        return
+        return false
       }
 
       navigation.setToStepForStatus(signIn: signIn)
+      return signInStatusStaysOnStart(signIn.status)
     } catch {
       if withSignUp, let clerkApiError = error as? ClerkAPIError, ["form_identifier_not_found", "invitation_account_not_exists"].contains(clerkApiError.code) {
-        await signUp()
+        return await signUp()
       } else {
         fieldError = error
+        return true
       }
     }
   }
@@ -484,14 +519,16 @@ extension AuthStartView {
   }
   #endif
 
-  private func signUp() async {
+  private func signUp() async -> Bool {
     fieldError = nil
 
     do {
       let signUp = try await signUpParams()
       navigation.setToStepForStatus(signUp: signUp)
+      return signUpStatusStaysOnStart(signUp.status)
     } catch {
       fieldError = error
+      return true
     }
   }
 
@@ -530,6 +567,24 @@ extension AuthStartView {
       authState.storeLastUsedIdentifierType(.email)
     } else {
       authState.storeLastUsedIdentifierType(.username)
+    }
+  }
+
+  private func signInStatusStaysOnStart(_ status: SignIn.Status) -> Bool {
+    switch status {
+    case .needsIdentifier, .unknown:
+      true
+    default:
+      false
+    }
+  }
+
+  private func signUpStatusStaysOnStart(_ status: SignUp.Status) -> Bool {
+    switch status {
+    case .abandoned, .unknown:
+      true
+    default:
+      false
     }
   }
 }

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -86,7 +86,7 @@ struct AuthStartView: View {
   var passkeySignInIsAvailable: Bool {
     switch authState.mode {
     case .signIn, .signInOrUp:
-      clerk.environment?.enabledFirstFactorAttributes.contains("passkey") == true &&
+      clerk.environment?.passkeyIsEnabled == true &&
         !lockedInitialIdentifierIsActive
     case .signUp:
       false

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -26,13 +26,9 @@ struct AuthStartView: View {
   @State private var automaticPasskeySignInTask: Task<Void, Never>?
   @State private var automaticPasskeySignInTaskGeneration = 0
   @State private var automaticPasskeySignInRestartID = 0
+  @State private var automaticPasskeySignInHasStarted = false
 
   // MARK: - Configuration
-
-  private struct PasskeySignInTaskID: Equatable {
-    let isEnabled: Bool
-    let restartID: Int
-  }
 
   var emailIsEnabled: Bool {
     clerk.environment?.enabledFirstFactorAttributes
@@ -128,8 +124,8 @@ struct AuthStartView: View {
     #endif
   }
 
-  private var passkeySignInTaskID: PasskeySignInTaskID {
-    .init(isEnabled: passkeySignInTaskIsEnabled, restartID: automaticPasskeySignInRestartID)
+  private var passkeySignInTaskID: Int? {
+    passkeySignInTaskIsEnabled ? automaticPasskeySignInRestartID : nil
   }
 
   private var socialProvidersMinusLastUsed: [OAuthProvider] {
@@ -247,9 +243,9 @@ struct AuthStartView: View {
     }
     #if os(iOS) && !targetEnvironment(macCatalyst)
     .task(id: passkeySignInTaskID) {
-      guard passkeySignInTaskID.isEnabled else { return }
-      let includeAutomaticModal = !authState.automaticPasskeySignInHasStarted
-      authState.automaticPasskeySignInHasStarted = true
+      guard passkeySignInTaskID != nil else { return }
+      let includeAutomaticModal = !automaticPasskeySignInHasStarted
+      automaticPasskeySignInHasStarted = true
       automaticPasskeySignInTaskGeneration += 1
       let taskGeneration = automaticPasskeySignInTaskGeneration
       let task = Task { await startPasskeySignIn(includeAutomaticModal: includeAutomaticModal) }
@@ -465,12 +461,26 @@ extension AuthStartView {
     }
   }
 
-  private func signInWithPasskey(
+  private func createPasskeySignIn() async -> SignIn? {
+    do {
+      return try await clerk.auth.createPasskeySignIn()
+    } catch {
+      if Task.isCancelled || error.isCancellationError { return nil }
+      guard navigation.path.isEmpty else { return nil }
+
+      generalError = error
+      ClerkLogger.error("Failed to create passkey sign-in", error: error)
+      return nil
+    }
+  }
+
+  private func authenticateWithPasskey(
+    signIn: SignIn,
     autofill: Bool,
     preferImmediatelyAvailableCredentials: Bool
   ) async -> PasskeySignInResult {
     do {
-      let signIn = try await clerk.auth.signInWithPasskey(
+      let signIn = try await signIn.authenticateWithPasskey(
         autofill: autofill,
         preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
       )
@@ -500,9 +510,12 @@ extension AuthStartView {
   #if os(iOS) && !targetEnvironment(macCatalyst)
   private func startPasskeySignIn(includeAutomaticModal: Bool) async {
     guard navigation.path.isEmpty else { return }
+    guard let signIn = await createPasskeySignIn() else { return }
+    guard !Task.isCancelled, navigation.path.isEmpty else { return }
 
     if includeAutomaticModal, passkeyAutomaticModalIsEnabled {
-      let result = await signInWithPasskey(
+      let result = await authenticateWithPasskey(
+        signIn: signIn,
         autofill: false,
         preferImmediatelyAvailableCredentials: true
       )
@@ -512,7 +525,8 @@ extension AuthStartView {
     guard navigation.path.isEmpty else { return }
     // Clerk's AutoFill setting gates the automatic modal above; this keeps
     // iOS text-field AutoFill available.
-    await signInWithPasskey(
+    await authenticateWithPasskey(
+      signIn: signIn,
       autofill: true,
       preferImmediatelyAvailableCredentials: true
     )

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -349,7 +349,9 @@ extension AuthStartView {
           provider: lastUsedProvider,
           transferable: authState.transferable,
           unsafeMetadata: authState.unsafeMetadata,
-          action: { await signInWithSocialProvider(lastUsedProvider) }
+          onStart: cancelAutomaticPasskeySignIn,
+          onSuccess: handleTransferFlowResult,
+          onError: { generalError = $0 }
         )
         .lastUsedAuthBadgeOverlay(true)
         .simultaneousGesture(TapGesture())
@@ -363,7 +365,9 @@ extension AuthStartView {
               transferable: authState.transferable,
               unsafeMetadata: authState.unsafeMetadata,
               showsTitle: socialProvidersMinusLastUsed.count == 1,
-              action: { await signInWithSocialProvider(provider) }
+              onStart: cancelAutomaticPasskeySignIn,
+              onSuccess: handleTransferFlowResult,
+              onError: { generalError = $0 }
             )
             .simultaneousGesture(TapGesture())
           }
@@ -396,34 +400,6 @@ extension AuthStartView {
   private func cancelAutomaticPasskeySignIn() {
     automaticPasskeySignInTask?.cancel()
     automaticPasskeySignInTask = nil
-  }
-
-  private func signInWithSocialProvider(_ provider: OAuthProvider) async {
-    cancelAutomaticPasskeySignIn()
-
-    do {
-      let result: TransferFlowResult
-      if provider == .apple {
-        let appleTransferable = SocialButton.shouldTransferAppleSignIn(
-          transferable: authState.transferable,
-          environment: clerk.environment
-        )
-        result = try await clerk.auth.signInWithApple(
-          transferable: appleTransferable,
-          unsafeMetadata: authState.unsafeMetadata
-        )
-      } else {
-        result = try await clerk.auth.signInWithOAuth(
-          provider: provider,
-          transferable: authState.transferable,
-          unsafeMetadata: authState.unsafeMetadata
-        )
-      }
-      handleTransferFlowResult(result)
-    } catch {
-      if error.isUserCancelledError { return }
-      generalError = error
-    }
   }
 
   private func signIn(withSignUp: Bool) async {

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -455,6 +455,7 @@ extension AuthStartView {
         preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
       )
 
+      guard !Task.isCancelled else { return .stopped }
       generalError = nil
       guard navigation.path.isEmpty else { return .stopped }
       navigation.setToStepForStatus(signIn: signIn)

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -126,7 +126,7 @@ struct AuthStartView: View {
 
   var passkeyAutoFillFallbackIsEnabled: Bool {
     #if os(iOS) && !targetEnvironment(macCatalyst)
-    passkeySignInIsAvailable && showIdentifierField
+    passkeySignInIsAvailable && !phoneNumberInputIsActive && (emailIsEnabled || usernameIsEnabled)
     #else
     false
     #endif
@@ -349,9 +349,11 @@ extension AuthStartView {
 
   private var identifierSwitcherButton: some View {
     Button {
+      cancelAutomaticPasskeySignIn()
       withAnimation(.default.speed(2)) {
         authState.authStartPhoneNumberFieldIsActive.toggle()
       }
+      restartAutomaticPasskeySignInIfNeeded()
     } label: {
       Text(identifierSwitcherString, bundle: .module)
         .id(phoneNumberFieldIsActive)
@@ -518,10 +520,13 @@ extension AuthStartView {
   #if os(iOS) && !targetEnvironment(macCatalyst)
   private func startPasskeySignIn(includeAutomaticModal: Bool) async {
     guard navigation.path.isEmpty else { return }
+    let shouldPresentAutomaticModal = includeAutomaticModal && passkeyAutomaticModalIsEnabled
+    guard shouldPresentAutomaticModal || passkeyAutoFillFallbackIsEnabled else { return }
+
     guard let signIn = await createPasskeySignIn() else { return }
     guard !Task.isCancelled, navigation.path.isEmpty else { return }
 
-    if includeAutomaticModal, passkeyAutomaticModalIsEnabled {
+    if shouldPresentAutomaticModal {
       let result = await authenticateWithPasskey(
         signIn: signIn,
         autofill: false,

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -113,6 +113,14 @@ struct AuthStartView: View {
     #endif
   }
 
+  var passkeySignInTaskIsEnabled: Bool {
+    #if os(iOS) && !targetEnvironment(macCatalyst)
+    passkeySignInIsEnabled && navigation.path.isEmpty
+    #else
+    false
+    #endif
+  }
+
   private var socialProvidersMinusLastUsed: [OAuthProvider] {
     let providers = clerk.environment?.authenticatableSocialProviders ?? []
     guard let lastUsedSocialProvider = lastUsedAuth?.socialProvider else { return providers }
@@ -227,10 +235,11 @@ struct AuthStartView: View {
       }
     }
     #if os(iOS) && !targetEnvironment(macCatalyst)
-    .task(id: passkeySignInIsEnabled) {
-      guard passkeySignInIsEnabled, !authState.automaticPasskeySignInHasStarted, navigation.path.isEmpty else { return }
+    .task(id: passkeySignInTaskIsEnabled) {
+      guard passkeySignInTaskIsEnabled else { return }
+      let includeAutomaticModal = !authState.automaticPasskeySignInHasStarted
       authState.automaticPasskeySignInHasStarted = true
-      let task = Task { await startPasskeySignIn() }
+      let task = Task { await startPasskeySignIn(includeAutomaticModal: includeAutomaticModal) }
       automaticPasskeySignInTask = task
       await withTaskCancellationHandler {
         await task.value
@@ -238,11 +247,6 @@ struct AuthStartView: View {
         task.cancel()
       }
       automaticPasskeySignInTask = nil
-    }
-    .onChange(of: navigation.path) { _, newPath in
-      if !newPath.isEmpty {
-        cancelAutomaticPasskeySignIn()
-      }
     }
     #endif
   }
@@ -476,15 +480,17 @@ extension AuthStartView {
       } else {
         ClerkLogger.error("Failed to authenticate with passkey", error: error)
       }
+      // Keep iOS text-field AutoFill armed after a modal error so users can
+      // pick another passkey without a second modal.
       return autofill ? .stopped : .continueWithAutofill
     }
   }
 
   #if os(iOS) && !targetEnvironment(macCatalyst)
-  private func startPasskeySignIn() async {
+  private func startPasskeySignIn(includeAutomaticModal: Bool) async {
     guard navigation.path.isEmpty else { return }
 
-    if passkeyAutomaticModalIsEnabled {
+    if includeAutomaticModal, passkeyAutomaticModalIsEnabled {
       let result = await signInWithPasskey(
         autofill: false,
         preferImmediatelyAvailableCredentials: true
@@ -493,6 +499,8 @@ extension AuthStartView {
     }
 
     guard navigation.path.isEmpty else { return }
+    // Clerk's AutoFill setting gates the automatic modal above; this keeps
+    // iOS text-field AutoFill available.
     await signInWithPasskey(
       autofill: true,
       preferImmediatelyAvailableCredentials: true

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -93,11 +93,20 @@ struct AuthStartView: View {
     authState.prefilledFieldsAreLocked && authState.hasInitialIdentifier
   }
 
-  var automaticPasskeySignInIsEnabled: Bool {
+  var passkeyAutomaticModalIsEnabled: Bool {
     #if os(iOS) && !targetEnvironment(macCatalyst)
     guard let environment = clerk.environment else { return false }
+    // Clerk's AutoFill setting controls the no-interaction modal, not iOS's text-field AutoFill request.
     return passkeySignInIsAvailable &&
       environment.userSettings.passkeySettings?.allowAutofill == true
+    #else
+    false
+    #endif
+  }
+
+  var passkeySignInIsEnabled: Bool {
+    #if os(iOS) && !targetEnvironment(macCatalyst)
+    passkeySignInIsAvailable
     #else
     false
     #endif
@@ -217,8 +226,8 @@ struct AuthStartView: View {
       }
     }
     #if os(iOS) && !targetEnvironment(macCatalyst)
-    .task(id: automaticPasskeySignInIsEnabled) {
-      guard automaticPasskeySignInIsEnabled, !authState.automaticPasskeySignInHasStarted else { return }
+    .task(id: passkeySignInIsEnabled) {
+      guard passkeySignInIsEnabled, !authState.automaticPasskeySignInHasStarted else { return }
       authState.automaticPasskeySignInHasStarted = true
       await startPasskeySignIn()
     }
@@ -358,8 +367,8 @@ extension AuthStartView {
 extension AuthStartView {
   private enum PasskeySignInResult {
     case completed
-    case retryWithAutofill
-    case failed
+    case continueWithAutofill
+    case stopped
   }
 
   func startAuth() async {
@@ -414,7 +423,8 @@ extension AuthStartView {
       navigation.setToStepForStatus(signIn: signIn)
       return .completed
     } catch {
-      if error.isUserCancelledError || error.isCancellationError { return .retryWithAutofill }
+      if Task.isCancelled || error.isCancellationError { return .stopped }
+      if error.isUserCancelledError { return .continueWithAutofill }
 
       generalError = error
       if autofill {
@@ -422,17 +432,19 @@ extension AuthStartView {
       } else {
         ClerkLogger.error("Failed to authenticate with passkey", error: error)
       }
-      return .failed
+      return autofill ? .stopped : .continueWithAutofill
     }
   }
 
   #if os(iOS) && !targetEnvironment(macCatalyst)
   private func startPasskeySignIn() async {
-    let result = await signInWithPasskey(
-      autofill: false,
-      preferImmediatelyAvailableCredentials: true
-    )
-    guard case .retryWithAutofill = result else { return }
+    if passkeyAutomaticModalIsEnabled {
+      let result = await signInWithPasskey(
+        autofill: false,
+        preferImmediatelyAvailableCredentials: true
+      )
+      guard case .continueWithAutofill = result else { return }
+    }
 
     await signInWithPasskey(
       autofill: true,

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -239,6 +239,11 @@ struct AuthStartView: View {
       }
       automaticPasskeySignInTask = nil
     }
+    .onChange(of: navigation.path) { _, newPath in
+      if !newPath.isEmpty {
+        cancelAutomaticPasskeySignIn()
+      }
+    }
     #endif
   }
 }

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -263,7 +263,6 @@ struct AuthStartView: View {
     .task(id: passkeySignInTaskID) {
       guard passkeySignInTaskID != nil else { return }
       let includeAutomaticModal = !automaticPasskeySignInHasStarted
-      automaticPasskeySignInHasStarted = true
       automaticPasskeySignInTaskGeneration += 1
       let taskGeneration = automaticPasskeySignInTaskGeneration
       let task = Task { await startPasskeySignIn(includeAutomaticModal: includeAutomaticModal) }
@@ -276,6 +275,9 @@ struct AuthStartView: View {
       if automaticPasskeySignInTaskGeneration == taskGeneration {
         automaticPasskeySignInTask = nil
       }
+    }
+    .onChange(of: clerk.environmentRefreshCheckpoint) { _, _ in
+      restartAutomaticPasskeySignInAfterEnvironmentRefreshIfNeeded()
     }
     #endif
   }
@@ -451,6 +453,11 @@ extension AuthStartView {
     automaticPasskeySignInRestartID += 1
   }
 
+  private func restartAutomaticPasskeySignInAfterEnvironmentRefreshIfNeeded() {
+    guard !automaticPasskeySignInHasStarted, automaticPasskeySignInTask == nil else { return }
+    restartAutomaticPasskeySignInIfNeeded()
+  }
+
   private func signIn(withSignUp: Bool) async -> Bool {
     fieldError = nil
 
@@ -533,6 +540,9 @@ extension AuthStartView {
     let checkpoint = authState.environmentRefreshCheckpoint(for: clerk)
     guard let environment = try? await clerk.ensureEnvironmentRefreshed(after: checkpoint) else { return }
     guard !Task.isCancelled, navigation.path.isEmpty else { return }
+    if includeAutomaticModal {
+      automaticPasskeySignInHasStarted = true
+    }
 
     let shouldPresentAutomaticModal = includeAutomaticModal && passkeyAutomaticModalIsEnabled(environment: environment)
     let shouldStartAutoFillFallback = passkeyAutoFillFallbackIsEnabled(environment: environment)

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -88,6 +88,12 @@ struct AuthStartView: View {
     }
   }
 
+  var passkeyAutomaticModalIsEnabled: Bool {
+    guard let environment = clerk.environment else { return false }
+    return passkeySignInIsAvailable &&
+      environment.userSettings.passkeySettings?.allowAutofill == true
+  }
+
   var passkeySignInIsEnabled: Bool {
     #if os(iOS) && !targetEnvironment(macCatalyst)
     passkeySignInIsAvailable
@@ -414,11 +420,13 @@ extension AuthStartView {
 
   #if os(iOS) && !targetEnvironment(macCatalyst)
   private func startPasskeySignIn() async {
-    let completedWithModal = await signInWithPasskey(
-      autofill: false,
-      preferImmediatelyAvailableCredentials: true
-    )
-    guard !completedWithModal else { return }
+    if passkeyAutomaticModalIsEnabled {
+      let completedWithModal = await signInWithPasskey(
+        autofill: false,
+        preferImmediatelyAvailableCredentials: true
+      )
+      guard !completedWithModal else { return }
+    }
 
     await signInWithPasskey(
       autofill: true,

--- a/Sources/ClerkKitUI/Components/Auth/AuthState.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthState.swift
@@ -42,6 +42,8 @@ final class AuthState {
   /// Unsafe metadata to attach if the current UI flow creates a sign-up.
   private(set) var unsafeMetadata: JSON?
 
+  var automaticPasskeySignInHasStarted = false
+
   private let userDefaults: UserDefaults
 
   init(

--- a/Sources/ClerkKitUI/Components/Auth/AuthState.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthState.swift
@@ -42,8 +42,6 @@ final class AuthState {
   /// Unsafe metadata to attach if the current UI flow creates a sign-up.
   private(set) var unsafeMetadata: JSON?
 
-  var automaticPasskeySignInHasStarted = false
-
   private let userDefaults: UserDefaults
 
   init(

--- a/Sources/ClerkKitUI/Components/Auth/AuthState.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthState.swift
@@ -42,6 +42,8 @@ final class AuthState {
   /// Unsafe metadata to attach if the current UI flow creates a sign-up.
   private(set) var unsafeMetadata: JSON?
 
+  private var environmentRefreshCheckpoint: Clerk.EnvironmentRefreshCheckpoint?
+
   private let userDefaults: UserDefaults
 
   init(
@@ -163,6 +165,16 @@ enum AuthStartField {
 }
 
 extension AuthState {
+  func environmentRefreshCheckpoint(for clerk: Clerk) -> Clerk.EnvironmentRefreshCheckpoint {
+    if let environmentRefreshCheckpoint {
+      return environmentRefreshCheckpoint
+    }
+
+    let checkpoint = clerk.environmentRefreshCheckpoint
+    environmentRefreshCheckpoint = checkpoint
+    return checkpoint
+  }
+
   var authStartIdentifierIsLocked: Bool {
     prefilledFieldsAreLocked && authStartIdentifierWasPrefilled && !authStartIdentifier.isEmptyTrimmed
   }

--- a/Sources/ClerkKitUI/Components/Auth/AuthView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthView.swift
@@ -164,7 +164,8 @@ public struct AuthView: View {
       }
     }
     .task {
-      _ = try? await clerk.refreshEnvironment()
+      let checkpoint = authState.environmentRefreshCheckpoint(for: clerk)
+      _ = try? await clerk.ensureEnvironmentRefreshed(after: checkpoint)
     }
     .task {
       for await event in clerk.auth.events {

--- a/Tests/Domains/Auth/AuthTests.swift
+++ b/Tests/Domains/Auth/AuthTests.swift
@@ -281,6 +281,23 @@ struct AuthTests {
   }
 
   @Test
+  func createPasskeySignInUsesPasskeyStrategy() async throws {
+    let signInParams = LockIsolated<SignIn.CreateParams?>(nil)
+    let signInService = MockSignInService(create: { params in
+      signInParams.setValue(params)
+      return .mock
+    })
+
+    configureDependencies(signInService: signInService)
+
+    let signIn = try await Clerk.shared.auth.createPasskeySignIn()
+
+    #expect(signIn == .mock)
+    let createParams = try #require(signInParams.value)
+    #expect(createParams.strategy == .passkey)
+  }
+
+  @Test
   func signInWithPasskeyUsesOneShotPasskeySignIn() async throws {
     var preparedSignIn = SignIn.mock
     preparedSignIn.firstFactorVerification = nil

--- a/Tests/Domains/Environment/EnvironmentTests.swift
+++ b/Tests/Domains/Environment/EnvironmentTests.swift
@@ -18,15 +18,97 @@ struct EnvironmentTests {
       called.setValue(true)
       return expectedEnvironment
     })
+    let clerk = makeClerk(environmentService: service)
 
-    Clerk.shared.dependencies = MockDependencyContainer(
-      apiClient: createMockAPIClient(),
-      environmentService: service
-    )
-
-    _ = try await Clerk.shared.refreshEnvironment()
+    _ = try await clerk.refreshEnvironment()
 
     #expect(called.value == true)
-    #expect(Clerk.shared.environment == expectedEnvironment)
+    #expect(clerk.environment == expectedEnvironment)
+  }
+
+  @Test
+  func refreshEnvironmentCoalescesConcurrentRequests() async throws {
+    let callCount = LockIsolated(0)
+    let service = MockEnvironmentService(get: {
+      callCount.withValue { $0 += 1 }
+      try await Task.sleep(for: .milliseconds(100))
+      return .mock
+    })
+    let clerk = makeClerk(environmentService: service)
+
+    let firstRefresh = Task { @MainActor in
+      try await clerk.refreshEnvironment()
+    }
+    try await waitUntil { callCount.value == 1 }
+
+    let secondRefresh = Task { @MainActor in
+      try await clerk.refreshEnvironment()
+    }
+
+    _ = try await firstRefresh.value
+    _ = try await secondRefresh.value
+
+    #expect(callCount.value == 1)
+  }
+
+  @Test
+  func ensureEnvironmentRefreshedAfterSatisfiedCheckpointDoesNotRequestAgain() async throws {
+    let callCount = LockIsolated(0)
+    let service = MockEnvironmentService(get: {
+      callCount.withValue { $0 += 1 }
+      return .mock
+    })
+    let clerk = makeClerk(environmentService: service)
+
+    let checkpoint = clerk.environmentRefreshCheckpoint
+    _ = try await clerk.refreshEnvironment()
+    _ = try await clerk.ensureEnvironmentRefreshed(after: checkpoint)
+
+    #expect(callCount.value == 1)
+  }
+
+  @Test
+  func ensureEnvironmentRefreshedAfterUnsatisfiedCheckpointRequestsEnvironment() async throws {
+    let callCount = LockIsolated(0)
+    let service = MockEnvironmentService(get: {
+      callCount.withValue { $0 += 1 }
+      return .mock
+    })
+    let clerk = makeClerk(environmentService: service)
+
+    let checkpoint = clerk.environmentRefreshCheckpoint
+    _ = try await clerk.ensureEnvironmentRefreshed(after: checkpoint)
+
+    #expect(callCount.value == 1)
+  }
+
+  private func makeClerk(environmentService: MockEnvironmentService) -> Clerk {
+    let clerk = Clerk()
+    clerk.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(runtimeScope: clerk.runtimeScope),
+      environmentService: environmentService
+    )
+    return clerk
+  }
+
+  private func waitUntil(
+    timeout: Duration = .milliseconds(500),
+    _ condition: () -> Bool
+  ) async throws {
+    enum TimeoutError: Error {
+      case timedOut
+    }
+
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+      if condition() {
+        return
+      }
+      try await Task.sleep(for: .milliseconds(10))
+    }
+
+    if !condition() {
+      throw TimeoutError.timedOut
+    }
   }
 }

--- a/Tests/UI/AuthStateConfigurationTests.swift
+++ b/Tests/UI/AuthStateConfigurationTests.swift
@@ -36,23 +36,6 @@ struct AuthStateConfigurationTests {
   }
 
   @Test
-  func automaticPasskeySignInHasNotStartedByDefault() {
-    let authState = AuthState(userDefaults: makeUserDefaults())
-
-    #expect(!authState.automaticPasskeySignInHasStarted)
-  }
-
-  @Test
-  func automaticPasskeySignInStateSurvivesConfigurationChanges() {
-    let authState = AuthState(userDefaults: makeUserDefaults())
-    authState.automaticPasskeySignInHasStarted = true
-
-    authState.configure(AuthConfig(initialIdentifier: "seed@example.com"))
-
-    #expect(authState.automaticPasskeySignInHasStarted)
-  }
-
-  @Test
   func initialEmailOverridesPersistedValues() {
     let defaults = makeUserDefaults()
     defaults.set("stored@example.com", forKey: AuthState.identifierStorageKey)

--- a/Tests/UI/AuthStateConfigurationTests.swift
+++ b/Tests/UI/AuthStateConfigurationTests.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) || os(macOS)
 
 @testable import ClerkKit
 @testable import ClerkKitUI
@@ -33,6 +33,23 @@ struct AuthStateConfigurationTests {
     #expect(defaults.string(forKey: AuthState.identifierStorageKey) == "edited@example.com")
     #expect(defaults.string(forKey: AuthState.phoneNumberStorageKey) == "16666660123")
     #expect(defaults.bool(forKey: AuthState.phoneNumberFieldIsActiveStorageKey))
+  }
+
+  @Test
+  func automaticPasskeySignInHasNotStartedByDefault() {
+    let authState = AuthState(userDefaults: makeUserDefaults())
+
+    #expect(!authState.automaticPasskeySignInHasStarted)
+  }
+
+  @Test
+  func automaticPasskeySignInStateSurvivesConfigurationChanges() {
+    let authState = AuthState(userDefaults: makeUserDefaults())
+    authState.automaticPasskeySignInHasStarted = true
+
+    authState.configure(AuthConfig(initialIdentifier: "seed@example.com"))
+
+    #expect(authState.automaticPasskeySignInHasStarted)
   }
 
   @Test


### PR DESCRIPTION
## Summary

This changes AuthStart so passkey sign-in can start before the user types an identifier, while keeping the existing AuthStart paths available.

When AuthStart is shown and passkeys are available, the view creates one passkey sign-in. If the Clerk dashboard AutoFill setting is enabled, AuthStart uses that sign-in to present the iOS passkey sheet automatically. If the user cancels the sheet or iOS does not find an immediately available credential, the same sign-in is reused for iOS text-field AutoFill so the identifier field can still offer passkey suggestions.

The dashboard AutoFill setting only controls the automatic sheet. The iOS AutoFill fallback stays enabled for passkey sign-in, which lets someone dismiss the sheet, tap into the identifier field, and pick a different passkey without starting a second sign-in.

The flow also cancels pending passkey authorization before another AuthStart action begins, and real passkey errors are surfaced instead of being silently swallowed.

https://github.com/user-attachments/assets/f5015053-5da8-40d1-8923-80003b5c9686