### PR TITLE
Bump SDK version to 1.2.8

### DIFF
--- a/Sources/ClerkKit/Utils/Version.swift
+++ b/Sources/ClerkKit/Utils/Version.swift
@@ -5,6 +5,6 @@
 import Foundation
 
 extension Clerk {
-  public nonisolated static let sdkVersion: String = "1.2.7"
+  public nonisolated static let sdkVersion: String = "1.2.8"
   nonisolated static let apiVersion: String = "2026-05-12"
 }


### PR DESCRIPTION
## Summary
- Bump the Clerk iOS SDK version constant to 1.2.8.

## Testing
- git diff --check