### PR TITLE
feat: add hosted auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ clean:
 # Run ClerkKitTests on macOS
 test:
 	@echo "Running unit tests..."
-	swift test --skip Integration --filter '^ClerkKitTests\.'
+	swift test --skip Integration --no-parallel --filter '^ClerkKitTests\.'
 	CLERK_RUN_RECONFIGURE_TESTS=1 swift test --skip Integration --no-parallel --filter '^ClerkKitTests\.ClerkReconfigureTests'
 	@echo "✅ Unit tests completed!"
 

--- a/Sources/ClerkKit/Core/Auth+HostedAuth.swift
+++ b/Sources/ClerkKit/Core/Auth+HostedAuth.swift
@@ -65,7 +65,7 @@ extension Auth {
 
     let redirect = try HostedAuthRedirect(redirectUrl ?? Clerk.shared.options.redirectConfig.redirectUrl)
     let state = try HostedAuthState.generate()
-    let pkce = try HostedAuthPKCE.generatePair()
+    let pkce = try PKCE.generatePair()
 
     let hostedAuth = try await hostedAuthService.create(params: HostedAuthCreateParams(
       redirectUrl: redirect.rawValue,

--- a/Sources/ClerkKit/Core/Auth+HostedAuth.swift
+++ b/Sources/ClerkKit/Core/Auth+HostedAuth.swift
@@ -78,12 +78,20 @@ extension Auth {
     let state = try HostedAuthState.generate()
     let pkce = try PKCE.generatePair()
 
-    let hostedAuth = try await hostedAuthService.create(params: HostedAuthCreateParams(
+    let createParams = HostedAuthCreateParams(
       redirectUrl: redirect.rawValue,
       codeChallenge: pkce.challenge,
       state: state,
       mode: mode
-    ))
+    )
+    let hostedAuth: HostedAuthResource
+    do {
+      hostedAuth = try await hostedAuthService.create(params: createParams)
+    } catch let error as ClerkAPIError where error.code == "signed_out" {
+      // Reconcile an abandoned handoff before retrying once with the same request inputs.
+      try await clerk.refreshClient(skipClientId: true)
+      hostedAuth = try await hostedAuthService.create(params: createParams)
+    }
     let hostedAuthUrl = try hostedAuth.authenticationUrl()
 
     let callbackUrl = try await webAuthentication(

--- a/Sources/ClerkKit/Core/Auth+HostedAuth.swift
+++ b/Sources/ClerkKit/Core/Auth+HostedAuth.swift
@@ -63,7 +63,11 @@ extension Auth {
     try HostedAuthInFlightGate.acquire()
     defer { HostedAuthInFlightGate.release() }
 
-    let redirect = try HostedAuthRedirect(redirectUrl ?? Clerk.shared.options.redirectConfig.redirectUrl)
+    let clerk = Clerk.shared
+    let runtime = clerk.runtimeScope
+    let clientResponseGeneration = clerk.clientResponseGeneration
+
+    let redirect = try HostedAuthRedirect(redirectUrl ?? clerk.options.redirectConfig.redirectUrl)
     let state = try HostedAuthState.generate()
     let pkce = try PKCE.generatePair()
 
@@ -82,9 +86,10 @@ extension Auth {
     )
     let callback = try HostedAuthCallback(url: callbackUrl, redirect: redirect, state: state)
 
-    let clerk = Clerk.shared
-    let runtime = clerk.runtimeScope
-    let clientResponseGeneration = clerk.clientResponseGeneration
+    // A reconfiguration while the browser was open invalidates this flow; fail
+    // before the redeem request consumes the single-use rotating token nonce.
+    try runtime.validateStableRuntime()
+
     let response = try await hostedAuthService.redeem(params: HostedAuthRedeemParams(
       rotatingTokenNonce: callback.rotatingTokenNonce,
       codeVerifier: pkce.verifier

--- a/Sources/ClerkKit/Core/Auth+HostedAuth.swift
+++ b/Sources/ClerkKit/Core/Auth+HostedAuth.swift
@@ -1,0 +1,135 @@
+//
+//  Auth+HostedAuth.swift
+//  Clerk
+//
+
+import Foundation
+
+#if !os(tvOS) && !os(watchOS)
+
+typealias HostedAuthWebAuthentication = @MainActor @Sendable (
+  _ url: URL,
+  _ callbackUrlScheme: String,
+  _ prefersEphemeralWebBrowserSession: Bool
+) async throws -> URL
+
+@MainActor
+private enum HostedAuthInFlightGate {
+  private static var isAcquired = false
+
+  static func acquire() throws {
+    guard !isAcquired else {
+      throw ClerkClientError(message: "A hosted authentication session is already in progress.")
+    }
+    isAcquired = true
+  }
+
+  static func release() {
+    isAcquired = false
+  }
+}
+
+extension Auth {
+  /// Opens Clerk's hosted authentication flow and activates the created session.
+  ///
+  /// - Parameters:
+  ///   - mode: The Account Portal screen to open. When omitted, Account Portal opens sign-in.
+  ///   - redirectUrl: A custom-scheme callback URL. Defaults to Clerk's configured redirect URL,
+  ///     which is `{bundleIdentifier}://callback` unless overridden. Register the URL scheme in the app.
+  ///   - prefersEphemeralWebBrowserSession: Whether to use an ephemeral browser session. Defaults to `false`.
+  /// - Returns: The session created and activated by hosted authentication.
+  /// - Throws: An error if hosted authentication cannot be completed or the callback is invalid.
+  @discardableResult
+  public func startHostedAuth(
+    mode: HostedAuthMode? = nil,
+    redirectUrl: String? = nil,
+    prefersEphemeralWebBrowserSession: Bool = false
+  ) async throws -> Session {
+    try await performHostedAuth(
+      mode: mode,
+      redirectUrl: redirectUrl,
+      prefersEphemeralWebBrowserSession: prefersEphemeralWebBrowserSession,
+      webAuthentication: Self.startHostedAuthWebAuthentication
+    )
+  }
+
+  @discardableResult
+  func performHostedAuth(
+    mode: HostedAuthMode?,
+    redirectUrl: String?,
+    prefersEphemeralWebBrowserSession: Bool,
+    webAuthentication: HostedAuthWebAuthentication
+  ) async throws -> Session {
+    try HostedAuthInFlightGate.acquire()
+    defer { HostedAuthInFlightGate.release() }
+
+    let redirect = try HostedAuthRedirect(redirectUrl ?? Clerk.shared.options.redirectConfig.redirectUrl)
+    let state = try HostedAuthState.generate()
+    let pkce = try HostedAuthPKCE.generatePair()
+
+    let hostedAuth = try await hostedAuthService.create(params: HostedAuthCreateParams(
+      redirectUrl: redirect.rawValue,
+      codeChallenge: pkce.challenge,
+      state: state,
+      mode: mode
+    ))
+    let hostedAuthUrl = try hostedAuth.authenticationUrl()
+
+    let callbackUrl = try await webAuthentication(
+      hostedAuthUrl,
+      redirect.callbackUrlScheme,
+      prefersEphemeralWebBrowserSession
+    )
+    let callback = try HostedAuthCallback(url: callbackUrl, redirect: redirect, state: state)
+
+    let clerk = Clerk.shared
+    let runtime = clerk.runtimeScope
+    let clientResponseGeneration = clerk.clientResponseGeneration
+    let response = try await hostedAuthService.redeem(params: HostedAuthRedeemParams(
+      rotatingTokenNonce: callback.rotatingTokenNonce,
+      codeVerifier: pkce.verifier
+    ))
+    try runtime.validateStableRuntime()
+
+    guard
+      let returnedClient = response.client,
+      returnedClient.sessions.contains(where: { $0.id == callback.createdSessionId })
+    else {
+      throw ClerkClientError(message: "Hosted auth completion did not include the created session.")
+    }
+
+    clerk.applyResponseClient(
+      returnedClient,
+      responseSequence: response.requestSequence,
+      serverDate: response.serverDate,
+      clientResponseGeneration: clientResponseGeneration
+    )
+    guard clerk.client?.sessions.contains(where: { $0.id == callback.createdSessionId }) == true else {
+      throw ClerkClientError(message: "Hosted auth completion could not update the current client.")
+    }
+
+    try await activateSession(sessionId: callback.createdSessionId)
+    guard
+      clerk.client?.lastActiveSessionId == callback.createdSessionId,
+      let activeSession = clerk.client?.sessions.first(where: { $0.id == callback.createdSessionId })
+    else {
+      throw ClerkClientError(message: "Hosted auth completion could not activate the created session.")
+    }
+    return activeSession
+  }
+
+  private static func startHostedAuthWebAuthentication(
+    url: URL,
+    callbackUrlScheme: String,
+    prefersEphemeralWebBrowserSession: Bool
+  ) async throws -> URL {
+    let authSession = WebAuthentication(
+      url: url,
+      prefersEphemeralWebBrowserSession: prefersEphemeralWebBrowserSession,
+      callbackURLScheme: callbackUrlScheme
+    )
+    return try await authSession.start()
+  }
+}
+
+#endif

--- a/Sources/ClerkKit/Core/Auth+HostedAuth.swift
+++ b/Sources/ClerkKit/Core/Auth+HostedAuth.swift
@@ -32,6 +32,13 @@ private enum HostedAuthInFlightGate {
 extension Auth {
   /// Opens Clerk's hosted authentication flow and activates the created session.
   ///
+  /// Completion is observable through the returned ``Session`` and ``AuthEvent/sessionChanged(oldValue:newValue:)``
+  /// events; hosted authentication does not emit ``AuthEvent/signInCompleted(signIn:)`` or
+  /// ``AuthEvent/signUpCompleted(signUp:)`` events.
+  ///
+  /// Only custom-scheme callback URLs are supported; `http`, `https`, and universal-link
+  /// callback URLs are rejected.
+  ///
   /// - Parameters:
   ///   - mode: The Account Portal screen to open. When omitted, Account Portal opens sign-in.
   ///   - redirectUrl: A custom-scheme callback URL. Defaults to Clerk's configured redirect URL,

--- a/Sources/ClerkKit/Core/Auth+HostedAuth.swift
+++ b/Sources/ClerkKit/Core/Auth+HostedAuth.swift
@@ -28,7 +28,9 @@ extension Auth {
   /// - Parameters:
   ///   - mode: The Account Portal screen to open. When omitted, Account Portal opens sign-in.
   ///   - redirectUrl: A custom-scheme callback URL. Defaults to Clerk's configured redirect URL,
-  ///     which is `{bundleIdentifier}://callback` unless overridden. Register the URL scheme in the app.
+  ///     which is `{bundleIdentifier}://callback` unless overridden. The web authentication session
+  ///     delivers the callback directly, so the scheme does not need to be registered in the
+  ///     app's `Info.plist` for this flow.
   ///   - prefersEphemeralWebBrowserSession: Whether to use an ephemeral browser session. Defaults to `false`.
   /// - Returns: The session created and activated by hosted authentication.
   /// - Throws: An error if hosted authentication cannot be completed or the callback is invalid.

--- a/Sources/ClerkKit/Core/Auth+HostedAuth.swift
+++ b/Sources/ClerkKit/Core/Auth+HostedAuth.swift
@@ -13,23 +13,9 @@ typealias HostedAuthWebAuthentication = @MainActor @Sendable (
   _ prefersEphemeralWebBrowserSession: Bool
 ) async throws -> URL
 
-@MainActor
-private enum HostedAuthInFlightGate {
-  private static var isAcquired = false
-
-  static func acquire() throws {
-    guard !isAcquired else {
-      throw ClerkClientError(message: "A hosted authentication session is already in progress.")
-    }
-    isAcquired = true
-  }
-
-  static func release() {
-    isAcquired = false
-  }
-}
-
 extension Auth {
+  @MainActor private static var isHostedAuthInFlight = false
+
   /// Opens Clerk's hosted authentication flow and activates the created session.
   ///
   /// Completion is observable through the returned ``Session`` and ``AuthEvent/sessionChanged(oldValue:newValue:)``
@@ -67,8 +53,11 @@ extension Auth {
     prefersEphemeralWebBrowserSession: Bool,
     webAuthentication: HostedAuthWebAuthentication
   ) async throws -> Session {
-    try HostedAuthInFlightGate.acquire()
-    defer { HostedAuthInFlightGate.release() }
+    guard !Self.isHostedAuthInFlight else {
+      throw ClerkClientError(message: "A hosted authentication session is already in progress.")
+    }
+    Self.isHostedAuthInFlight = true
+    defer { Self.isHostedAuthInFlight = false }
 
     let clerk = Clerk.shared
     let runtime = clerk.runtimeScope

--- a/Sources/ClerkKit/Core/Auth+HostedAuth.swift
+++ b/Sources/ClerkKit/Core/Auth+HostedAuth.swift
@@ -109,7 +109,7 @@ extension Auth {
       throw ClerkClientError(message: "Hosted auth completion did not include the created session.")
     }
 
-    clerk.applyResponseClient(
+    clerk.identityController.applyLegacyResponseClient(
       returnedClient,
       responseSequence: response.requestSequence,
       serverDate: response.serverDate,

--- a/Sources/ClerkKit/Core/Auth+HostedAuth.swift
+++ b/Sources/ClerkKit/Core/Auth+HostedAuth.swift
@@ -63,7 +63,6 @@ extension Auth {
 
     let clerk = Clerk.shared
     let runtime = clerk.runtimeScope
-    let clientResponseGeneration = clerk.clientResponseGeneration
 
     let redirect = try HostedAuthRedirect(redirectUrl ?? clerk.options.redirectConfig.redirectUrl)
     let state = try HostedAuthState.generate()
@@ -85,6 +84,9 @@ extension Auth {
     }
     let hostedAuthUrl = try hostedAuth.authenticationUrl()
 
+    try Task.checkCancellation()
+    try runtime.validateStableRuntime()
+    let browserStartClientResponseGeneration = clerk.clientResponseGeneration
     let callbackUrl = try await webAuthentication(
       hostedAuthUrl,
       redirect.callbackUrlScheme,
@@ -94,13 +96,23 @@ extension Auth {
 
     // A reconfiguration while the browser was open invalidates this flow; fail
     // before the redeem request consumes the single-use rotating token nonce.
+    try Task.checkCancellation()
     try runtime.validateStableRuntime()
+    guard clerk.clientResponseGeneration == browserStartClientResponseGeneration else {
+      throw ClerkClientError(message: "Hosted auth completion could not update the current client.")
+    }
 
     let response = try await hostedAuthService.redeem(params: HostedAuthRedeemParams(
       rotatingTokenNonce: callback.rotatingTokenNonce,
       codeVerifier: pkce.verifier
     ))
+    try Task.checkCancellation()
     try runtime.validateStableRuntime()
+
+    if response.clientSyncContext.update == .explicitClear {
+      try await clerk.identityController.applyNetworkResponse(response.clientSyncContext)
+      throw ClerkClientError(message: "Hosted auth completion could not update the current client.")
+    }
 
     guard
       let returnedClient = response.client,
@@ -109,12 +121,14 @@ extension Auth {
       throw ClerkClientError(message: "Hosted auth completion did not include the created session.")
     }
 
-    clerk.identityController.applyLegacyResponseClient(
-      returnedClient,
-      responseSequence: response.requestSequence,
-      serverDate: response.serverDate,
-      clientResponseGeneration: clientResponseGeneration
-    )
+    guard
+      response.clientSyncContext.clientResponseGeneration
+        == browserStartClientResponseGeneration
+    else {
+      throw ClerkClientError(message: "Hosted auth completion could not update the current client.")
+    }
+
+    try await clerk.identityController.applyNetworkResponse(response.clientSyncContext)
     guard clerk.client?.sessions.contains(where: { $0.id == callback.createdSessionId }) == true else {
       throw ClerkClientError(message: "Hosted auth completion could not update the current client.")
     }

--- a/Sources/ClerkKit/Core/Auth.swift
+++ b/Sources/ClerkKit/Core/Auth.swift
@@ -16,6 +16,7 @@ import Foundation
 public struct Auth {
   private let magicLinkStore: MagicLinkStore
   private let magicLinkService: MagicLinkServiceProtocol
+  let hostedAuthService: HostedAuthServiceProtocol
   private let signInService: SignInServiceProtocol
   private let signUpService: SignUpServiceProtocol
   private let sessionService: SessionServiceProtocol
@@ -25,6 +26,7 @@ public struct Auth {
   init(
     magicLinkStore: MagicLinkStore,
     magicLinkService: MagicLinkServiceProtocol,
+    hostedAuthService: HostedAuthServiceProtocol,
     signInService: SignInServiceProtocol,
     signUpService: SignUpServiceProtocol,
     sessionService: SessionServiceProtocol,
@@ -33,6 +35,7 @@ public struct Auth {
   ) {
     self.magicLinkStore = magicLinkStore
     self.magicLinkService = magicLinkService
+    self.hostedAuthService = hostedAuthService
     self.signInService = signInService
     self.signUpService = signUpService
     self.sessionService = sessionService
@@ -661,7 +664,7 @@ extension Auth {
     }
   }
 
-  private func activateSession(sessionId: String) async throws {
+  func activateSession(sessionId: String) async throws {
     do {
       try await setActive(sessionId: sessionId)
     } catch {

--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -248,6 +248,7 @@ public final class Clerk {
     Auth(
       magicLinkStore: dependencies.magicLinkStore,
       magicLinkService: dependencies.magicLinkService,
+      hostedAuthService: dependencies.hostedAuthService,
       signInService: dependencies.signInService,
       signUpService: dependencies.signUpService,
       sessionService: dependencies.sessionService,

--- a/Sources/ClerkKit/Dependencies/Dependencies.swift
+++ b/Sources/ClerkKit/Dependencies/Dependencies.swift
@@ -50,6 +50,9 @@ protocol Dependencies: AnyObject {
   /// Service for client-related operations.
   var clientService: ClientServiceProtocol { get }
 
+  /// Service for hosted authentication operations.
+  var hostedAuthService: HostedAuthServiceProtocol { get }
+
   /// Service for user-related operations.
   var userService: UserServiceProtocol { get }
 

--- a/Sources/ClerkKit/Dependencies/DependencyContainer.swift
+++ b/Sources/ClerkKit/Dependencies/DependencyContainer.swift
@@ -39,6 +39,7 @@ final class DependencyContainer: Dependencies {
   // MARK: - Services
 
   let clientService: ClientServiceProtocol
+  let hostedAuthService: HostedAuthServiceProtocol
   let userService: UserServiceProtocol
   let signInService: SignInServiceProtocol
   let signUpService: SignUpServiceProtocol
@@ -168,6 +169,7 @@ final class DependencyContainer: Dependencies {
 
     // Phase 4: Services (depend on apiClient and other dependencies)
     clientService = ClientService(apiClient: apiClient)
+    hostedAuthService = HostedAuthService(apiClient: apiClient)
     userService = UserService(apiClient: apiClient)
     signInService = SignInService(apiClient: apiClient)
     signUpService = SignUpService(apiClient: apiClient)

--- a/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
+++ b/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
@@ -125,7 +125,14 @@ struct HostedAuthCallback: Equatable {
     }
 
     let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
-    guard Self.singleValue(named: "state", in: queryItems) == state else {
+    let stateItems = queryItems.filter { $0.name == "state" }
+    guard !stateItems.isEmpty else {
+      throw ClerkClientError(message: "Hosted auth callback did not include a state parameter.")
+    }
+    guard stateItems.count == 1 else {
+      throw ClerkClientError(message: "Hosted auth callback included more than one state parameter.")
+    }
+    guard stateItems[0].value == state else {
       throw ClerkClientError(message: "Hosted auth callback state did not match the initiated state.")
     }
     guard let rotatingTokenNonce = Self.nonEmptySingleValue(named: "rotating_token_nonce", in: queryItems) else {

--- a/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
+++ b/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
@@ -3,9 +3,7 @@
 //  Clerk
 //
 
-import CryptoKit
 import Foundation
-import Security
 
 /// The Account Portal screen shown when hosted authentication starts.
 public enum HostedAuthMode: String, Codable, Sendable {
@@ -57,38 +55,10 @@ struct HostedAuthResource: Codable {
   }
 }
 
-enum HostedAuthPKCE {
-  struct Pair: Equatable {
-    let verifier: String
-    let challenge: String
-  }
-
-  static func generatePair() throws -> Pair {
-    let randomBytes = try HostedAuthRandom.bytes(count: 32)
-    let verifier = Data(randomBytes).base64EncodedString().base64URLFromBase64String()
-    return Pair(verifier: verifier, challenge: challenge(for: verifier))
-  }
-
-  static func challenge(for verifier: String) -> String {
-    let digest = SHA256.hash(data: Data(verifier.utf8))
-    return Data(digest).base64EncodedString().base64URLFromBase64String()
-  }
-}
-
 enum HostedAuthState {
   static func generate() throws -> String {
-    let randomBytes = try HostedAuthRandom.bytes(count: 16)
+    let randomBytes = try SecureRandom.bytes(count: 16)
     return Data(randomBytes).base64EncodedString().base64URLFromBase64String()
-  }
-}
-
-private enum HostedAuthRandom {
-  static func bytes(count: Int) throws -> [UInt8] {
-    var bytes = [UInt8](repeating: 0, count: count)
-    guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
-      throw ClerkClientError(message: "Unable to generate secure random data for hosted auth.")
-    }
-    return bytes
   }
 }
 

--- a/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
+++ b/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
@@ -1,0 +1,184 @@
+//
+//  HostedAuth.swift
+//  Clerk
+//
+
+import CryptoKit
+import Foundation
+import Security
+
+/// The Account Portal screen shown when hosted authentication starts.
+public enum HostedAuthMode: String, Codable, Sendable {
+  /// Opens Account Portal on sign-in.
+  case signIn = "sign-in"
+
+  /// Opens Account Portal on sign-up.
+  case signUp = "sign-up"
+}
+
+struct HostedAuthCreateParams: Encodable {
+  let redirectUrl: String
+  let codeChallenge: String
+  let state: String
+  let mode: HostedAuthMode?
+}
+
+struct HostedAuthRedeemParams: Encodable {
+  let rotatingTokenNonce: String
+  let codeVerifier: String
+  let method = "GET"
+
+  private enum CodingKeys: String, CodingKey {
+    case rotatingTokenNonce
+    case codeVerifier
+    case method = "_method"
+  }
+}
+
+struct HostedAuthResource: Codable {
+  let object: String
+  let url: String
+
+  func authenticationUrl() throws -> URL {
+    guard
+      object == "hosted_auth",
+      let components = URLComponents(string: url),
+      let scheme = components.scheme?.lowercased(),
+      let host = components.host,
+      !host.isEmpty,
+      components.user == nil,
+      components.password == nil,
+      let url = components.url,
+      scheme == "https"
+    else {
+      throw ClerkClientError(message: "Hosted auth creation returned an invalid response.")
+    }
+    return url
+  }
+}
+
+enum HostedAuthPKCE {
+  struct Pair: Equatable {
+    let verifier: String
+    let challenge: String
+  }
+
+  static func generatePair() throws -> Pair {
+    let randomBytes = try HostedAuthRandom.bytes(count: 32)
+    let verifier = Data(randomBytes).base64EncodedString().base64URLFromBase64String()
+    return Pair(verifier: verifier, challenge: challenge(for: verifier))
+  }
+
+  static func challenge(for verifier: String) -> String {
+    let digest = SHA256.hash(data: Data(verifier.utf8))
+    return Data(digest).base64EncodedString().base64URLFromBase64String()
+  }
+}
+
+enum HostedAuthState {
+  static func generate() throws -> String {
+    let randomBytes = try HostedAuthRandom.bytes(count: 16)
+    return Data(randomBytes).base64EncodedString().base64URLFromBase64String()
+  }
+}
+
+private enum HostedAuthRandom {
+  static func bytes(count: Int) throws -> [UInt8] {
+    var bytes = [UInt8](repeating: 0, count: count)
+    guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+      throw ClerkClientError(message: "Unable to generate secure random data for hosted auth.")
+    }
+    return bytes
+  }
+}
+
+struct HostedAuthRedirect: Equatable {
+  let rawValue: String
+  private let components: URLComponents
+
+  var callbackUrlScheme: String {
+    components.scheme ?? ""
+  }
+
+  init(_ rawValue: String) throws {
+    let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard
+      rawValue == trimmed,
+      !rawValue.isEmpty,
+      rawValue.contains("://"),
+      let components = URLComponents(string: rawValue),
+      let scheme = components.scheme,
+      !scheme.isEmpty,
+      components.url != nil,
+      scheme.caseInsensitiveCompare("http") != .orderedSame,
+      scheme.caseInsensitiveCompare("https") != .orderedSame
+    else {
+      throw ClerkClientError(message: "Hosted auth requires a valid custom-scheme redirect URL.")
+    }
+
+    self.rawValue = rawValue
+    self.components = components
+  }
+
+  func matches(_ callbackUrl: URL) -> Bool {
+    guard let callback = URLComponents(url: callbackUrl, resolvingAgainstBaseURL: false) else {
+      return false
+    }
+
+    return Self.caseInsensitiveEqual(components.scheme, callback.scheme)
+      && components.percentEncodedUser == callback.percentEncodedUser
+      && components.percentEncodedPassword == callback.percentEncodedPassword
+      && Self.caseInsensitiveEqual(components.host, callback.host)
+      && components.port == callback.port
+      && components.percentEncodedPath == callback.percentEncodedPath
+  }
+
+  private static func caseInsensitiveEqual(_ lhs: String?, _ rhs: String?) -> Bool {
+    switch (lhs, rhs) {
+    case (nil, nil):
+      true
+    case (.some(let lhs), .some(let rhs)):
+      lhs.caseInsensitiveCompare(rhs) == .orderedSame
+    default:
+      false
+    }
+  }
+}
+
+struct HostedAuthCallback: Equatable {
+  let rotatingTokenNonce: String
+  let createdSessionId: String
+
+  init(url: URL, redirect: HostedAuthRedirect, state: String) throws {
+    guard redirect.matches(url) else {
+      throw ClerkClientError(message: "Hosted auth callback URL did not match the initiated redirect URL.")
+    }
+
+    let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    guard Self.singleValue(named: "state", in: queryItems) == state else {
+      throw ClerkClientError(message: "Hosted auth callback state did not match the initiated state.")
+    }
+    guard let rotatingTokenNonce = Self.nonEmptySingleValue(named: "rotating_token_nonce", in: queryItems) else {
+      throw ClerkClientError(message: "Hosted auth callback did not include a rotating token nonce.")
+    }
+    guard let createdSessionId = Self.nonEmptySingleValue(named: "created_session_id", in: queryItems) else {
+      throw ClerkClientError(message: "Hosted auth callback did not include the created session.")
+    }
+
+    self.rotatingTokenNonce = rotatingTokenNonce
+    self.createdSessionId = createdSessionId
+  }
+
+  private static func nonEmptySingleValue(named name: String, in queryItems: [URLQueryItem]) -> String? {
+    guard let value = singleValue(named: name, in: queryItems), !value.isEmpty else {
+      return nil
+    }
+    return value
+  }
+
+  private static func singleValue(named name: String, in queryItems: [URLQueryItem]) -> String? {
+    let matches = queryItems.filter { $0.name == name }
+    guard matches.count == 1 else { return nil }
+    return matches[0].value
+  }
+}

--- a/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
+++ b/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
@@ -24,6 +24,8 @@ struct HostedAuthCreateParams: Encodable {
 struct HostedAuthRedeemParams: Encodable {
   let rotatingTokenNonce: String
   let codeVerifier: String
+  /// FAPI method-override tunnel: routes the redeem as a client GET while keeping
+  /// the nonce and PKCE verifier in the POST body, per the hosted-auth contract.
   let method = "GET"
 
   private enum CodingKeys: String, CodingKey {

--- a/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
+++ b/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
@@ -149,15 +149,8 @@ struct HostedAuthCallback: Equatable {
   }
 
   private static func nonEmptySingleValue(named name: String, in queryItems: [URLQueryItem]) -> String? {
-    guard let value = singleValue(named: name, in: queryItems), !value.isEmpty else {
-      return nil
-    }
-    return value
-  }
-
-  private static func singleValue(named name: String, in queryItems: [URLQueryItem]) -> String? {
     let matches = queryItems.filter { $0.name == name }
-    guard matches.count == 1 else { return nil }
-    return matches[0].value
+    guard matches.count == 1, let value = matches[0].value, !value.isEmpty else { return nil }
+    return value
   }
 }

--- a/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
+++ b/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
@@ -127,15 +127,8 @@ struct HostedAuthCallback: Equatable {
     }
 
     let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
-    let stateItems = queryItems.filter { $0.name == "state" }
-    guard !stateItems.isEmpty else {
-      throw ClerkClientError(message: "Hosted auth callback did not include a state parameter.")
-    }
-    guard stateItems.count == 1 else {
-      throw ClerkClientError(message: "Hosted auth callback included more than one state parameter.")
-    }
-    guard stateItems[0].value == state else {
-      throw ClerkClientError(message: "Hosted auth callback state did not match the initiated state.")
+    guard let callbackState = Self.nonEmptySingleValue(named: "state", in: queryItems), callbackState == state else {
+      throw ClerkClientError(message: "Hosted auth callback state was missing or did not match the initiated state.")
     }
     guard let rotatingTokenNonce = Self.nonEmptySingleValue(named: "rotating_token_nonce", in: queryItems) else {
       throw ClerkClientError(message: "Hosted auth callback did not include a rotating token nonce.")

--- a/Sources/ClerkKit/Domains/Auth/HostedAuthService.swift
+++ b/Sources/ClerkKit/Domains/Auth/HostedAuthService.swift
@@ -23,6 +23,7 @@ final class HostedAuthService: HostedAuthServiceProtocol {
       path: "/v1/client/hosted_auth",
       method: .post,
       body: params,
+      automaticallySyncClient: false,
       logBodies: false
     )
 

--- a/Sources/ClerkKit/Domains/Auth/HostedAuthService.swift
+++ b/Sources/ClerkKit/Domains/Auth/HostedAuthService.swift
@@ -1,0 +1,48 @@
+//
+//  HostedAuthService.swift
+//  Clerk
+//
+
+import Foundation
+
+protocol HostedAuthServiceProtocol: Sendable {
+  @MainActor func create(params: HostedAuthCreateParams) async throws -> HostedAuthResource
+  @MainActor func redeem(params: HostedAuthRedeemParams) async throws -> ClientServiceResponse
+}
+
+final class HostedAuthService: HostedAuthServiceProtocol {
+  private let apiClient: APIClient
+
+  init(apiClient: APIClient) {
+    self.apiClient = apiClient
+  }
+
+  @MainActor
+  func create(params: HostedAuthCreateParams) async throws -> HostedAuthResource {
+    let request = Request<ClientResponse<HostedAuthResource>>(
+      path: "/v1/client/hosted_auth",
+      method: .post,
+      body: params,
+      logBodies: false
+    )
+
+    return try await apiClient.send(request).value.response
+  }
+
+  @MainActor
+  func redeem(params: HostedAuthRedeemParams) async throws -> ClientServiceResponse {
+    let request = Request<ClientResponse<Client?>>(
+      path: "/v1/client",
+      method: .post,
+      body: params,
+      automaticallySyncClient: false,
+      logBodies: false
+    )
+    let response = try await apiClient.send(request)
+    return ClientServiceResponse(
+      client: response.value.response,
+      requestSequence: response.requestSequence,
+      serverDate: response.serverDate
+    )
+  }
+}

--- a/Sources/ClerkKit/Domains/Auth/HostedAuthService.swift
+++ b/Sources/ClerkKit/Domains/Auth/HostedAuthService.swift
@@ -7,7 +7,12 @@ import Foundation
 
 protocol HostedAuthServiceProtocol: Sendable {
   @MainActor func create(params: HostedAuthCreateParams) async throws -> HostedAuthResource
-  @MainActor func redeem(params: HostedAuthRedeemParams) async throws -> ClientServiceResponse
+  @MainActor func redeem(params: HostedAuthRedeemParams) async throws -> HostedAuthRedeemResponse
+}
+
+struct HostedAuthRedeemResponse {
+  let client: Client?
+  let clientSyncContext: ClientSyncResponseContext
 }
 
 final class HostedAuthService: HostedAuthServiceProtocol {
@@ -31,19 +36,32 @@ final class HostedAuthService: HostedAuthServiceProtocol {
   }
 
   @MainActor
-  func redeem(params: HostedAuthRedeemParams) async throws -> ClientServiceResponse {
+  func redeem(params: HostedAuthRedeemParams) async throws -> HostedAuthRedeemResponse {
     let request = Request<ClientResponse<Client?>>(
       path: "/v1/client",
       method: .post,
+      headers: [
+        ClerkHeaderRequestMiddleware.canonicalClientRequestHeader: "1",
+      ],
       body: params,
       automaticallySyncClient: false,
       logBodies: false
     )
     let response = try await apiClient.send(request)
-    return ClientServiceResponse(
-      client: response.value.response,
-      requestSequence: response.requestSequence,
-      serverDate: response.serverDate
+    guard let clientSyncMetadata = response.deferredClientSyncMetadata else {
+      throw ClerkClientError(
+        message: "Hosted auth completion response was missing identity synchronization metadata."
+      )
+    }
+    let client = response.value.response
+    let update: ClientResponseUpdate = if clientSyncMetadata.deviceTokenUpdate == .clear {
+      .explicitClear
+    } else {
+      client.map(ClientResponseUpdate.client) ?? .absent
+    }
+    return HostedAuthRedeemResponse(
+      client: client,
+      clientSyncContext: clientSyncMetadata.context(update: update)
     )
   }
 }

--- a/Sources/ClerkKit/Domains/Auth/MagicLink.swift
+++ b/Sources/ClerkKit/Domains/Auth/MagicLink.swift
@@ -3,9 +3,7 @@
 //  Clerk
 //
 
-import CryptoKit
 import Foundation
-import Security
 
 struct MagicLinkCompleteParams: Encodable {
   let flowId: String
@@ -125,28 +123,6 @@ struct MagicLinkCallback: Equatable {
   }
 
   static let requiredParams = Set(Param.allCases.map(\.rawValue))
-}
-
-enum MagicLinkPKCE {
-  static let codeChallengeMethod = "S256"
-
-  struct Pair: Equatable {
-    let verifier: String
-    let challenge: String
-  }
-
-  static func generatePair() throws -> Pair {
-    var randomBytes = [UInt8](repeating: 0, count: 32)
-    let status = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
-    guard status == errSecSuccess else {
-      throw ClerkClientError(message: "Unable to generate a secure magic link verifier.")
-    }
-
-    let verifier = Data(randomBytes).base64EncodedString().base64URLFromBase64String()
-    let digest = SHA256.hash(data: Data(verifier.utf8))
-    let challenge = Data(digest).base64EncodedString().base64URLFromBase64String()
-    return Pair(verifier: verifier, challenge: challenge)
-  }
 }
 
 final class MagicLinkStore {

--- a/Sources/ClerkKit/Domains/Auth/SignIn/SignIn.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignIn/SignIn.swift
@@ -139,7 +139,7 @@ extension SignIn {
       throw ClerkClientError(message: "Redirect URI is missing. Unable to start email link sign-in.")
     }
 
-    let pkcePair = try MagicLinkPKCE.generatePair()
+    let pkcePair = try PKCE.generatePair()
     try magicLinkStore.save(kind: .signIn, flowId: id, codeVerifier: pkcePair.verifier)
 
     return try await signInService.prepareFirstFactor(
@@ -149,7 +149,7 @@ extension SignIn {
         emailAddressId: emailId,
         redirectUri: resolvedRedirectUri,
         codeChallenge: pkcePair.challenge,
-        codeChallengeMethod: MagicLinkPKCE.codeChallengeMethod
+        codeChallengeMethod: PKCE.codeChallengeMethod
       )
     )
   }

--- a/Sources/ClerkKit/Domains/Auth/SignUp/SignUp.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignUp/SignUp.swift
@@ -173,7 +173,7 @@ extension SignUp {
       throw ClerkClientError(message: "Redirect URI is missing. Unable to start email link sign-up verification.")
     }
 
-    let pkcePair = try MagicLinkPKCE.generatePair()
+    let pkcePair = try PKCE.generatePair()
     try magicLinkStore.save(kind: .signUp, flowId: id, codeVerifier: pkcePair.verifier)
 
     return try await signUpService.prepareVerification(
@@ -183,7 +183,7 @@ extension SignUp {
         emailAddressId: nil,
         redirectUri: resolvedRedirectUri,
         codeChallenge: pkcePair.challenge,
-        codeChallengeMethod: MagicLinkPKCE.codeChallengeMethod
+        codeChallengeMethod: PKCE.codeChallengeMethod
       )
     )
   }

--- a/Sources/ClerkKit/Mocks/MockDependencyContainer.swift
+++ b/Sources/ClerkKit/Mocks/MockDependencyContainer.swift
@@ -28,6 +28,7 @@ final class MockDependencyContainer: Dependencies {
   let telemetryCollector: any TelemetryCollectorProtocol
 
   let clientService: ClientServiceProtocol
+  let hostedAuthService: HostedAuthServiceProtocol
   let userService: UserServiceProtocol
   let signInService: SignInServiceProtocol
   let signUpService: SignUpServiceProtocol
@@ -50,6 +51,7 @@ final class MockDependencyContainer: Dependencies {
   ///   - keychain: Optional keychain storage (defaults to InMemoryKeychain).
   ///   - telemetryCollector: Optional telemetry collector (defaults to NoOpTelemetryCollector).
   ///   - clientService: Optional custom client service (defaults to MockClientService with Client.mock).
+  ///   - hostedAuthService: Optional custom hosted authentication service (defaults to MockHostedAuthService).
   ///   - userService: Optional custom user service (defaults to MockUserService).
   ///   - signInService: Optional custom sign-in service (defaults to MockSignInService).
   ///   - signUpService: Optional custom sign-up service (defaults to MockSignUpService).
@@ -73,6 +75,7 @@ final class MockDependencyContainer: Dependencies {
     shouldHydrateProvisionalLegacyClient: Bool = false,
     telemetryCollector: (any TelemetryCollectorProtocol)? = nil,
     clientService: (any ClientServiceProtocol)? = nil,
+    hostedAuthService: (any HostedAuthServiceProtocol)? = nil,
     userService: (any UserServiceProtocol)? = nil,
     signInService: (any SignInServiceProtocol)? = nil,
     signUpService: (any SignUpServiceProtocol)? = nil,
@@ -105,6 +108,7 @@ final class MockDependencyContainer: Dependencies {
 
     // Use custom services if provided, otherwise use mock services
     self.clientService = clientService ?? MockClientService()
+    self.hostedAuthService = hostedAuthService ?? MockHostedAuthService()
     self.userService = userService ?? MockUserService()
     self.signInService = signInService ?? MockSignInService()
     self.signUpService = signUpService ?? MockSignUpService()

--- a/Sources/ClerkKit/Mocks/MockServices/MockHostedAuthService.swift
+++ b/Sources/ClerkKit/Mocks/MockServices/MockHostedAuthService.swift
@@ -1,0 +1,35 @@
+//
+//  MockHostedAuthService.swift
+//  Clerk
+//
+
+import Foundation
+
+final class MockHostedAuthService: HostedAuthServiceProtocol {
+  nonisolated(unsafe) var createHandler: ((HostedAuthCreateParams) async throws -> HostedAuthResource)?
+  nonisolated(unsafe) var redeemHandler: ((HostedAuthRedeemParams) async throws -> ClientServiceResponse)?
+
+  init(
+    create: ((HostedAuthCreateParams) async throws -> HostedAuthResource)? = nil,
+    redeem: ((HostedAuthRedeemParams) async throws -> ClientServiceResponse)? = nil
+  ) {
+    createHandler = create
+    redeemHandler = redeem
+  }
+
+  @MainActor
+  func create(params: HostedAuthCreateParams) async throws -> HostedAuthResource {
+    if let createHandler {
+      return try await createHandler(params)
+    }
+    return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+  }
+
+  @MainActor
+  func redeem(params: HostedAuthRedeemParams) async throws -> ClientServiceResponse {
+    if let redeemHandler {
+      return try await redeemHandler(params)
+    }
+    return ClientServiceResponse(client: .mock, requestSequence: nil, serverDate: nil)
+  }
+}

--- a/Sources/ClerkKit/Mocks/MockServices/MockHostedAuthService.swift
+++ b/Sources/ClerkKit/Mocks/MockServices/MockHostedAuthService.swift
@@ -7,11 +7,11 @@ import Foundation
 
 final class MockHostedAuthService: HostedAuthServiceProtocol {
   nonisolated(unsafe) var createHandler: ((HostedAuthCreateParams) async throws -> HostedAuthResource)?
-  nonisolated(unsafe) var redeemHandler: ((HostedAuthRedeemParams) async throws -> ClientServiceResponse)?
+  nonisolated(unsafe) var redeemHandler: ((HostedAuthRedeemParams) async throws -> HostedAuthRedeemResponse)?
 
   init(
     create: ((HostedAuthCreateParams) async throws -> HostedAuthResource)? = nil,
-    redeem: ((HostedAuthRedeemParams) async throws -> ClientServiceResponse)? = nil
+    redeem: ((HostedAuthRedeemParams) async throws -> HostedAuthRedeemResponse)? = nil
   ) {
     createHandler = create
     redeemHandler = redeem
@@ -26,10 +26,25 @@ final class MockHostedAuthService: HostedAuthServiceProtocol {
   }
 
   @MainActor
-  func redeem(params: HostedAuthRedeemParams) async throws -> ClientServiceResponse {
+  func redeem(params: HostedAuthRedeemParams) async throws -> HostedAuthRedeemResponse {
     if let redeemHandler {
       return try await redeemHandler(params)
     }
-    return ClientServiceResponse(client: .mock, requestSequence: nil, serverDate: nil)
+    let requestIdentity = try await Clerk.shared.identityController.captureRequestIdentity()
+    return HostedAuthRedeemResponse(
+      client: .mock,
+      clientSyncContext: ClientSyncResponseContext(
+        update: .client(.mock),
+        deviceTokenUpdate: requestIdentity.deviceToken == nil
+          ? .set("mock-device-token")
+          : .absent,
+        requestDeviceToken: requestIdentity.deviceToken,
+        baseGeneration: requestIdentity.baseGeneration,
+        serverDate: nil,
+        isCanonicalClientRequest: true,
+        clientResponseGeneration: requestIdentity.clientResponseGeneration,
+        responseSequence: nil
+      )
+    )
   }
 }

--- a/Sources/ClerkKit/Networking/APIRequest.swift
+++ b/Sources/ClerkKit/Networking/APIRequest.swift
@@ -68,6 +68,8 @@ struct Request<Response: Decodable & Sendable> {
 
   private let queryItems: [URLQueryItem]
   private let body: RequestBody?
+  private let automaticallySyncClient: Bool
+  private let logBodies: Bool
   private let decodeClosure: @Sendable (Data, JSONDecoder) throws -> Response
 
   init(
@@ -77,6 +79,8 @@ struct Request<Response: Decodable & Sendable> {
     canEstablishClientWhenTokenless: Bool = false,
     query: [(String, String?)] = [],
     body: (any Encodable & Sendable)? = nil,
+    automaticallySyncClient: Bool = true,
+    logBodies: Bool = true,
     decode: @escaping @Sendable (Data, JSONDecoder) throws -> Response = { data, decoder in
       if Response.self == EmptyResponse.self {
         guard let response = EmptyResponse() as? Response else {
@@ -95,6 +99,8 @@ struct Request<Response: Decodable & Sendable> {
     self.canEstablishClientWhenTokenless = canEstablishClientWhenTokenless
     queryItems = query.map { URLQueryItem(name: $0.0, value: $0.1) }
     self.body = body.map { .encodable(AnyEncodable($0)) }
+    self.automaticallySyncClient = automaticallySyncClient
+    self.logBodies = logBodies
     decodeClosure = decode
   }
 
@@ -144,6 +150,13 @@ struct Request<Response: Decodable & Sendable> {
       if !hasContentTypeHeader {
         urlRequest.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
       }
+    }
+
+    if !automaticallySyncClient {
+      urlRequest.disableAutomaticClerkClientSync()
+    }
+    if !logBodies {
+      urlRequest.disableClerkBodyLogging()
     }
 
     return urlRequest

--- a/Sources/ClerkKit/Networking/APIRequest.swift
+++ b/Sources/ClerkKit/Networking/APIRequest.swift
@@ -185,4 +185,5 @@ struct APIResponse<Value: Sendable> {
   let value: Value
   let requestSequence: Int?
   let serverDate: Date?
+  let deferredClientSyncMetadata: ClientSyncResponseMetadata?
 }

--- a/Sources/ClerkKit/Networking/ClerkAPIClient.swift
+++ b/Sources/ClerkKit/Networking/ClerkAPIClient.swift
@@ -164,7 +164,18 @@ actor APIClient {
 
         let value = try request.decode(data, using: decoder)
         try ensureCurrentRuntimeScope()
-        return APIResponse(value: value, requestSequence: requestSequence, serverDate: httpResponse.serverDate)
+        let deferredClientSyncMetadata: ClientSyncResponseMetadata? =
+          if !urlRequest.shouldAutomaticallySyncClerkClient {
+            ClientSyncResponseMetadata(response: httpResponse, request: urlRequest)
+          } else {
+            nil
+          }
+        return APIResponse(
+          value: value,
+          requestSequence: requestSequence,
+          serverDate: httpResponse.serverDate,
+          deferredClientSyncMetadata: deferredClientSyncMetadata
+        )
       } catch {
         try ensureCurrentRuntimeScope()
 

--- a/Sources/ClerkKit/Networking/Middleware/ClerkClientSyncResponseMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkClientSyncResponseMiddleware.swift
@@ -84,6 +84,33 @@ struct ClientSyncResponseContext {
   }
 }
 
+struct ClientSyncResponseMetadata {
+  let deviceTokenUpdate: ClerkDeviceTokenResponseUpdate
+  let checkpoint: ClerkRequestCheckpoint
+  let serverDate: Date?
+
+  init(response: HTTPURLResponse, request: URLRequest) {
+    deviceTokenUpdate = ClerkDeviceTokenResponseUpdate(
+      authorizationHeader: response.value(forHTTPHeaderField: "Authorization")
+    )
+    checkpoint = request.clerkRequestCheckpoint
+    serverDate = response.serverDate
+  }
+
+  func context(update: ClientResponseUpdate) -> ClientSyncResponseContext {
+    ClientSyncResponseContext(
+      update: update,
+      deviceTokenUpdate: deviceTokenUpdate,
+      requestDeviceToken: checkpoint.requestDeviceToken,
+      baseGeneration: checkpoint.sharedSessionBaseGeneration,
+      serverDate: serverDate,
+      isCanonicalClientRequest: checkpoint.isCanonicalClientRequest,
+      clientResponseGeneration: checkpoint.clientResponseGeneration,
+      responseSequence: checkpoint.requestSequence
+    )
+  }
+}
+
 struct ClerkClientSyncResponseMiddleware: ClerkResponseMiddleware {
   private let runtimeScope: ClerkRuntimeScope
 
@@ -92,27 +119,17 @@ struct ClerkClientSyncResponseMiddleware: ClerkResponseMiddleware {
   }
 
   func validate(_ response: HTTPURLResponse, data: Data, for request: URLRequest) async throws {
-    guard request.shouldAutomaticallySyncClerkClient else { return }
-
     try Task.checkCancellation()
-    let deviceTokenUpdate = ClerkDeviceTokenResponseUpdate(
-      authorizationHeader: response.value(forHTTPHeaderField: "Authorization")
+    let metadata = ClientSyncResponseMetadata(response: response, request: request)
+    let update = Self.classifyClientUpdate(
+      from: data,
+      isCanonicalClientRequest: metadata.checkpoint.isCanonicalClientRequest,
+      deviceTokenUpdate: metadata.deviceTokenUpdate
     )
-    let checkpoint = request.clerkRequestCheckpoint
-    let context = ClientSyncResponseContext(
-      update: Self.classifyClientUpdate(
-        from: data,
-        isCanonicalClientRequest: checkpoint.isCanonicalClientRequest,
-        deviceTokenUpdate: deviceTokenUpdate
-      ),
-      deviceTokenUpdate: deviceTokenUpdate,
-      requestDeviceToken: checkpoint.requestDeviceToken,
-      baseGeneration: checkpoint.sharedSessionBaseGeneration,
-      serverDate: response.serverDate,
-      isCanonicalClientRequest: checkpoint.isCanonicalClientRequest,
-      clientResponseGeneration: checkpoint.clientResponseGeneration,
-      responseSequence: checkpoint.requestSequence
-    )
+    guard request.shouldAutomaticallySyncClerkClient || update == .explicitClear else {
+      return
+    }
+    let context = metadata.context(update: update)
 
     let clerk = try await runtimeScope.requireCurrentClerk()
     try Task.checkCancellation()

--- a/Sources/ClerkKit/Networking/Middleware/ClerkClientSyncResponseMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkClientSyncResponseMiddleware.swift
@@ -5,6 +5,110 @@
 
 import Foundation
 
+struct ClerkClientSyncResponseMiddleware: ClerkResponseMiddleware {
+  private let runtimeScope: ClerkRuntimeScope
+
+  init(runtimeScope: ClerkRuntimeScope) {
+    self.runtimeScope = runtimeScope
+  }
+
+  func validate(_ response: HTTPURLResponse, data: Data, for request: URLRequest) async throws {
+    try Task.checkCancellation()
+    let metadata = ClientSyncResponseMetadata(response: response, request: request)
+    let update = Self.classifyClientUpdate(
+      from: data,
+      isCanonicalClientRequest: metadata.checkpoint.isCanonicalClientRequest,
+      deviceTokenUpdate: metadata.deviceTokenUpdate
+    )
+    guard request.shouldAutomaticallySyncClerkClient || update == .explicitClear else {
+      return
+    }
+    let context = metadata.context(update: update)
+
+    let clerk = try await runtimeScope.requireCurrentClerk()
+    try Task.checkCancellation()
+    try await clerk.identityController.applyNetworkResponse(context)
+  }
+
+  static func classifyClientUpdate(
+    from jsonData: Data,
+    isCanonicalClientRequest: Bool,
+    deviceTokenUpdate: ClerkDeviceTokenResponseUpdate = .absent
+  ) -> ClientResponseUpdate {
+    if deviceTokenUpdate == .clear {
+      return .explicitClear
+    }
+
+    if let client = decodeClient(from: jsonData) {
+      return .client(client)
+    }
+
+    guard let object = try? JSONSerialization.jsonObject(with: jsonData),
+          let payload = object as? [String: Any]
+    else {
+      return .invalid
+    }
+
+    if isCanonicalClientRequest, let response = payload["response"] {
+      return response is NSNull ? .absent : .invalid
+    }
+    if let client = payload["client"], !(client is NSNull) {
+      return .invalid
+    }
+    if let meta = payload["meta"] as? [String: Any],
+       let client = meta["client"],
+       !(client is NSNull)
+    {
+      return .invalid
+    }
+    return .absent
+  }
+
+  static func decodeClient(from jsonData: Data) -> Client? {
+    struct ClientWrapper: Decodable {
+      let client: Client?
+
+      enum CodingKeys: String, CodingKey {
+        case response, client, meta
+      }
+
+      enum MetaCodingKeys: String, CodingKey {
+        case client
+      }
+
+      init(from decoder: Decoder) throws {
+        let container = try? decoder.container(keyedBy: CodingKeys.self)
+
+        if let responseClient = try? container?.decode(Client.self, forKey: .response) {
+          client = responseClient
+          return
+        }
+
+        if let clientClient = try? container?.decode(Client.self, forKey: .client) {
+          client = clientClient
+          return
+        }
+
+        if let metaContainer = try? container?.nestedContainer(keyedBy: MetaCodingKeys.self, forKey: .meta),
+           let metaClient = try? metaContainer.decode(Client.self, forKey: .client)
+        {
+          client = metaClient
+          return
+        }
+
+        if let topLevelClient = try? Client(from: decoder) {
+          client = topLevelClient
+          return
+        }
+
+        client = nil
+      }
+    }
+
+    return (try? JSONDecoder.clerkDecoder.decode(ClientWrapper.self, from: jsonData))?.client
+  }
+}
+
 enum ClientResponseUpdate: Equatable {
   case client(Client)
   case explicitClear
@@ -108,109 +212,5 @@ struct ClientSyncResponseMetadata {
       clientResponseGeneration: checkpoint.clientResponseGeneration,
       responseSequence: checkpoint.requestSequence
     )
-  }
-}
-
-struct ClerkClientSyncResponseMiddleware: ClerkResponseMiddleware {
-  private let runtimeScope: ClerkRuntimeScope
-
-  init(runtimeScope: ClerkRuntimeScope) {
-    self.runtimeScope = runtimeScope
-  }
-
-  func validate(_ response: HTTPURLResponse, data: Data, for request: URLRequest) async throws {
-    try Task.checkCancellation()
-    let metadata = ClientSyncResponseMetadata(response: response, request: request)
-    let update = Self.classifyClientUpdate(
-      from: data,
-      isCanonicalClientRequest: metadata.checkpoint.isCanonicalClientRequest,
-      deviceTokenUpdate: metadata.deviceTokenUpdate
-    )
-    guard request.shouldAutomaticallySyncClerkClient || update == .explicitClear else {
-      return
-    }
-    let context = metadata.context(update: update)
-
-    let clerk = try await runtimeScope.requireCurrentClerk()
-    try Task.checkCancellation()
-    try await clerk.identityController.applyNetworkResponse(context)
-  }
-
-  static func classifyClientUpdate(
-    from jsonData: Data,
-    isCanonicalClientRequest: Bool,
-    deviceTokenUpdate: ClerkDeviceTokenResponseUpdate = .absent
-  ) -> ClientResponseUpdate {
-    if deviceTokenUpdate == .clear {
-      return .explicitClear
-    }
-
-    if let client = decodeClient(from: jsonData) {
-      return .client(client)
-    }
-
-    guard let object = try? JSONSerialization.jsonObject(with: jsonData),
-          let payload = object as? [String: Any]
-    else {
-      return .invalid
-    }
-
-    if isCanonicalClientRequest, let response = payload["response"] {
-      return response is NSNull ? .absent : .invalid
-    }
-    if let client = payload["client"], !(client is NSNull) {
-      return .invalid
-    }
-    if let meta = payload["meta"] as? [String: Any],
-       let client = meta["client"],
-       !(client is NSNull)
-    {
-      return .invalid
-    }
-    return .absent
-  }
-
-  static func decodeClient(from jsonData: Data) -> Client? {
-    struct ClientWrapper: Decodable {
-      let client: Client?
-
-      enum CodingKeys: String, CodingKey {
-        case response, client, meta
-      }
-
-      enum MetaCodingKeys: String, CodingKey {
-        case client
-      }
-
-      init(from decoder: Decoder) throws {
-        let container = try? decoder.container(keyedBy: CodingKeys.self)
-
-        if let responseClient = try? container?.decode(Client.self, forKey: .response) {
-          client = responseClient
-          return
-        }
-
-        if let clientClient = try? container?.decode(Client.self, forKey: .client) {
-          client = clientClient
-          return
-        }
-
-        if let metaContainer = try? container?.nestedContainer(keyedBy: MetaCodingKeys.self, forKey: .meta),
-           let metaClient = try? metaContainer.decode(Client.self, forKey: .client)
-        {
-          client = metaClient
-          return
-        }
-
-        if let topLevelClient = try? Client(from: decoder) {
-          client = topLevelClient
-          return
-        }
-
-        client = nil
-      }
-    }
-
-    return (try? JSONDecoder.clerkDecoder.decode(ClientWrapper.self, from: jsonData))?.client
   }
 }

--- a/Sources/ClerkKit/Networking/Middleware/ClerkClientSyncResponseMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkClientSyncResponseMiddleware.swift
@@ -92,6 +92,8 @@ struct ClerkClientSyncResponseMiddleware: ClerkResponseMiddleware {
   }
 
   func validate(_ response: HTTPURLResponse, data: Data, for request: URLRequest) async throws {
+    guard request.shouldAutomaticallySyncClerkClient else { return }
+
     try Task.checkCancellation()
     let deviceTokenUpdate = ClerkDeviceTokenResponseUpdate(
       authorizationHeader: response.value(forHTTPHeaderField: "Authorization")

--- a/Sources/ClerkKit/Networking/Middleware/ClerkLoggingMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkLoggingMiddleware.swift
@@ -28,7 +28,8 @@ struct ClerkRequestLoggingMiddleware: ClerkRequestMiddleware {
       }
     }
 
-    if let body = request.httpBody,
+    if request.shouldLogClerkBodies,
+       let body = request.httpBody,
        let bodyString = String(data: body, encoding: .utf8),
        !bodyString.isEmpty
     {
@@ -53,7 +54,8 @@ struct ClerkResponseLoggingMiddleware: ClerkResponseMiddleware {
     ClerkLogger.info(basicMessage)
 
     // Log response body at verbose level
-    if !data.isEmpty,
+    if request.shouldLogClerkBodies,
+       !data.isEmpty,
        let body = String(data: data, encoding: .utf8),
        !body.isEmpty
     {

--- a/Sources/ClerkKit/Networking/Middleware/NetworkMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/NetworkMiddleware.swift
@@ -324,22 +324,10 @@ extension URLRequest {
   }
 
   mutating func disableAutomaticClerkClientSync() {
-    guard let mutableRequest = (self as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
-      assertionFailure("Failed to create mutable URLRequest copy.")
-      return
-    }
-
-    URLProtocol.setProperty(false, forKey: Self.clerkAutomaticClientSyncKey, in: mutableRequest)
-    self = mutableRequest as URLRequest
+    setClerkProperty(NSNumber(value: false), key: Self.clerkAutomaticClientSyncKey)
   }
 
   mutating func disableClerkBodyLogging() {
-    guard let mutableRequest = (self as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
-      assertionFailure("Failed to create mutable URLRequest copy.")
-      return
-    }
-
-    URLProtocol.setProperty(false, forKey: Self.clerkBodyLoggingKey, in: mutableRequest)
-    self = mutableRequest as URLRequest
+    setClerkProperty(NSNumber(value: false), key: Self.clerkBodyLoggingKey)
   }
 }

--- a/Sources/ClerkKit/Networking/Middleware/NetworkMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/NetworkMiddleware.swift
@@ -183,6 +183,8 @@ extension URLRequest {
   private static let clerkSharedSessionBaseGenerationKey = "com.clerk.shared-session-base-generation"
   private static let clerkCanonicalClientRequestKey = "com.clerk.canonical-client-request"
   private static let clerkRequestDeviceTokenKey = "com.clerk.request-device-token"
+  private static let clerkAutomaticClientSyncKey = "com.clerk.automatic-client-sync"
+  private static let clerkBodyLoggingKey = "com.clerk.body-logging"
 
   var clerkRequestCheckpoint: ClerkRequestCheckpoint {
     ClerkRequestCheckpoint(request: self)
@@ -224,6 +226,14 @@ extension URLRequest {
 
   var clerkRequestDeviceToken: String? {
     URLProtocol.property(forKey: Self.clerkRequestDeviceTokenKey, in: self) as? String
+  }
+
+  var shouldAutomaticallySyncClerkClient: Bool {
+    URLProtocol.property(forKey: Self.clerkAutomaticClientSyncKey, in: self) as? Bool ?? true
+  }
+
+  var shouldLogClerkBodies: Bool {
+    URLProtocol.property(forKey: Self.clerkBodyLoggingKey, in: self) as? Bool ?? true
   }
 
   mutating func setClerkRequestSequence(_ sequence: Int) {
@@ -310,6 +320,26 @@ extension URLRequest {
         URLProtocol.removeProperty(forKey: key, in: mutableRequest)
       }
     }
+    self = mutableRequest as URLRequest
+  }
+
+  mutating func disableAutomaticClerkClientSync() {
+    guard let mutableRequest = (self as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+      assertionFailure("Failed to create mutable URLRequest copy.")
+      return
+    }
+
+    URLProtocol.setProperty(false, forKey: Self.clerkAutomaticClientSyncKey, in: mutableRequest)
+    self = mutableRequest as URLRequest
+  }
+
+  mutating func disableClerkBodyLogging() {
+    guard let mutableRequest = (self as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+      assertionFailure("Failed to create mutable URLRequest copy.")
+      return
+    }
+
+    URLProtocol.setProperty(false, forKey: Self.clerkBodyLoggingKey, in: mutableRequest)
     self = mutableRequest as URLRequest
   }
 }

--- a/Sources/ClerkKit/Utils/PKCE.swift
+++ b/Sources/ClerkKit/Utils/PKCE.swift
@@ -1,0 +1,39 @@
+//
+//  PKCE.swift
+//  Clerk
+//
+
+import CryptoKit
+import Foundation
+import Security
+
+/// Generates PKCE values using the `S256` code challenge method (RFC 7636).
+enum PKCE {
+  static let codeChallengeMethod = "S256"
+
+  struct Pair: Equatable {
+    let verifier: String
+    let challenge: String
+  }
+
+  static func generatePair() throws -> Pair {
+    let randomBytes = try SecureRandom.bytes(count: 32)
+    let verifier = Data(randomBytes).base64EncodedString().base64URLFromBase64String()
+    return Pair(verifier: verifier, challenge: challenge(for: verifier))
+  }
+
+  static func challenge(for verifier: String) -> String {
+    let digest = SHA256.hash(data: Data(verifier.utf8))
+    return Data(digest).base64EncodedString().base64URLFromBase64String()
+  }
+}
+
+enum SecureRandom {
+  static func bytes(count: Int) throws -> [UInt8] {
+    var bytes = [UInt8](repeating: 0, count: count)
+    guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+      throw ClerkClientError(message: "Unable to generate secure random data.")
+    }
+    return bytes
+  }
+}

--- a/Tests/Domains/Auth/AuthTests.swift
+++ b/Tests/Domains/Auth/AuthTests.swift
@@ -384,7 +384,7 @@ struct AuthTests {
     #expect(capturedPrepareParams.strategy == .emailLink)
     #expect(capturedPrepareParams.emailAddressId == "ema_123")
     #expect(capturedPrepareParams.redirectUri == Clerk.shared.options.redirectConfig.redirectUrl)
-    #expect(capturedPrepareParams.codeChallengeMethod == MagicLinkPKCE.codeChallengeMethod)
+    #expect(capturedPrepareParams.codeChallengeMethod == PKCE.codeChallengeMethod)
     #expect(capturedPrepareParams.codeChallenge?.isEmpty == false)
 
     #expect(try keychain.hasItem(forKey: ClerkKeychainKey.pendingMagicLinkFlow.rawValue))

--- a/Tests/Domains/Auth/HostedAuthPersistenceTests.swift
+++ b/Tests/Domains/Auth/HostedAuthPersistenceTests.swift
@@ -1,0 +1,577 @@
+@testable import ClerkKit
+import ConcurrencyExtras
+import Foundation
+import Testing
+
+extension HostedAuthFlowTests {
+  @Test(arguments: HostedAuthPersistenceTestMode.allCases)
+  func redeemPersistsIdentityBeforeActivation(
+    mode: HostedAuthPersistenceTestMode
+  ) async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let persistedBeforeActivation = LockIsolated(false)
+    let redeemedClient = makeHostedAuthPersistenceClient(
+      id: "redeemed-client",
+      sessions: [.mock, .mock2],
+      lastActiveSessionId: Session.mock.id
+    )
+    let activatedClient = makeHostedAuthPersistenceClient(
+      id: redeemedClient.id,
+      sessions: redeemedClient.sessions,
+      lastActiveSessionId: Session.mock2.id
+    )
+    let initialIdentity = makeHostedAuthInitialIdentity()
+    let identityStore = HostedAuthPersistenceIdentityStore()
+    let slotStore = HostedAuthPersistenceSlotStore()
+
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(
+          object: "hosted_auth",
+          url: "https://accounts.example.com/sign-in"
+        )
+      },
+      redeem: { _ in
+        hostedAuthRedeemResponse(client: redeemedClient)
+      }
+    )
+    let sessionService = MockSessionService(setActive: { sessionId, _ in
+      let persistedIdentity = try identityStore.load()
+      let persistedSlot = try slotStore.loadOwnSlot()
+      persistedBeforeActivation.setValue(
+        persistedIdentity?.deviceToken == "redeemed-token"
+          && persistedIdentity?.client == redeemedClient
+          && persistedIdentity?.serverDate
+          == Date(timeIntervalSince1970: 200)
+          && (
+            mode == .atomic
+              || (
+                persistedSlot?.event.deviceToken == "redeemed-token"
+                  && persistedSlot?.event.client == redeemedClient
+              )
+          )
+      )
+      #expect(sessionId == Session.mock2.id)
+      Clerk.shared.client = activatedClient
+    })
+    let runtime = try configureHostedAuthPersistenceTest(
+      mode: mode,
+      identityStore: identityStore,
+      slotStore: slotStore,
+      initialIdentity: initialIdentity,
+      hostedAuthService: hostedAuthService,
+      sessionService: sessionService
+    )
+    defer { runtime.stop() }
+
+    let session = try await Clerk.shared.auth.performHostedAuth(
+      mode: nil,
+      redirectUrl: "myapp://callback",
+      prefersEphemeralWebBrowserSession: false,
+      webAuthentication: { _, _, _ in
+        try hostedAuthPersistenceCallbackURL(
+          state: #require(createParams.value?.state),
+          createdSessionId: Session.mock2.id
+        )
+      }
+    )
+
+    #expect(persistedBeforeActivation.value)
+    #expect(session.id == Session.mock2.id)
+    let persistedIdentity = try #require(try identityStore.load())
+    #expect(persistedIdentity.deviceToken == "redeemed-token")
+    #expect(persistedIdentity.client == redeemedClient)
+    #expect(try identityStore.loadRecord()?.pendingPublication == nil)
+    if mode == .shared {
+      let slot = try #require(try slotStore.loadOwnSlot())
+      #expect(slot.event.deviceToken == "redeemed-token")
+      #expect(slot.event.client == redeemedClient)
+    }
+  }
+
+  @Test(arguments: HostedAuthPersistenceTestMode.allCases)
+  func redeemPersistenceFailureDoesNotExposeOrActivateIdentity(
+    mode: HostedAuthPersistenceTestMode
+  ) async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let setActiveCalled = LockIsolated(false)
+    let redeemedClient = makeHostedAuthPersistenceClient(
+      id: "redeemed-client",
+      sessions: [.mock],
+      lastActiveSessionId: Session.mock.id
+    )
+    let initialIdentity = makeHostedAuthInitialIdentity()
+    let identityStore = HostedAuthPersistenceIdentityStore()
+    let slotStore = HostedAuthPersistenceSlotStore()
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(
+          object: "hosted_auth",
+          url: "https://accounts.example.com/sign-in"
+        )
+      },
+      redeem: { _ in
+        hostedAuthRedeemResponse(client: redeemedClient)
+      }
+    )
+    let runtime = try configureHostedAuthPersistenceTest(
+      mode: mode,
+      identityStore: identityStore,
+      slotStore: slotStore,
+      initialIdentity: initialIdentity,
+      hostedAuthService: hostedAuthService,
+      sessionService: MockSessionService(setActive: { _, _ in
+        setActiveCalled.setValue(true)
+      })
+    )
+    defer { runtime.stop() }
+    switch mode {
+    case .atomic:
+      identityStore.failUpdates()
+    case .shared:
+      slotStore.failSaves()
+    }
+
+    do {
+      _ = try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in
+          try hostedAuthPersistenceCallbackURL(
+            state: #require(createParams.value?.state),
+            createdSessionId: Session.mock.id
+          )
+        }
+      )
+      Issue.record("Expected identity persistence to fail.")
+    } catch {
+      switch mode {
+      case .atomic:
+        #expect(error is HostedAuthPersistenceIdentityStore.Failure)
+      case .shared:
+        #expect(error is HostedAuthPersistenceSlotStore.Failure)
+      }
+    }
+
+    #expect(!setActiveCalled.value)
+    #expect(Clerk.shared.client == initialIdentity.client)
+    #expect(try identityStore.load() == initialIdentity)
+    #expect(try slotStore.loadOwnSlot() == nil)
+    let record = try identityStore.loadRecord()
+    switch mode {
+    case .atomic:
+      #expect(record?.pendingPublication == nil)
+    case .shared:
+      #expect(record?.pendingPublication?.client == redeemedClient)
+      #expect(record?.pendingPublication?.deviceToken == "redeemed-token")
+    }
+  }
+
+  @Test(arguments: HostedAuthPersistenceTestMode.allCases)
+  func missingCallbackSessionDoesNotMutatePersistedIdentity(
+    mode: HostedAuthPersistenceTestMode
+  ) async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let setActiveCalled = LockIsolated(false)
+    let returnedClient = makeHostedAuthPersistenceClient(
+      id: "wrong-client",
+      sessions: [.mock],
+      lastActiveSessionId: Session.mock.id
+    )
+    let initialIdentity = makeHostedAuthInitialIdentity()
+    let identityStore = HostedAuthPersistenceIdentityStore()
+    let slotStore = HostedAuthPersistenceSlotStore()
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(
+          object: "hosted_auth",
+          url: "https://accounts.example.com/sign-in"
+        )
+      },
+      redeem: { _ in
+        hostedAuthRedeemResponse(client: returnedClient)
+      }
+    )
+    let runtime = try configureHostedAuthPersistenceTest(
+      mode: mode,
+      identityStore: identityStore,
+      slotStore: slotStore,
+      initialIdentity: initialIdentity,
+      hostedAuthService: hostedAuthService,
+      sessionService: MockSessionService(setActive: { _, _ in
+        setActiveCalled.setValue(true)
+      })
+    )
+    defer { runtime.stop() }
+
+    do {
+      _ = try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in
+          try hostedAuthPersistenceCallbackURL(
+            state: #require(createParams.value?.state),
+            createdSessionId: "sess_not_in_response"
+          )
+        }
+      )
+      Issue.record("Expected a redeem response missing the callback session to throw.")
+    } catch let error as ClerkClientError {
+      #expect(error.message == "Hosted auth completion did not include the created session.")
+    } catch {
+      Issue.record("Expected ClerkClientError, got \(error).")
+    }
+
+    #expect(!setActiveCalled.value)
+    #expect(Clerk.shared.client == initialIdentity.client)
+    #expect(try identityStore.load() == initialIdentity)
+    #expect(try slotStore.loadOwnSlot() == nil)
+  }
+
+  @Test(arguments: HostedAuthPersistenceTestMode.allCases)
+  func generationChangeBeforeRedeemSkipsRedeemAndPreservesIdentity(
+    mode: HostedAuthPersistenceTestMode
+  ) async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let redeemCalled = LockIsolated(false)
+    let setActiveCalled = LockIsolated(false)
+    let initialIdentity = makeHostedAuthInitialIdentity()
+    let identityStore = HostedAuthPersistenceIdentityStore()
+    let slotStore = HostedAuthPersistenceSlotStore()
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(
+          object: "hosted_auth",
+          url: "https://accounts.example.com/sign-in"
+        )
+      },
+      redeem: { _ in
+        redeemCalled.setValue(true)
+        return hostedAuthRedeemResponse(client: .mock)
+      }
+    )
+    let runtime = try configureHostedAuthPersistenceTest(
+      mode: mode,
+      identityStore: identityStore,
+      slotStore: slotStore,
+      initialIdentity: initialIdentity,
+      hostedAuthService: hostedAuthService,
+      sessionService: MockSessionService(setActive: { _, _ in
+        setActiveCalled.setValue(true)
+      })
+    )
+    defer { runtime.stop() }
+
+    do {
+      _ = try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in
+          Clerk.shared.identityController.fenceClientResponses()
+          return try hostedAuthPersistenceCallbackURL(
+            state: #require(createParams.value?.state),
+            createdSessionId: Session.mock.id
+          )
+        }
+      )
+      Issue.record("Expected the stale hosted-auth flow to throw.")
+    } catch let error as ClerkClientError {
+      #expect(error.message == "Hosted auth completion could not update the current client.")
+    } catch {
+      Issue.record("Expected ClerkClientError, got \(error).")
+    }
+
+    #expect(!redeemCalled.value)
+    #expect(!setActiveCalled.value)
+    #expect(Clerk.shared.client == initialIdentity.client)
+    #expect(try identityStore.load() == initialIdentity)
+    #expect(try slotStore.loadOwnSlot() == nil)
+  }
+
+  @Test
+  func sharedFrontierAdvanceDuringRedeemRejectsResponseWithoutActivating() async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let setActiveCalled = LockIsolated(false)
+    let initialIdentity = makeHostedAuthInitialIdentity()
+    let redeemedClient = makeHostedAuthPersistenceClient(
+      id: "redeemed-client",
+      sessions: [.mock],
+      lastActiveSessionId: Session.mock.id
+    )
+    let newerSharedClient = makeHostedAuthPersistenceClient(
+      id: "newer-shared-client",
+      sessions: [],
+      lastActiveSessionId: nil
+    )
+    let identityStore = HostedAuthPersistenceIdentityStore()
+    let slotStore = HostedAuthPersistenceSlotStore()
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(
+          object: "hosted_auth",
+          url: "https://accounts.example.com/sign-in"
+        )
+      },
+      redeem: { _ in
+        let response = hostedAuthRedeemResponse(client: redeemedClient)
+        let responseGeneration = Clerk.shared.clientResponseGeneration
+        let coordinator = try #require(Clerk.shared.sharedSessionSyncCoordinator)
+        let didPublish = try await coordinator.publishLocalIdentity(
+          state: .present,
+          deviceToken: "initial-token",
+          client: newerSharedClient,
+          serverDate: Date(timeIntervalSince1970: 150)
+        )
+        #expect(didPublish)
+        #expect(Clerk.shared.clientResponseGeneration == responseGeneration)
+        return response
+      }
+    )
+    let runtime = try configureHostedAuthPersistenceTest(
+      mode: .shared,
+      identityStore: identityStore,
+      slotStore: slotStore,
+      initialIdentity: initialIdentity,
+      hostedAuthService: hostedAuthService,
+      sessionService: MockSessionService(setActive: { _, _ in
+        setActiveCalled.setValue(true)
+      })
+    )
+    defer { runtime.stop() }
+
+    do {
+      _ = try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in
+          try hostedAuthPersistenceCallbackURL(
+            state: #require(createParams.value?.state),
+            createdSessionId: Session.mock.id
+          )
+        }
+      )
+      Issue.record("Expected the stale shared-frontier response to throw.")
+    } catch let error as ClerkClientError {
+      #expect(error.message == "Hosted auth completion could not update the current client.")
+    } catch {
+      Issue.record("Expected ClerkClientError, got \(error).")
+    }
+
+    #expect(!setActiveCalled.value)
+    #expect(Clerk.shared.client == newerSharedClient)
+    #expect(try identityStore.load()?.client == newerSharedClient)
+    #expect(try slotStore.loadOwnSlot()?.event.client == newerSharedClient)
+  }
+}
+
+enum HostedAuthPersistenceTestMode: String, CaseIterable {
+  case atomic
+  case shared
+}
+
+@MainActor
+private struct HostedAuthPersistenceTestRuntime {
+  let coordinator: SharedSessionSyncCoordinator?
+
+  func stop() {
+    coordinator?.deactivate()
+    if Clerk.shared.sharedSessionSyncCoordinator === coordinator {
+      Clerk.shared.sharedSessionSyncCoordinator = nil
+    }
+  }
+}
+
+@MainActor
+private func configureHostedAuthPersistenceTest(
+  mode: HostedAuthPersistenceTestMode,
+  identityStore: HostedAuthPersistenceIdentityStore,
+  slotStore: HostedAuthPersistenceSlotStore,
+  initialIdentity: ClerkIdentitySnapshot,
+  hostedAuthService: some HostedAuthServiceProtocol,
+  sessionService: some SessionServiceProtocol
+) throws -> HostedAuthPersistenceTestRuntime {
+  configureClerkForTesting()
+  let clerk = Clerk.shared
+  clerk.sharedSessionSyncCoordinator?.deactivate()
+  clerk.sharedSessionSyncCoordinator = nil
+  clerk.identityController.resetRuntimeIdentity()
+  try identityStore.save(initialIdentity)
+
+  let apiClient = createMockAPIClient(runtimeScope: clerk.runtimeScope)
+  let dependencies = MockDependencyContainer(
+    apiClient: apiClient,
+    keychain: InMemoryKeychain(),
+    atomicIdentityStore: identityStore,
+    sharedSessionOwnerIdentifier: "com.example.hosted-auth",
+    hostedAuthService: hostedAuthService,
+    sessionService: sessionService
+  )
+  try dependencies.configurationManager.configure(
+    publishableKey: testPublishableKey,
+    options: Clerk.Options(
+      sharedSessionSync: mode == .shared ? .enabled : nil
+    )
+  )
+  clerk.dependencies = dependencies
+  clerk.hydrateIdentityIfNeeded(initialIdentity)
+
+  guard mode == .shared else {
+    return HostedAuthPersistenceTestRuntime(coordinator: nil)
+  }
+
+  let coordinator = SharedSessionSyncCoordinator(
+    ownerIdentifier: "com.example.hosted-auth",
+    instanceFingerprint: "hosted-auth-tests",
+    slotStore: slotStore,
+    localIdentityStore: identityStore,
+    notifier: HostedAuthPersistenceNotifier(),
+    configurationEpoch: clerk.configurationEpoch,
+    clerk: clerk,
+    logError: { _, _ in }
+  )
+  clerk.sharedSessionSyncCoordinator = coordinator
+  clerk.internalStateChanges.addObserver(coordinator)
+  return HostedAuthPersistenceTestRuntime(coordinator: coordinator)
+}
+
+@MainActor
+private func hostedAuthRedeemResponse(
+  client: Client
+) -> HostedAuthRedeemResponse {
+  HostedAuthRedeemResponse(
+    client: client,
+    clientSyncContext: ClientSyncResponseContext(
+      update: .client(client),
+      deviceTokenUpdate: .set("redeemed-token"),
+      requestDeviceToken: "initial-token",
+      baseGeneration: 0,
+      serverDate: Date(timeIntervalSince1970: 200),
+      isCanonicalClientRequest: true,
+      clientResponseGeneration: Clerk.shared.clientResponseGeneration,
+      responseSequence: 1
+    )
+  )
+}
+
+private func makeHostedAuthInitialIdentity() -> ClerkIdentitySnapshot {
+  ClerkIdentitySnapshot(
+    state: .present,
+    deviceToken: "initial-token",
+    client: makeHostedAuthPersistenceClient(
+      id: "initial-client",
+      sessions: [],
+      lastActiveSessionId: nil
+    ),
+    serverDate: Date(timeIntervalSince1970: 100)
+  )
+}
+
+private func makeHostedAuthPersistenceClient(
+  id: String,
+  sessions: [Session],
+  lastActiveSessionId: String?
+) -> Client {
+  var client = Client.mockSignedOut
+  client.id = id
+  client.sessions = sessions
+  client.lastActiveSessionId = lastActiveSessionId
+  return client
+}
+
+private func hostedAuthPersistenceCallbackURL(
+  state: String,
+  createdSessionId: String
+) throws -> URL {
+  var components = try #require(URLComponents(string: "myapp://callback"))
+  components.queryItems = [
+    URLQueryItem(name: "state", value: state),
+    URLQueryItem(name: "rotating_token_nonce", value: "nonce_123"),
+    URLQueryItem(name: "created_session_id", value: createdSessionId),
+  ]
+  return try #require(components.url)
+}
+
+private final class HostedAuthPersistenceIdentityStore: @unchecked Sendable,
+  SharedSessionLocalIdentityStoring
+{
+  enum Failure: Error {
+    case update
+  }
+
+  private let lock = NSLock()
+  private var record: SharedSessionLocalIdentityRecord?
+  private var shouldFailUpdates = false
+
+  func failUpdates() {
+    lock.withLock {
+      shouldFailUpdates = true
+    }
+  }
+
+  func loadRecord() throws -> SharedSessionLocalIdentityRecord? {
+    lock.withLock { record }
+  }
+
+  func updateRecord(
+    _ update: (SharedSessionLocalIdentityRecord?) throws -> SharedSessionLocalIdentityRecord?
+  ) throws {
+    try lock.withLock {
+      guard !shouldFailUpdates else { throw Failure.update }
+      record = try update(record)
+    }
+  }
+}
+
+private final class HostedAuthPersistenceSlotStore: @unchecked Sendable,
+  SharedSessionSlotStoring
+{
+  enum Failure: Error {
+    case save
+  }
+
+  private let lock = NSLock()
+  private var slot: SharedSessionOwnerSlot?
+  private var shouldFailSaves = false
+
+  func failSaves() {
+    lock.withLock {
+      shouldFailSaves = true
+    }
+  }
+
+  func loadOwnSlot() throws -> SharedSessionOwnerSlot? {
+    lock.withLock { slot }
+  }
+
+  func loadAllSlots() throws -> [SharedSessionOwnerSlot] {
+    lock.withLock { slot.map { [$0] } ?? [] }
+  }
+
+  func saveOwnSlot(_ slot: SharedSessionOwnerSlot) throws {
+    try lock.withLock {
+      guard !shouldFailSaves else { throw Failure.save }
+      self.slot = slot
+    }
+  }
+
+  func deleteOwnSlot() throws {
+    lock.withLock {
+      slot = nil
+    }
+  }
+}
+
+@MainActor
+private final class HostedAuthPersistenceNotifier: SharedSessionSyncNotifying {
+  func setHandler(_: @escaping @MainActor () -> Void) {}
+  func post() {}
+}

--- a/Tests/Domains/Auth/HostedAuthServiceTests.swift
+++ b/Tests/Domains/Auth/HostedAuthServiceTests.swift
@@ -23,6 +23,7 @@ extension HostedAuthFlowTests {
     )
     mock.onRequestHandler = OnRequestHandler { @Sendable request in
       #expect(request.httpMethod == "POST")
+      #expect(!request.shouldAutomaticallySyncClerkClient)
       #expect(!request.shouldLogClerkBodies)
       let queryItems = request.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false)?.queryItems }
       #expect(queryItems == [

--- a/Tests/Domains/Auth/HostedAuthServiceTests.swift
+++ b/Tests/Domains/Auth/HostedAuthServiceTests.swift
@@ -34,6 +34,7 @@ extension HostedAuthFlowTests {
       #expect(body?["code_challenge"] == "challenge_123")
       #expect(body?["state"] == "state_123")
       #expect(body?["mode"] == "sign-up")
+      // The wire param is "mode"; guard against regressing to the web SDK's "initial_page".
       #expect(body?["initial_page"] == nil)
       requestHandled.setValue(true)
     }

--- a/Tests/Domains/Auth/HostedAuthServiceTests.swift
+++ b/Tests/Domains/Auth/HostedAuthServiceTests.swift
@@ -1,0 +1,114 @@
+@testable import ClerkKit
+import ConcurrencyExtras
+import Foundation
+import Mocker
+import Testing
+
+@MainActor
+extension HostedAuthFlowTests {
+  @Test
+  func createUsesHostedAuthPostRequestShape() async throws {
+    configureClerkForTesting()
+    let requestHandled = LockIsolated(false)
+    let requestUrl = try #require(URL(string: mockBaseUrl.absoluteString + "/v1/client/hosted_auth"))
+    let resource = HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+    var mock = try Mock(
+      url: requestUrl,
+      ignoreQuery: true,
+      contentType: .json,
+      statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(ClientResponse(response: resource, client: Client.mockSignedOut)),
+      ]
+    )
+    mock.onRequestHandler = OnRequestHandler { @Sendable request in
+      #expect(request.httpMethod == "POST")
+      #expect(!request.shouldLogClerkBodies)
+      let queryItems = request.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false)?.queryItems }
+      #expect(queryItems == [
+        URLQueryItem(name: "_is_native", value: "true"),
+      ])
+      let body = request.urlEncodedFormBody
+      #expect(body?["redirect_url"] == "myapp://callback")
+      #expect(body?["code_challenge"] == "challenge_123")
+      #expect(body?["state"] == "state_123")
+      #expect(body?["mode"] == "sign-up")
+      #expect(body?["initial_page"] == nil)
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    let service = HostedAuthService(apiClient: Clerk.shared.dependencies.apiClient)
+    let response = try await service.create(params: HostedAuthCreateParams(
+      redirectUrl: "myapp://callback",
+      codeChallenge: "challenge_123",
+      state: "state_123",
+      mode: .signUp
+    ))
+
+    #expect(requestHandled.value)
+    #expect(response.url == resource.url)
+  }
+
+  @Test
+  func createOmitsModeWhenNotProvided() throws {
+    let params = HostedAuthCreateParams(
+      redirectUrl: "myapp://callback",
+      codeChallenge: "challenge_123",
+      state: "state_123",
+      mode: nil
+    )
+    let encoded = try JSONEncoder.clerkEncoder.encode(params)
+    let json = try JSONDecoder.clerkDecoder.decode(JSON.self, from: encoded)
+
+    #expect(json["mode"] == nil)
+  }
+
+  @Test
+  func redeemUsesPhysicalPostBodyAndDisablesAutomaticClientSync() async throws {
+    configureClerkForTesting()
+    let requestHandled = LockIsolated(false)
+    let requestUrl = try #require(URL(string: mockBaseUrl.absoluteString + "/v1/client"))
+    var redeemedClient = Client.mock
+    redeemedClient.sessions = [.mock, .mock2]
+
+    var mock = try Mock(
+      url: requestUrl,
+      ignoreQuery: true,
+      contentType: .json,
+      statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(ClientResponse<Client?>(
+          response: redeemedClient,
+          client: nil
+        )),
+      ]
+    )
+    mock.onRequestHandler = OnRequestHandler { @Sendable request in
+      #expect(request.httpMethod == "POST")
+      #expect(request.url?.path == requestUrl.path)
+      let queryItems = request.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false)?.queryItems }
+      #expect(queryItems == [
+        URLQueryItem(name: "_is_native", value: "true"),
+      ])
+      #expect(!request.shouldAutomaticallySyncClerkClient)
+      #expect(!request.shouldLogClerkBodies)
+      let body = request.urlEncodedFormBody
+      #expect(body?["_method"] == "GET")
+      #expect(body?["rotating_token_nonce"] == "nonce_123")
+      #expect(body?["code_verifier"] == "verifier_123")
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    let service = HostedAuthService(apiClient: Clerk.shared.dependencies.apiClient)
+    let response = try await service.redeem(params: HostedAuthRedeemParams(
+      rotatingTokenNonce: "nonce_123",
+      codeVerifier: "verifier_123"
+    ))
+
+    #expect(requestHandled.value)
+    #expect(response.client?.id == redeemedClient.id)
+    #expect(response.client?.sessions.map(\.id) == redeemedClient.sessions.map(\.id))
+  }
+}

--- a/Tests/Domains/Auth/HostedAuthServiceTests.swift
+++ b/Tests/Domains/Auth/HostedAuthServiceTests.swift
@@ -95,6 +95,7 @@ extension HostedAuthFlowTests {
       ])
       #expect(!request.shouldAutomaticallySyncClerkClient)
       #expect(!request.shouldLogClerkBodies)
+      #expect(request.clerkRequestCheckpoint.isCanonicalClientRequest)
       let body = request.urlEncodedFormBody
       #expect(body?["_method"] == "GET")
       #expect(body?["rotating_token_nonce"] == "nonce_123")
@@ -112,5 +113,50 @@ extension HostedAuthFlowTests {
     #expect(requestHandled.value)
     #expect(response.client?.id == redeemedClient.id)
     #expect(response.client?.sessions.map(\.id) == redeemedClient.sessions.map(\.id))
+    guard case .client(let synchronizedClient) = response.clientSyncContext.update else {
+      Issue.record("Expected hosted auth redeem to defer the decoded client update.")
+      return
+    }
+    #expect(synchronizedClient.id == redeemedClient.id)
+    #expect(synchronizedClient.sessions.map(\.id) == redeemedClient.sessions.map(\.id))
+    #expect(response.clientSyncContext.isCanonicalClientRequest)
+    #expect(
+      response.clientSyncContext.clientResponseGeneration
+        == Clerk.shared.clientResponseGeneration
+    )
+  }
+
+  @Test
+  func redeemPreservesAuthoritativeDeviceTokenClear() async throws {
+    configureClerkForTesting()
+    let requestUrl = try #require(URL(string: mockBaseUrl.absoluteString + "/v1/client"))
+    var redeemedClient = Client.mock
+    redeemedClient.sessions = [.mock]
+    let mock = try Mock(
+      url: requestUrl,
+      ignoreQuery: true,
+      contentType: .json,
+      statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(ClientResponse<Client?>(
+          response: redeemedClient,
+          client: nil
+        )),
+      ],
+      additionalHeaders: [
+        "Authorization": "Bearer",
+      ]
+    )
+    mock.register()
+
+    let service = HostedAuthService(apiClient: Clerk.shared.dependencies.apiClient)
+    let response = try await service.redeem(params: HostedAuthRedeemParams(
+      rotatingTokenNonce: "nonce_123",
+      codeVerifier: "verifier_123"
+    ))
+
+    #expect(response.client?.id == redeemedClient.id)
+    #expect(response.clientSyncContext.update == .explicitClear)
+    #expect(response.clientSyncContext.deviceTokenUpdate == .clear)
   }
 }

--- a/Tests/Domains/Auth/HostedAuthTests.swift
+++ b/Tests/Domains/Auth/HostedAuthTests.swift
@@ -73,6 +73,25 @@ struct HostedAuthProtocolTests {
   }
 
   @Test
+  func redirectInitRejectsNonCustomSchemeAndMalformedValues() {
+    for rawValue in [
+      "http://example.com/callback",
+      "https://example.com/callback",
+      "HTTPS://example.com/callback",
+      "",
+      "callback-without-scheme",
+      "/callback",
+      " myapp://callback",
+      "myapp://callback ",
+      "myapp://callback\n",
+    ] {
+      #expect(throws: ClerkClientError.self, "Expected redirect to be rejected: \(rawValue)") {
+        try HostedAuthRedirect(rawValue)
+      }
+    }
+  }
+
+  @Test
   func tripleSlashRedirectRejectsInjectedOrMissingAuthority() throws {
     let redirect = try HostedAuthRedirect("myapp:///hosted-auth-callback")
     let valid = try #require(URL(string: "myapp:///hosted-auth-callback?state=state_123"))
@@ -417,6 +436,202 @@ struct HostedAuthFlowTests {
       #expect(Clerk.shared.client == .mockSignedOut)
     }
   }
+
+  @Test
+  func failedFlowReleasesInFlightGateForSubsequentAttempts() async throws {
+    let createCalls = LockIsolated(0)
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    var redeemedClient = Client.mock
+    redeemedClient.sessions = [.mock]
+    redeemedClient.lastActiveSessionId = Session.mock.id
+
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createCalls.withValue { $0 += 1 }
+        createParams.setValue(params)
+        return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+      },
+      redeem: { _ in
+        ClientServiceResponse(client: redeemedClient, requestSequence: nil, serverDate: nil)
+      }
+    )
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: MockSessionService(),
+      initialClient: .mockSignedOut
+    )
+
+    let auth = Clerk.shared.auth
+    await #expect(throws: CancellationError.self) {
+      try await auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in throw CancellationError() }
+      )
+    }
+
+    let session = try await auth.performHostedAuth(
+      mode: nil,
+      redirectUrl: "myapp://callback",
+      prefersEphemeralWebBrowserSession: false,
+      webAuthentication: { _, _, _ in
+        try makeHostedAuthCallbackUrl(
+          redirectUrl: "myapp://callback",
+          state: #require(createParams.value?.state),
+          rotatingTokenNonce: "nonce_123",
+          createdSessionId: Session.mock.id
+        )
+      }
+    )
+
+    #expect(createCalls.value == 2)
+    #expect(session.id == Session.mock.id)
+  }
+
+  @Test
+  func reconfigurationWhileBrowserOpenFailsBeforeRedeem() async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let redeemCalled = LockIsolated(false)
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+      },
+      redeem: { _ in
+        redeemCalled.setValue(true)
+        return ClientServiceResponse(client: .mock, requestSequence: nil, serverDate: nil)
+      }
+    )
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: MockSessionService(),
+      initialClient: .mockSignedOut
+    )
+
+    let runtimeState = Clerk.shared.runtimeState
+    defer { runtimeState.endReconfiguration() }
+
+    await #expect(throws: CancellationError.self) {
+      try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in
+          runtimeState.beginReconfiguration()
+          return try makeHostedAuthCallbackUrl(
+            redirectUrl: "myapp://callback",
+            state: #require(createParams.value?.state),
+            rotatingTokenNonce: "nonce_123",
+            createdSessionId: Session.mock.id
+          )
+        }
+      )
+    }
+    #expect(!redeemCalled.value)
+  }
+
+  @Test
+  func generationChangeWhileBrowserOpenDiscardsRedeemedClient() async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let setActiveCalled = LockIsolated(false)
+    let initialClient = Client.mockSignedOut
+    var redeemedClient = Client.mock
+    redeemedClient.sessions = [.mock]
+    redeemedClient.lastActiveSessionId = Session.mock.id
+
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+      },
+      redeem: { _ in
+        ClientServiceResponse(client: redeemedClient, requestSequence: nil, serverDate: nil)
+      }
+    )
+    let sessionService = MockSessionService(setActive: { _, _ in
+      setActiveCalled.setValue(true)
+    })
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: sessionService,
+      initialClient: initialClient
+    )
+
+    do {
+      _ = try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in
+          Clerk.shared.fenceClientResponsesAfterDeviceTokenChange()
+          return try makeHostedAuthCallbackUrl(
+            redirectUrl: "myapp://callback",
+            state: #require(createParams.value?.state),
+            rotatingTokenNonce: "nonce_123",
+            createdSessionId: Session.mock.id
+          )
+        }
+      )
+      Issue.record("Expected stale client response generation to throw")
+    } catch let error as ClerkClientError {
+      #expect(error.message == "Hosted auth completion could not update the current client.")
+      #expect(!setActiveCalled.value)
+      #expect(Clerk.shared.client == initialClient)
+    } catch {
+      Issue.record("Expected ClerkClientError, got \(error)")
+    }
+  }
+
+  @Test
+  func nilRedirectUrlFallsBackToConfiguredRedirectUrl() async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let browserInputs = LockIsolated<HostedAuthBrowserInputs?>(nil)
+    var redeemedClient = Client.mock
+    redeemedClient.sessions = [.mock]
+    redeemedClient.lastActiveSessionId = Session.mock.id
+
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+      },
+      redeem: { _ in
+        ClientServiceResponse(client: redeemedClient, requestSequence: nil, serverDate: nil)
+      }
+    )
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: MockSessionService(),
+      initialClient: .mockSignedOut,
+      options: Clerk.Options(
+        redirectConfig: .init(redirectUrl: "fallbackapp://hosted-callback", callbackUrlScheme: "fallbackapp")
+      )
+    )
+
+    let session = try await Clerk.shared.auth.performHostedAuth(
+      mode: nil,
+      redirectUrl: nil,
+      prefersEphemeralWebBrowserSession: false,
+      webAuthentication: { url, callbackUrlScheme, prefersEphemeral in
+        browserInputs.setValue(HostedAuthBrowserInputs(
+          url: url,
+          callbackUrlScheme: callbackUrlScheme,
+          prefersEphemeralWebBrowserSession: prefersEphemeral
+        ))
+        return try makeHostedAuthCallbackUrl(
+          redirectUrl: "fallbackapp://hosted-callback",
+          state: #require(createParams.value?.state),
+          rotatingTokenNonce: "nonce_123",
+          createdSessionId: Session.mock.id
+        )
+      }
+    )
+
+    #expect(createParams.value?.redirectUrl == "fallbackapp://hosted-callback")
+    #expect(browserInputs.value?.callbackUrlScheme == "fallbackapp")
+    #expect(session.id == Session.mock.id)
+  }
 }
 
 private struct HostedAuthBrowserInputs: Equatable {
@@ -434,7 +649,8 @@ private struct HostedAuthSetActiveCall: Equatable {
 private func configureHostedAuthForTesting(
   hostedAuthService: some HostedAuthServiceProtocol,
   sessionService: some SessionServiceProtocol,
-  initialClient: Client
+  initialClient: Client,
+  options: Clerk.Options = .init()
 ) {
   configureClerkForTesting()
   Clerk.shared.dependencies = MockDependencyContainer(
@@ -442,6 +658,9 @@ private func configureHostedAuthForTesting(
     hostedAuthService: hostedAuthService,
     sessionService: sessionService
   )
+  try! (Clerk.shared.dependencies as! MockDependencyContainer)
+    .configurationManager
+    .configure(publishableKey: testPublishableKey, options: options)
   Clerk.shared.client = initialClient
 }
 

--- a/Tests/Domains/Auth/HostedAuthTests.swift
+++ b/Tests/Domains/Auth/HostedAuthTests.swift
@@ -342,6 +342,185 @@ struct HostedAuthFlowTests {
   }
 
   @Test
+  func signedOutCreateRefreshesClientAndRetriesOnceWithSameParams() async throws {
+    let createCalls = LockIsolated(0)
+    let firstCreateParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let refreshCalls = LockIsolated(0)
+    let reconciledClient = Client.mockSignedOut
+    let hostedAuthService = MockHostedAuthService(create: { params in
+      let call = createCalls.withValue { calls in
+        defer { calls += 1 }
+        return calls
+      }
+      if call == 0 {
+        firstCreateParams.setValue(params)
+        throw hostedAuthAPIError(code: "signed_out")
+      }
+
+      let firstParams = try #require(firstCreateParams.value)
+      #expect(params.redirectUrl == firstParams.redirectUrl)
+      #expect(params.codeChallenge == firstParams.codeChallenge)
+      #expect(params.state == firstParams.state)
+      #expect(params.mode == firstParams.mode)
+      #expect(Clerk.shared.client == reconciledClient)
+      return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+    })
+    let clientService = HostedAuthClientService(get: {
+      refreshCalls.withValue { $0 += 1 }
+      return reconciledClient
+    })
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: MockSessionService(),
+      clientService: clientService,
+      initialClient: .mock
+    )
+
+    await #expect(throws: CancellationError.self) {
+      try await Clerk.shared.auth.performHostedAuth(
+        mode: .signUp,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in throw CancellationError() }
+      )
+    }
+
+    #expect(createCalls.value == 2)
+    #expect(refreshCalls.value == 1)
+    #expect(clientService.skipClientIdValues.value == [true])
+  }
+
+  @Test
+  func secondSignedOutCreateIsNotRetried() async throws {
+    let createCalls = LockIsolated(0)
+    let refreshCalls = LockIsolated(0)
+    let browserCalled = LockIsolated(false)
+    let hostedAuthService = MockHostedAuthService(create: { _ in
+      createCalls.withValue { $0 += 1 }
+      throw hostedAuthAPIError(code: "signed_out")
+    })
+    let clientService = MockClientService(get: {
+      refreshCalls.withValue { $0 += 1 }
+      return .mockSignedOut
+    })
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: MockSessionService(),
+      clientService: clientService,
+      initialClient: .mock
+    )
+
+    do {
+      _ = try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in
+          browserCalled.setValue(true)
+          throw CancellationError()
+        }
+      )
+      Issue.record("Expected the second signed_out error to propagate")
+    } catch let error as ClerkAPIError {
+      #expect(error.code == "signed_out")
+    } catch {
+      Issue.record("Expected ClerkAPIError, got \(error)")
+    }
+
+    #expect(createCalls.value == 2)
+    #expect(refreshCalls.value == 1)
+    #expect(!browserCalled.value)
+  }
+
+  @Test
+  func nonSignedOutCreateErrorIsNotRetried() async throws {
+    let createCalls = LockIsolated(0)
+    let refreshCalls = LockIsolated(0)
+    let hostedAuthService = MockHostedAuthService(create: { _ in
+      createCalls.withValue { $0 += 1 }
+      throw hostedAuthAPIError(code: "resource_not_found")
+    })
+    let clientService = MockClientService(get: {
+      refreshCalls.withValue { $0 += 1 }
+      return .mockSignedOut
+    })
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: MockSessionService(),
+      clientService: clientService,
+      initialClient: .mock
+    )
+
+    do {
+      _ = try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in throw CancellationError() }
+      )
+      Issue.record("Expected create error to propagate")
+    } catch let error as ClerkAPIError {
+      #expect(error.code == "resource_not_found")
+    } catch {
+      Issue.record("Expected ClerkAPIError, got \(error)")
+    }
+
+    #expect(createCalls.value == 1)
+    #expect(refreshCalls.value == 0)
+  }
+
+  @Test
+  func signedOutRedeemErrorIsNotRetriedOrReconciled() async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let redeemCalls = LockIsolated(0)
+    let refreshCalls = LockIsolated(0)
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+      },
+      redeem: { _ in
+        redeemCalls.withValue { $0 += 1 }
+        throw hostedAuthAPIError(code: "signed_out")
+      }
+    )
+    let clientService = MockClientService(get: {
+      refreshCalls.withValue { $0 += 1 }
+      return .mockSignedOut
+    })
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: MockSessionService(),
+      clientService: clientService,
+      initialClient: .mockSignedOut
+    )
+
+    do {
+      _ = try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in
+          try makeHostedAuthCallbackUrl(
+            redirectUrl: "myapp://callback",
+            state: #require(createParams.value?.state),
+            rotatingTokenNonce: "nonce_123",
+            createdSessionId: Session.mock.id
+          )
+        }
+      )
+      Issue.record("Expected redeem error to propagate")
+    } catch let error as ClerkAPIError {
+      #expect(error.code == "signed_out")
+    } catch {
+      Issue.record("Expected ClerkAPIError, got \(error)")
+    }
+
+    #expect(redeemCalls.value == 1)
+    #expect(refreshCalls.value == 0)
+  }
+
+  @Test
   func missingCallbackSessionDoesNotApplyClientOrActivateAnotherSession() async throws {
     let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
     let setActiveCalled = LockIsolated(false)
@@ -645,16 +824,37 @@ private struct HostedAuthSetActiveCall: Equatable {
   let organizationId: String?
 }
 
+private final class HostedAuthClientService: ClientServiceProtocol {
+  let skipClientIdValues = LockIsolated<[Bool]>([])
+  let getHandler: @Sendable () async throws -> Client?
+
+  init(get: @escaping @Sendable () async throws -> Client?) {
+    getHandler = get
+  }
+
+  @MainActor
+  func getResponse(skipClientId: Bool) async throws -> ClientServiceResponse {
+    skipClientIdValues.withValue { $0.append(skipClientId) }
+    return try await ClientServiceResponse(
+      client: getHandler(),
+      requestSequence: nil,
+      serverDate: nil
+    )
+  }
+}
+
 @MainActor
 private func configureHostedAuthForTesting(
   hostedAuthService: some HostedAuthServiceProtocol,
   sessionService: some SessionServiceProtocol,
+  clientService: (any ClientServiceProtocol)? = nil,
   initialClient: Client,
   options: Clerk.Options = .init()
 ) {
   configureClerkForTesting()
   Clerk.shared.dependencies = MockDependencyContainer(
     apiClient: Clerk.shared.dependencies.apiClient,
+    clientService: clientService,
     hostedAuthService: hostedAuthService,
     sessionService: sessionService
   )
@@ -682,4 +882,14 @@ private func makeHostedAuthCallbackUrl(
     throw ClerkClientError(message: "Invalid callback URL in test.")
   }
   return url
+}
+
+private func hostedAuthAPIError(code: String) -> ClerkAPIError {
+  ClerkAPIError(
+    code: code,
+    message: code,
+    longMessage: nil,
+    meta: nil,
+    clerkTraceId: nil
+  )
 }

--- a/Tests/Domains/Auth/HostedAuthTests.swift
+++ b/Tests/Domains/Auth/HostedAuthTests.swift
@@ -32,17 +32,17 @@ struct HostedAuthProtocolTests {
   func pkceChallengeMatchesRFC7636Vector() {
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
 
-    #expect(HostedAuthPKCE.challenge(for: verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+    #expect(PKCE.challenge(for: verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
   }
 
   @Test
   func generatedPKCEPairUsesS256CompatibleValues() throws {
-    let pair = try HostedAuthPKCE.generatePair()
+    let pair = try PKCE.generatePair()
 
     #expect(pair.verifier.count == 43)
     #expect(pair.challenge.count == 43)
     #expect(pair.verifier.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" })
-    #expect(pair.challenge == HostedAuthPKCE.challenge(for: pair.verifier))
+    #expect(pair.challenge == PKCE.challenge(for: pair.verifier))
   }
 
   @Test
@@ -145,7 +145,7 @@ struct HostedAuthFlowTests {
         guard let createParams = createParams.value else {
           throw ClerkClientError(message: "Missing create params in test.")
         }
-        #expect(HostedAuthPKCE.challenge(for: params.codeVerifier) == createParams.codeChallenge)
+        #expect(PKCE.challenge(for: params.codeVerifier) == createParams.codeChallenge)
         return ClientServiceResponse(client: redeemedClient, requestSequence: nil, serverDate: nil)
       }
     )

--- a/Tests/Domains/Auth/HostedAuthTests.swift
+++ b/Tests/Domains/Auth/HostedAuthTests.swift
@@ -362,7 +362,10 @@ struct HostedAuthFlowTests {
       #expect(params.codeChallenge == firstParams.codeChallenge)
       #expect(params.state == firstParams.state)
       #expect(params.mode == firstParams.mode)
-      #expect(Clerk.shared.client == reconciledClient)
+      // Assert ordering (reconcile before retry) via the refresh counter instead of
+      // Clerk.shared.client: parallel suites share the singleton and can rewrite it
+      // between the refresh and this closure.
+      #expect(refreshCalls.value == 1)
       return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
     })
     let clientService = HostedAuthClientService(get: {

--- a/Tests/Domains/Auth/HostedAuthTests.swift
+++ b/Tests/Domains/Auth/HostedAuthTests.swift
@@ -117,6 +117,35 @@ struct HostedAuthProtocolTests {
       try HostedAuthCallback(url: duplicateState, redirect: redirect, state: "state_123")
     }
   }
+
+  @Test
+  func callbackStateValidationDistinguishesMissingDuplicatedAndMismatchedState() throws {
+    let redirect = try HostedAuthRedirect("myapp:///hosted-auth-callback")
+    let cases: [(query: String, expectedMessage: String)] = [
+      (
+        "rotating_token_nonce=nonce_123&created_session_id=sess_123",
+        "Hosted auth callback did not include a state parameter."
+      ),
+      (
+        "state=state_123&state=state_123&rotating_token_nonce=nonce_123&created_session_id=sess_123",
+        "Hosted auth callback included more than one state parameter."
+      ),
+      (
+        "state=other_state&rotating_token_nonce=nonce_123&created_session_id=sess_123",
+        "Hosted auth callback state did not match the initiated state."
+      ),
+    ]
+
+    for (query, expectedMessage) in cases {
+      let url = try #require(URL(string: "myapp:///hosted-auth-callback?\(query)"))
+      do {
+        _ = try HostedAuthCallback(url: url, redirect: redirect, state: "state_123")
+        Issue.record("Expected state validation to throw for query: \(query)")
+      } catch let error as ClerkClientError {
+        #expect(error.message == expectedMessage)
+      }
+    }
+  }
 }
 
 @MainActor

--- a/Tests/Domains/Auth/HostedAuthTests.swift
+++ b/Tests/Domains/Auth/HostedAuthTests.swift
@@ -29,23 +29,6 @@ struct HostedAuthProtocolTests {
   }
 
   @Test
-  func pkceChallengeMatchesRFC7636Vector() {
-    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
-
-    #expect(PKCE.challenge(for: verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
-  }
-
-  @Test
-  func generatedPKCEPairUsesS256CompatibleValues() throws {
-    let pair = try PKCE.generatePair()
-
-    #expect(pair.verifier.count == 43)
-    #expect(pair.challenge.count == 43)
-    #expect(pair.verifier.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" })
-    #expect(pair.challenge == PKCE.challenge(for: pair.verifier))
-  }
-
-  @Test
   func generatedStateIsRandomAndNonEmpty() throws {
     let first = try HostedAuthState.generate()
     let second = try HostedAuthState.generate()
@@ -138,30 +121,21 @@ struct HostedAuthProtocolTests {
   }
 
   @Test
-  func callbackStateValidationDistinguishesMissingDuplicatedAndMismatchedState() throws {
+  func callbackStateValidationRejectsMissingDuplicatedAndMismatchedState() throws {
     let redirect = try HostedAuthRedirect("myapp:///hosted-auth-callback")
-    let cases: [(query: String, expectedMessage: String)] = [
-      (
-        "rotating_token_nonce=nonce_123&created_session_id=sess_123",
-        "Hosted auth callback did not include a state parameter."
-      ),
-      (
-        "state=state_123&state=state_123&rotating_token_nonce=nonce_123&created_session_id=sess_123",
-        "Hosted auth callback included more than one state parameter."
-      ),
-      (
-        "state=other_state&rotating_token_nonce=nonce_123&created_session_id=sess_123",
-        "Hosted auth callback state did not match the initiated state."
-      ),
+    let invalidStateQueries = [
+      "rotating_token_nonce=nonce_123&created_session_id=sess_123",
+      "state=state_123&state=state_123&rotating_token_nonce=nonce_123&created_session_id=sess_123",
+      "state=other_state&rotating_token_nonce=nonce_123&created_session_id=sess_123",
     ]
 
-    for (query, expectedMessage) in cases {
+    for query in invalidStateQueries {
       let url = try #require(URL(string: "myapp:///hosted-auth-callback?\(query)"))
       do {
         _ = try HostedAuthCallback(url: url, redirect: redirect, state: "state_123")
         Issue.record("Expected state validation to throw for query: \(query)")
       } catch let error as ClerkClientError {
-        #expect(error.message == expectedMessage)
+        #expect(error.message == "Hosted auth callback state was missing or did not match the initiated state.")
       }
     }
   }

--- a/Tests/Domains/Auth/HostedAuthTests.swift
+++ b/Tests/Domains/Auth/HostedAuthTests.swift
@@ -1,0 +1,437 @@
+@testable import ClerkKit
+import ConcurrencyExtras
+import Foundation
+import Testing
+
+struct HostedAuthProtocolTests {
+  @Test
+  func modeUsesHostedAuthProtocolValues() {
+    #expect(HostedAuthMode.signIn.rawValue == "sign-in")
+    #expect(HostedAuthMode.signUp.rawValue == "sign-up")
+  }
+
+  @Test
+  func hostedAuthResourceRequiresExpectedObjectAndWebOrigin() throws {
+    let resource = HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+    #expect(try resource.authenticationUrl().absoluteString == resource.url)
+
+    for invalidResource in [
+      HostedAuthResource(object: "client", url: resource.url),
+      HostedAuthResource(object: "hosted_auth", url: "https:missing-host"),
+      HostedAuthResource(object: "hosted_auth", url: "http://accounts.example.com/sign-in"),
+      HostedAuthResource(object: "hosted_auth", url: "https://user@accounts.example.com/sign-in"),
+      HostedAuthResource(object: "hosted_auth", url: "myapp://callback"),
+    ] {
+      #expect(throws: ClerkClientError.self) {
+        try invalidResource.authenticationUrl()
+      }
+    }
+  }
+
+  @Test
+  func pkceChallengeMatchesRFC7636Vector() {
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+
+    #expect(HostedAuthPKCE.challenge(for: verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+  }
+
+  @Test
+  func generatedPKCEPairUsesS256CompatibleValues() throws {
+    let pair = try HostedAuthPKCE.generatePair()
+
+    #expect(pair.verifier.count == 43)
+    #expect(pair.challenge.count == 43)
+    #expect(pair.verifier.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" })
+    #expect(pair.challenge == HostedAuthPKCE.challenge(for: pair.verifier))
+  }
+
+  @Test
+  func generatedStateIsRandomAndNonEmpty() throws {
+    let first = try HostedAuthState.generate()
+    let second = try HostedAuthState.generate()
+
+    #expect(!first.isEmpty)
+    #expect(first != second)
+  }
+
+  @Test
+  func redirectMatchesSchemeAuthorityPortAndPath() throws {
+    let redirect = try HostedAuthRedirect("myapp://expected.example:4242/callback")
+    let valid = try #require(URL(string: "myapp://expected.example:4242/callback?state=state_123"))
+    #expect(redirect.matches(valid))
+
+    for rawValue in [
+      "other://expected.example:4242/callback",
+      "myapp://other.example:4242/callback",
+      "myapp://expected.example:4243/callback",
+      "myapp://expected.example:4242/other",
+      "myapp://user@expected.example:4242/callback",
+    ] {
+      let callback = try #require(URL(string: rawValue))
+      #expect(!redirect.matches(callback), "Expected callback to be rejected: \(rawValue)")
+    }
+  }
+
+  @Test
+  func tripleSlashRedirectRejectsInjectedOrMissingAuthority() throws {
+    let redirect = try HostedAuthRedirect("myapp:///hosted-auth-callback")
+    let valid = try #require(URL(string: "myapp:///hosted-auth-callback?state=state_123"))
+    let injectedHost = try #require(URL(string: "myapp://attacker/hosted-auth-callback?state=state_123"))
+    let missingAuthority = try #require(URL(string: "myapp:/hosted-auth-callback?state=state_123"))
+
+    #expect(redirect.matches(valid))
+    #expect(!redirect.matches(injectedHost))
+    #expect(!redirect.matches(missingAuthority))
+  }
+
+  @Test
+  func callbackRequiresExactStateNonceAndCreatedSession() throws {
+    let redirect = try HostedAuthRedirect("myapp:///hosted-auth-callback")
+    let callbackUrl = try makeHostedAuthCallbackUrl(
+      redirectUrl: redirect.rawValue,
+      state: "state_123",
+      rotatingTokenNonce: "nonce_123",
+      createdSessionId: "sess_123"
+    )
+
+    let callback = try HostedAuthCallback(url: callbackUrl, redirect: redirect, state: "state_123")
+    #expect(callback.rotatingTokenNonce == "nonce_123")
+    #expect(callback.createdSessionId == "sess_123")
+
+    #expect(throws: ClerkClientError.self) {
+      try HostedAuthCallback(url: callbackUrl, redirect: redirect, state: "other_state")
+    }
+
+    let missingNonce = try #require(URL(string: "myapp:///hosted-auth-callback?state=state_123&created_session_id=sess_123"))
+    #expect(throws: ClerkClientError.self) {
+      try HostedAuthCallback(url: missingNonce, redirect: redirect, state: "state_123")
+    }
+
+    let missingCreatedSession = try #require(URL(string: "myapp:///hosted-auth-callback?state=state_123&rotating_token_nonce=nonce_123"))
+    #expect(throws: ClerkClientError.self) {
+      try HostedAuthCallback(url: missingCreatedSession, redirect: redirect, state: "state_123")
+    }
+
+    let duplicateState = try #require(URL(string: "myapp:///hosted-auth-callback?state=state_123&state=state_123&rotating_token_nonce=nonce_123&created_session_id=sess_123"))
+    #expect(throws: ClerkClientError.self) {
+      try HostedAuthCallback(url: duplicateState, redirect: redirect, state: "state_123")
+    }
+  }
+}
+
+@MainActor
+@Suite(.serialized)
+struct HostedAuthFlowTests {
+  @Test
+  func successRedeemsUpdatesClientAndActivatesOnlyCallbackSession() async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let redeemParams = LockIsolated<HostedAuthRedeemParams?>(nil)
+    let browserInputs = LockIsolated<HostedAuthBrowserInputs?>(nil)
+    let setActiveCall = LockIsolated<HostedAuthSetActiveCall?>(nil)
+
+    var redeemedClient = Client.mock
+    redeemedClient.sessions = [.mock, .mock2]
+    redeemedClient.lastActiveSessionId = Session.mock.id
+    var activatedClient = redeemedClient
+    activatedClient.lastActiveSessionId = Session.mock2.id
+
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+      },
+      redeem: { params in
+        redeemParams.setValue(params)
+        guard let createParams = createParams.value else {
+          throw ClerkClientError(message: "Missing create params in test.")
+        }
+        #expect(HostedAuthPKCE.challenge(for: params.codeVerifier) == createParams.codeChallenge)
+        return ClientServiceResponse(client: redeemedClient, requestSequence: nil, serverDate: nil)
+      }
+    )
+    let sessionService = MockSessionService(setActive: { sessionId, organizationId in
+      setActiveCall.setValue(HostedAuthSetActiveCall(sessionId: sessionId, organizationId: organizationId))
+      Clerk.shared.client = activatedClient
+    })
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: sessionService,
+      initialClient: .mockSignedOut
+    )
+
+    let session = try await Clerk.shared.auth.performHostedAuth(
+      mode: .signUp,
+      redirectUrl: "myapp:///hosted-auth-callback",
+      prefersEphemeralWebBrowserSession: false,
+      webAuthentication: { url, callbackUrlScheme, prefersEphemeral in
+        browserInputs.setValue(HostedAuthBrowserInputs(
+          url: url,
+          callbackUrlScheme: callbackUrlScheme,
+          prefersEphemeralWebBrowserSession: prefersEphemeral
+        ))
+        guard let state = createParams.value?.state else {
+          throw ClerkClientError(message: "Missing state in test.")
+        }
+        return try makeHostedAuthCallbackUrl(
+          redirectUrl: "myapp:///hosted-auth-callback",
+          state: state,
+          rotatingTokenNonce: "nonce_123",
+          createdSessionId: Session.mock2.id
+        )
+      }
+    )
+
+    #expect(session.id == Session.mock2.id)
+    #expect(Clerk.shared.client == activatedClient)
+    #expect(createParams.value?.redirectUrl == "myapp:///hosted-auth-callback")
+    #expect(createParams.value?.mode == .signUp)
+    #expect(redeemParams.value?.rotatingTokenNonce == "nonce_123")
+    #expect(setActiveCall.value == HostedAuthSetActiveCall(sessionId: Session.mock2.id, organizationId: nil))
+    #expect(try browserInputs.value == HostedAuthBrowserInputs(
+      url: #require(URL(string: "https://accounts.example.com/sign-in")),
+      callbackUrlScheme: "myapp",
+      prefersEphemeralWebBrowserSession: false
+    ))
+  }
+
+  @Test
+  func overlappingStartIsRejectedBeforeCreatingAnotherTransfer() async throws {
+    let createCalls = LockIsolated(0)
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    var redeemedClient = Client.mock
+    redeemedClient.sessions = [.mock]
+    redeemedClient.lastActiveSessionId = Session.mock.id
+
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createCalls.withValue { $0 += 1 }
+        createParams.setValue(params)
+        return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+      },
+      redeem: { _ in
+        ClientServiceResponse(client: redeemedClient, requestSequence: nil, serverDate: nil)
+      }
+    )
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: MockSessionService(),
+      initialClient: .mockSignedOut
+    )
+
+    let auth = Clerk.shared.auth
+    let session = try await auth.performHostedAuth(
+      mode: nil,
+      redirectUrl: "myapp://callback",
+      prefersEphemeralWebBrowserSession: false,
+      webAuthentication: { _, _, _ in
+        do {
+          _ = try await auth.performHostedAuth(
+            mode: nil,
+            redirectUrl: "myapp://callback",
+            prefersEphemeralWebBrowserSession: false,
+            webAuthentication: { _, _, _ in
+              throw ClerkClientError(message: "Unexpected second browser launch.")
+            }
+          )
+          Issue.record("Expected overlapping hosted auth to throw")
+        } catch let error as ClerkClientError {
+          #expect(error.message == "A hosted authentication session is already in progress.")
+          #expect(createCalls.value == 1)
+        }
+
+        return try makeHostedAuthCallbackUrl(
+          redirectUrl: "myapp://callback",
+          state: #require(createParams.value?.state),
+          rotatingTokenNonce: "nonce_123",
+          createdSessionId: Session.mock.id
+        )
+      }
+    )
+    #expect(session.id == Session.mock.id)
+  }
+
+  @Test
+  func cancellationPropagatesWithoutRedeemingOrActivating() async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let redeemCalled = LockIsolated(false)
+    let setActiveCalled = LockIsolated(false)
+    let initialClient = Client.mockSignedOut
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+      },
+      redeem: { _ in
+        redeemCalled.setValue(true)
+        return ClientServiceResponse(client: .mock, requestSequence: nil, serverDate: nil)
+      }
+    )
+    let sessionService = MockSessionService(setActive: { _, _ in
+      setActiveCalled.setValue(true)
+    })
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: sessionService,
+      initialClient: initialClient
+    )
+
+    do {
+      _ = try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in throw CancellationError() }
+      )
+      Issue.record("Expected hosted auth cancellation to throw")
+    } catch is CancellationError {
+      #expect(createParams.value?.redirectUrl == "myapp://callback")
+      #expect(!redeemCalled.value)
+      #expect(!setActiveCalled.value)
+      #expect(Clerk.shared.client == initialClient)
+    } catch {
+      Issue.record("Expected CancellationError, got \(error)")
+    }
+  }
+
+  @Test
+  func missingCallbackSessionDoesNotApplyClientOrActivateAnotherSession() async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let setActiveCalled = LockIsolated(false)
+    let initialClient = Client.mockSignedOut
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+      },
+      redeem: { _ in
+        ClientServiceResponse(client: .mock, requestSequence: nil, serverDate: nil)
+      }
+    )
+    let sessionService = MockSessionService(setActive: { _, _ in
+      setActiveCalled.setValue(true)
+    })
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: sessionService,
+      initialClient: initialClient
+    )
+
+    do {
+      _ = try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in
+          guard let state = createParams.value?.state else {
+            throw ClerkClientError(message: "Missing state in test.")
+          }
+          return try makeHostedAuthCallbackUrl(
+            redirectUrl: "myapp://callback",
+            state: state,
+            rotatingTokenNonce: "nonce_123",
+            createdSessionId: "sess_callback"
+          )
+        }
+      )
+      Issue.record("Expected missing callback session to throw")
+    } catch let error as ClerkClientError {
+      #expect(error.message == "Hosted auth completion did not include the created session.")
+      #expect(!setActiveCalled.value)
+      #expect(Clerk.shared.client == initialClient)
+    } catch {
+      Issue.record("Expected ClerkClientError, got \(error)")
+    }
+  }
+
+  @Test
+  func clientChangeDuringActivationDoesNotReturnStaleSession() async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    var redeemedClient = Client.mock
+    redeemedClient.sessions = [.mock]
+    redeemedClient.lastActiveSessionId = Session.mock.id
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+      },
+      redeem: { _ in
+        ClientServiceResponse(client: redeemedClient, requestSequence: nil, serverDate: nil)
+      }
+    )
+    let sessionService = MockSessionService(setActive: { _, _ in
+      Clerk.shared.client = .mockSignedOut
+    })
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: sessionService,
+      initialClient: .mockSignedOut
+    )
+
+    do {
+      _ = try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in
+          let state = try #require(createParams.value?.state)
+          return try makeHostedAuthCallbackUrl(
+            redirectUrl: "myapp://callback",
+            state: state,
+            rotatingTokenNonce: "nonce_123",
+            createdSessionId: Session.mock.id
+          )
+        }
+      )
+      Issue.record("Expected client change during activation to throw")
+    } catch let error as ClerkClientError {
+      #expect(error.message == "Hosted auth completion could not activate the created session.")
+      #expect(Clerk.shared.client == .mockSignedOut)
+    }
+  }
+}
+
+private struct HostedAuthBrowserInputs: Equatable {
+  let url: URL
+  let callbackUrlScheme: String
+  let prefersEphemeralWebBrowserSession: Bool
+}
+
+private struct HostedAuthSetActiveCall: Equatable {
+  let sessionId: String
+  let organizationId: String?
+}
+
+@MainActor
+private func configureHostedAuthForTesting(
+  hostedAuthService: some HostedAuthServiceProtocol,
+  sessionService: some SessionServiceProtocol,
+  initialClient: Client
+) {
+  configureClerkForTesting()
+  Clerk.shared.dependencies = MockDependencyContainer(
+    apiClient: Clerk.shared.dependencies.apiClient,
+    hostedAuthService: hostedAuthService,
+    sessionService: sessionService
+  )
+  Clerk.shared.client = initialClient
+}
+
+private func makeHostedAuthCallbackUrl(
+  redirectUrl: String,
+  state: String,
+  rotatingTokenNonce: String,
+  createdSessionId: String
+) throws -> URL {
+  guard var components = URLComponents(string: redirectUrl) else {
+    throw ClerkClientError(message: "Invalid redirect URL in test.")
+  }
+  components.queryItems = [
+    URLQueryItem(name: "state", value: state),
+    URLQueryItem(name: "rotating_token_nonce", value: rotatingTokenNonce),
+    URLQueryItem(name: "created_session_id", value: createdSessionId),
+  ]
+  guard let url = components.url else {
+    throw ClerkClientError(message: "Invalid callback URL in test.")
+  }
+  return url
+}

--- a/Tests/Domains/Auth/HostedAuthTests.swift
+++ b/Tests/Domains/Auth/HostedAuthTests.swift
@@ -168,7 +168,11 @@ struct HostedAuthFlowTests {
           throw ClerkClientError(message: "Missing create params in test.")
         }
         #expect(PKCE.challenge(for: params.codeVerifier) == createParams.codeChallenge)
-        return ClientServiceResponse(client: redeemedClient, requestSequence: nil, serverDate: nil)
+        return hostedAuthRedeemResponse(
+          client: redeemedClient,
+          responseSequence: 1,
+          serverDate: Date(timeIntervalSince1970: 200)
+        )
       }
     )
     let sessionService = MockSessionService(setActive: { sessionId, organizationId in
@@ -205,6 +209,12 @@ struct HostedAuthFlowTests {
 
     #expect(session.id == Session.mock2.id)
     #expect(Clerk.shared.client == activatedClient)
+    #expect(
+      try Clerk.shared.dependencies.identityKeychain.string(
+        forKey: ClerkKeychainKey.clerkDeviceToken.rawValue
+      ) == "hosted_auth_test_device_token"
+    )
+    #expect(Clerk.shared.lastClientServerFetchDate == Date(timeIntervalSince1970: 200))
     #expect(createParams.value?.redirectUrl == "myapp:///hosted-auth-callback")
     #expect(createParams.value?.mode == .signUp)
     #expect(redeemParams.value?.rotatingTokenNonce == "nonce_123")
@@ -231,7 +241,7 @@ struct HostedAuthFlowTests {
         return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
       },
       redeem: { _ in
-        ClientServiceResponse(client: redeemedClient, requestSequence: nil, serverDate: nil)
+        hostedAuthRedeemResponse(client: redeemedClient)
       }
     )
     configureHostedAuthForTesting(
@@ -285,7 +295,7 @@ struct HostedAuthFlowTests {
       },
       redeem: { _ in
         redeemCalled.setValue(true)
-        return ClientServiceResponse(client: .mock, requestSequence: nil, serverDate: nil)
+        return hostedAuthRedeemResponse(client: .mock)
       }
     )
     let sessionService = MockSessionService(setActive: { _, _ in
@@ -508,7 +518,7 @@ struct HostedAuthFlowTests {
         return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
       },
       redeem: { _ in
-        ClientServiceResponse(client: .mock, requestSequence: nil, serverDate: nil)
+        hostedAuthRedeemResponse(client: .mock)
       }
     )
     let sessionService = MockSessionService(setActive: { _, _ in
@@ -548,6 +558,73 @@ struct HostedAuthFlowTests {
   }
 
   @Test
+  func explicitClearRedeemResponseClearsIdentityWithoutActivating() async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let setActiveCalled = LockIsolated(false)
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+      },
+      redeem: { _ in
+        HostedAuthRedeemResponse(
+          client: nil,
+          clientSyncContext: ClientSyncResponseContext(
+            update: .explicitClear,
+            deviceTokenUpdate: .clear,
+            requestDeviceToken: Clerk.shared.identityController.currentDeviceToken,
+            baseGeneration: nil,
+            serverDate: Date(timeIntervalSince1970: 200),
+            isCanonicalClientRequest: true,
+            clientResponseGeneration: Clerk.shared.clientResponseGeneration,
+            responseSequence: 1
+          )
+        )
+      }
+    )
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: MockSessionService(setActive: { _, _ in
+        setActiveCalled.setValue(true)
+      }),
+      initialClient: .mock
+    )
+    try Clerk.shared.dependencies.identityKeychain.set(
+      "initial-token",
+      forKey: ClerkKeychainKey.clerkDeviceToken.rawValue
+    )
+
+    do {
+      _ = try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in
+          try makeHostedAuthCallbackUrl(
+            redirectUrl: "myapp://callback",
+            state: #require(createParams.value?.state),
+            rotatingTokenNonce: "nonce_123",
+            createdSessionId: Session.mock.id
+          )
+        }
+      )
+      Issue.record("Expected the authoritative clear to fail hosted auth completion")
+    } catch let error as ClerkClientError {
+      #expect(error.message == "Hosted auth completion could not update the current client.")
+    } catch {
+      Issue.record("Expected ClerkClientError, got \(error)")
+    }
+
+    #expect(!setActiveCalled.value)
+    #expect(Clerk.shared.client == nil)
+    #expect(
+      try Clerk.shared.dependencies.identityKeychain.string(
+        forKey: ClerkKeychainKey.clerkDeviceToken.rawValue
+      ) == nil
+    )
+  }
+
+  @Test
   func clientChangeDuringActivationDoesNotReturnStaleSession() async throws {
     let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
     var redeemedClient = Client.mock
@@ -559,7 +636,7 @@ struct HostedAuthFlowTests {
         return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
       },
       redeem: { _ in
-        ClientServiceResponse(client: redeemedClient, requestSequence: nil, serverDate: nil)
+        hostedAuthRedeemResponse(client: redeemedClient)
       }
     )
     let sessionService = MockSessionService(setActive: { _, _ in
@@ -608,7 +685,7 @@ struct HostedAuthFlowTests {
         return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
       },
       redeem: { _ in
-        ClientServiceResponse(client: redeemedClient, requestSequence: nil, serverDate: nil)
+        hostedAuthRedeemResponse(client: redeemedClient)
       }
     )
     configureHostedAuthForTesting(
@@ -656,7 +733,7 @@ struct HostedAuthFlowTests {
       },
       redeem: { _ in
         redeemCalled.setValue(true)
-        return ClientServiceResponse(client: .mock, requestSequence: nil, serverDate: nil)
+        return hostedAuthRedeemResponse(client: .mock)
       }
     )
     configureHostedAuthForTesting(
@@ -690,6 +767,7 @@ struct HostedAuthFlowTests {
   @Test
   func generationChangeWhileBrowserOpenDiscardsRedeemedClient() async throws {
     let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let redeemCalled = LockIsolated(false)
     let setActiveCalled = LockIsolated(false)
     let initialClient = Client.mockSignedOut
     var redeemedClient = Client.mock
@@ -702,7 +780,8 @@ struct HostedAuthFlowTests {
         return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
       },
       redeem: { _ in
-        ClientServiceResponse(client: redeemedClient, requestSequence: nil, serverDate: nil)
+        redeemCalled.setValue(true)
+        return hostedAuthRedeemResponse(client: redeemedClient)
       }
     )
     let sessionService = MockSessionService(setActive: { _, _ in
@@ -732,11 +811,69 @@ struct HostedAuthFlowTests {
       Issue.record("Expected stale client response generation to throw")
     } catch let error as ClerkClientError {
       #expect(error.message == "Hosted auth completion could not update the current client.")
+      #expect(!redeemCalled.value)
       #expect(!setActiveCalled.value)
       #expect(Clerk.shared.client == initialClient)
     } catch {
       Issue.record("Expected ClerkClientError, got \(error)")
     }
+  }
+
+  @Test
+  func generationChangeDuringRedeemDiscardsResponseWithoutActivating() async throws {
+    let createParams = LockIsolated<HostedAuthCreateParams?>(nil)
+    let redeemCalled = LockIsolated(false)
+    let setActiveCalled = LockIsolated(false)
+    let initialClient = Client.mockSignedOut
+    var redeemedClient = Client.mock
+    redeemedClient.sessions = [.mock]
+    redeemedClient.lastActiveSessionId = Session.mock.id
+
+    let hostedAuthService = MockHostedAuthService(
+      create: { params in
+        createParams.setValue(params)
+        return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
+      },
+      redeem: { _ in
+        redeemCalled.setValue(true)
+        let response = hostedAuthRedeemResponse(client: redeemedClient)
+        Clerk.shared.identityController.fenceClientResponses()
+        return response
+      }
+    )
+    let sessionService = MockSessionService(setActive: { _, _ in
+      setActiveCalled.setValue(true)
+    })
+    configureHostedAuthForTesting(
+      hostedAuthService: hostedAuthService,
+      sessionService: sessionService,
+      initialClient: initialClient
+    )
+
+    do {
+      _ = try await Clerk.shared.auth.performHostedAuth(
+        mode: nil,
+        redirectUrl: "myapp://callback",
+        prefersEphemeralWebBrowserSession: false,
+        webAuthentication: { _, _, _ in
+          try makeHostedAuthCallbackUrl(
+            redirectUrl: "myapp://callback",
+            state: #require(createParams.value?.state),
+            rotatingTokenNonce: "nonce_123",
+            createdSessionId: Session.mock.id
+          )
+        }
+      )
+      Issue.record("Expected the stale redeem response to throw")
+    } catch let error as ClerkClientError {
+      #expect(error.message == "Hosted auth completion could not update the current client.")
+    } catch {
+      Issue.record("Expected ClerkClientError, got \(error)")
+    }
+
+    #expect(redeemCalled.value)
+    #expect(!setActiveCalled.value)
+    #expect(Clerk.shared.client == initialClient)
   }
 
   @Test
@@ -753,7 +890,7 @@ struct HostedAuthFlowTests {
         return HostedAuthResource(object: "hosted_auth", url: "https://accounts.example.com/sign-in")
       },
       redeem: { _ in
-        ClientServiceResponse(client: redeemedClient, requestSequence: nil, serverDate: nil)
+        hostedAuthRedeemResponse(client: redeemedClient)
       }
     )
     configureHostedAuthForTesting(
@@ -799,6 +936,27 @@ private struct HostedAuthBrowserInputs: Equatable {
 private struct HostedAuthSetActiveCall: Equatable {
   let sessionId: String
   let organizationId: String?
+}
+
+@MainActor
+private func hostedAuthRedeemResponse(
+  client: Client?,
+  responseSequence: Int? = nil,
+  serverDate: Date? = nil
+) -> HostedAuthRedeemResponse {
+  HostedAuthRedeemResponse(
+    client: client,
+    clientSyncContext: ClientSyncResponseContext(
+      update: client.map(ClientResponseUpdate.client) ?? .absent,
+      deviceTokenUpdate: .set("hosted_auth_test_device_token"),
+      requestDeviceToken: Clerk.shared.identityController.currentDeviceToken,
+      baseGeneration: 0,
+      serverDate: serverDate,
+      isCanonicalClientRequest: true,
+      clientResponseGeneration: Clerk.shared.clientResponseGeneration,
+      responseSequence: responseSequence
+    )
+  )
 }
 
 private final class HostedAuthClientService: ClientServiceProtocol {

--- a/Tests/Domains/Auth/HostedAuthTests.swift
+++ b/Tests/Domains/Auth/HostedAuthTests.swift
@@ -720,7 +720,7 @@ struct HostedAuthFlowTests {
         redirectUrl: "myapp://callback",
         prefersEphemeralWebBrowserSession: false,
         webAuthentication: { _, _, _ in
-          Clerk.shared.fenceClientResponsesAfterDeviceTokenChange()
+          Clerk.shared.identityController.fenceClientResponses()
           return try makeHostedAuthCallbackUrl(
             redirectUrl: "myapp://callback",
             state: #require(createParams.value?.state),

--- a/Tests/Domains/Auth/SignIn/SignInTests.swift
+++ b/Tests/Domains/Auth/SignIn/SignInTests.swift
@@ -170,7 +170,7 @@ struct SignInTests {
     #expect(params.1.strategy == .emailLink)
     #expect(params.1.emailAddressId == "ema_123")
     #expect(params.1.redirectUri == Clerk.shared.options.redirectConfig.redirectUrl)
-    #expect(params.1.codeChallengeMethod == MagicLinkPKCE.codeChallengeMethod)
+    #expect(params.1.codeChallengeMethod == PKCE.codeChallengeMethod)
     #expect(params.1.codeChallenge?.isEmpty == false)
 
     let pendingFlow = try #require(magicLinkStore.load())

--- a/Tests/Domains/Auth/SignUp/SignUpTests.swift
+++ b/Tests/Domains/Auth/SignUp/SignUpTests.swift
@@ -65,7 +65,7 @@ struct SignUpTests {
     #expect(params.1.strategy == .emailLink)
     #expect(params.1.emailAddressId == nil)
     #expect(params.1.redirectUri == Clerk.shared.options.redirectConfig.redirectUrl)
-    #expect(params.1.codeChallengeMethod == MagicLinkPKCE.codeChallengeMethod)
+    #expect(params.1.codeChallengeMethod == PKCE.codeChallengeMethod)
     #expect(params.1.codeChallenge?.isEmpty == false)
 
     let pendingFlow = try #require(magicLinkStore.load())

--- a/Tests/Middleware/ClerkClientSyncResponseMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkClientSyncResponseMiddlewareTests.swift
@@ -189,6 +189,58 @@ struct ClerkClientSyncResponseMiddlewareTests {
   }
 
   @Test
+  func disabledAutomaticSyncDefersClientButStillAppliesExplicitClear() async throws {
+    let clerk = Clerk()
+    let keychain = InMemoryKeychain()
+    try keychain.set("current-token", forKey: ClerkKeychainKey.clerkDeviceToken.rawValue)
+    clerk.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(runtimeScope: clerk.runtimeScope),
+      keychain: keychain
+    )
+    let existingClient = client(id: "existing-client", updatedAt: .distantPast)
+    clerk.client = existingClient
+    let incomingClient = client(id: "incoming-client", updatedAt: .distantFuture)
+    let data = try JSONEncoder.clerkEncoder.encode(
+      ClientOnlyEnvelope(response: incomingClient, client: nil)
+    )
+    let url = try #require(URL(string: "https://example.com/v1/client"))
+    var request = URLRequest(url: url)
+    request.disableAutomaticClerkClientSync()
+    request.setClerkCanonicalClientRequest(true)
+    request.setClerkRequestDeviceToken("current-token")
+    request.setClerkClientResponseGeneration(clerk.clientResponseGeneration)
+    let middleware = ClerkClientSyncResponseMiddleware(runtimeScope: clerk.runtimeScope)
+    let positiveResponse = try #require(HTTPURLResponse(
+      url: url,
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: ["Authorization": "rotated-token"]
+    ))
+
+    try await middleware.validate(positiveResponse, data: data, for: request)
+
+    #expect(clerk.client?.id == existingClient.id)
+    #expect(
+      try keychain.string(forKey: ClerkKeychainKey.clerkDeviceToken.rawValue)
+        == "current-token"
+    )
+
+    let clearResponse = try #require(HTTPURLResponse(
+      url: url,
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: ["Authorization": "Bearer"]
+    ))
+    try await middleware.validate(clearResponse, data: data, for: request)
+
+    #expect(clerk.client == nil)
+    #expect(
+      try keychain.string(forKey: ClerkKeychainKey.clerkDeviceToken.rawValue)
+        == nil
+    )
+  }
+
+  @Test
   func validateAppliesClientFromClientResponseEnvelope() async throws {
     configureClerkForTesting()
     let clerk = Clerk()

--- a/Tests/Networking/ClerkAPIClientTests.swift
+++ b/Tests/Networking/ClerkAPIClientTests.swift
@@ -579,6 +579,88 @@ struct ClerkAPIClientTests {
     #expect(observedContexts.value.count == 1)
   }
 
+  @Test
+  func deferredClientSyncMetadataPreservesPreparedRequestAndResponseContext() async throws {
+    let testURL = URL(string: mockBaseUrl.absoluteString + "/v1/deferred-client-sync")!
+    let mock = try Mock(
+      url: testURL,
+      ignoreQuery: true,
+      contentType: .json,
+      statusCode: 200,
+      data: [.post: JSONEncoder().encode(["success": true])],
+      additionalHeaders: [
+        "Authorization": "rotated-device-token",
+        "Date": "Sat, 18 Jul 2026 14:00:00 GMT",
+      ]
+    )
+    mock.register()
+    let expectedClientResponseGeneration = ClientResponseGeneration.initial.next()
+    let pipeline = NetworkingPipeline(
+      requestMiddleware: [
+        PreparedDeferredClientSyncContextMiddleware(
+          clientResponseGeneration: expectedClientResponseGeneration
+        ),
+      ]
+    )
+    let apiClient = APIClient(
+      baseURL: mockBaseUrl,
+      runtimeScope: Clerk.shared.runtimeScope
+    ) { configuration in
+      configuration.pipeline = pipeline
+      configuration.sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
+    }
+
+    let response = try await apiClient.send(Request<EmptyResponse>(
+      path: "/v1/deferred-client-sync",
+      method: .post,
+      automaticallySyncClient: false
+    ))
+
+    let metadata = try #require(response.deferredClientSyncMetadata)
+    #expect(metadata.deviceTokenUpdate == .set("rotated-device-token"))
+    #expect(metadata.checkpoint.requestSequence == response.requestSequence)
+    #expect(metadata.checkpoint.clientResponseGeneration == expectedClientResponseGeneration)
+    #expect(metadata.checkpoint.sharedSessionBaseGeneration == 42)
+    #expect(metadata.checkpoint.isCanonicalClientRequest)
+    #expect(metadata.checkpoint.requestDeviceToken == "request-device-token")
+    #expect(metadata.serverDate == ISO8601DateFormatter().date(from: "2026-07-18T14:00:00Z"))
+
+    let context = metadata.context(update: .absent)
+    #expect(context.deviceTokenUpdate == .set("rotated-device-token"))
+    #expect(context.requestDeviceToken == "request-device-token")
+    #expect(context.baseGeneration == 42)
+    #expect(context.serverDate == metadata.serverDate)
+    #expect(context.isCanonicalClientRequest)
+    #expect(context.clientResponseGeneration == expectedClientResponseGeneration)
+    #expect(context.responseSequence == response.requestSequence)
+  }
+
+  @Test
+  func deferredClientSyncMetadataRequiresDisabledAutomaticSync() async throws {
+    let automaticURL = URL(string: mockBaseUrl.absoluteString + "/v1/automatic-client-sync")!
+    let automaticMock = try Mock(
+      url: automaticURL,
+      ignoreQuery: true,
+      contentType: .json,
+      statusCode: 200,
+      data: [.get: JSONEncoder().encode(["success": true])]
+    )
+    automaticMock.register()
+    let apiClient = APIClient(
+      baseURL: mockBaseUrl,
+      runtimeScope: Clerk.shared.runtimeScope
+    ) { configuration in
+      configuration.pipeline = NetworkingPipeline()
+      configuration.sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
+    }
+
+    let automaticResponse = try await apiClient.send(
+      Request<EmptyResponse>(path: "/v1/automatic-client-sync")
+    )
+
+    #expect(automaticResponse.deferredClientSyncMetadata == nil)
+  }
+
   private func waitUntil(_ condition: () -> Bool) async throws {
     let deadline = ContinuousClock.now + .seconds(1)
     while ContinuousClock.now < deadline {
@@ -586,6 +668,17 @@ struct ClerkAPIClientTests {
       await Task.yield()
     }
     throw ClerkClientError(message: "Timed out waiting for API client state.")
+  }
+}
+
+private struct PreparedDeferredClientSyncContextMiddleware: ClerkRequestMiddleware {
+  let clientResponseGeneration: ClientResponseGeneration
+
+  func prepare(_ request: inout URLRequest) async throws {
+    request.setClerkClientResponseGeneration(clientResponseGeneration)
+    request.setClerkSharedSessionBaseGeneration(42)
+    request.setClerkCanonicalClientRequest(true)
+    request.setClerkRequestDeviceToken("request-device-token")
   }
 }
 

--- a/Tests/Utils/PKCETests.swift
+++ b/Tests/Utils/PKCETests.swift
@@ -1,0 +1,22 @@
+@testable import ClerkKit
+import Foundation
+import Testing
+
+struct PKCETests {
+  @Test
+  func pkceChallengeMatchesRFC7636Vector() {
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+
+    #expect(PKCE.challenge(for: verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+  }
+
+  @Test
+  func generatedPKCEPairUsesS256CompatibleValues() throws {
+    let pair = try PKCE.generatePair()
+
+    #expect(pair.verifier.count == 43)
+    #expect(pair.challenge.count == 43)
+    #expect(pair.verifier.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" })
+    #expect(pair.challenge == PKCE.challenge(for: pair.verifier))
+  }
+}


### PR DESCRIPTION
## Summary

Adds hosted auth to Clerk iOS. An app can open Account Portal in `ASWebAuthenticationSession` for sign-in or sign-up, then activate the resulting session on the native Clerk client.

Account Portal continues to own the authentication flow. The native-specific behavior is limited to the final handoff: the browser returns a one-time transfer to the app, and the SDK redeems it into the existing native client instead of keeping a browser session.

## API

```swift
let session = try await Clerk.shared.auth.startHostedAuth(
  mode: .signUp,
  redirectUrl: nil,
  prefersEphemeralWebBrowserSession: false
)
```

`mode` defaults to sign-in. The SDK supplies its registered callback URL unless the app provides one explicitly.

## Implementation

- Creates the hosted-auth transfer through FAPI and decodes the standard `ClientResponse` envelope.
- Shares a single PKCE implementation with the magic link flow (`Utils/PKCE.swift`).
- Opens the returned Account Portal URL with `ASWebAuthenticationSession`.
- Validates the callback and redeems the transfer through the existing native client endpoint.
- Confirms that the returned client contains the session created by Account Portal before activating it.
- Keeps hosted-auth request bodies out of logs and prevents automatic client synchronization until the callback has been validated.
- Coordinates overlapping attempts and rejects stale completions so an older browser flow cannot replace newer client state.
- Revalidates the SDK runtime after the browser callback and before redemption, so a reconfiguration during the browser phase fails the flow without consuming the one-time transfer.
- Reports missing, duplicated, and mismatched callback state as distinct errors.
- If an abandoned handoff leaves the native client stale, refreshes without the old client ID and retries hosted-auth creation once.

Only custom-scheme callback URLs are supported; http/https callbacks are rejected. Completion is observable through the returned `Session` and `sessionChanged` events (hosted auth does not emit `signInCompleted`/`signUpCompleted`).

## Security

- Uses PKCE with SHA-256 to bind redemption to the app that initiated the flow.
- Generates cryptographically random state and validates it on callback.
- Requires the callback scheme, authority, port, and path to match the initiated redirect URL.
- Requires exactly one state, rotating-token nonce, and created-session ID.
- Sends the PKCE verifier in a POST body and excludes sensitive hosted-auth payloads from logging.
- Activates only the session identified by the validated callback.

## Related PRs

- Backend: https://github.com/clerk/clerk_go/pull/19852
- Account Portal: https://github.com/clerk/accounts/pull/1429
- Expo SDK: https://github.com/clerk/javascript/pull/8960
- Android SDK: https://github.com/clerk/clerk-android/pull/803


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hosted authentication flow with browser-based sign-in and sign-up
> - Adds `Auth.startHostedAuth(mode:redirectUrl:prefersEphemeralWebBrowserSession:)` which opens a system browser via `WebAuthentication`, validates the CSRF state and callback URL, redeems the rotating token nonce, syncs client state, and activates the returned session.
> - Introduces `HostedAuthService` with `create` (POST `/v1/client/hosted_auth`) and `redeem` (POST `/v1/client`) endpoints, plus supporting types: `HostedAuthMode`, `HostedAuthRedirect`, `HostedAuthCallback`, `HostedAuthState`, and `HostedAuthResource`.
> - Extracts PKCE pair generation into a shared `PKCE` utility, replacing the now-deleted `MagicLinkPKCE` enum used by magic-link sign-in and sign-up.
> - Adds per-request opt-outs for automatic client sync (`automaticallySyncClient: false`) and body logging (`logBodies: false`), consumed by new `shouldAutomaticallySyncClerkClient` and `shouldLogClerkBodies` URL request properties in middleware.
> - `APIResponse` gains a `deferredClientSyncMetadata` field so redeem responses can apply identity updates after generation checks rather than immediately in middleware.
> - Risk: magic-link flows now reference `PKCE.codeChallengeMethod` instead of the removed `MagicLinkPKCE.codeChallengeMethod`; any external code referencing `MagicLinkPKCE` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 387a518.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->