### PR TITLE
Request wobsoriano review on Expo bump PRs

### DIFF
--- a/.github/workflows/bump-javascript-expo-ios-sdk.yml
+++ b/.github/workflows/bump-javascript-expo-ios-sdk.yml
@@ -195,6 +195,10 @@ jobs:
               --body-file "$pr_body")"
           fi
 
+          if ! gh pr edit "$pr_url" --add-reviewer wobsoriano; then
+            echo "::warning::Could not request review from wobsoriano; continuing without a reviewer."
+          fi
+
           echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
 
   notify-slack-release:


### PR DESCRIPTION
The release workflow opens a PR in `clerk/javascript` when `@clerk/expo` needs a new iOS SDK pin. This change requests review from `wobsoriano` after creating or updating that PR.

The review request is best-effort: GitHub emits a workflow warning if it cannot add him, but the Expo bump job still succeeds. The existing release Slack notification already matches the shared mobile release format and is unchanged.

Validated with `actionlint .github/workflows/bump-javascript-expo-ios-sdk.yml` and `git diff --check`.
