### PR TITLE
docs(auth): document organization-scoped ticket sessions

### DIFF
--- a/Sources/ClerkKit/Core/Auth.swift
+++ b/Sources/ClerkKit/Core/Auth.swift
@@ -375,6 +375,10 @@ public struct Auth {
 
   /// Signs in with a ticket generated from the Backend API.
   ///
+  /// If the ticket is scoped to an organization, the resulting session activates that
+  /// organization. After sign-in succeeds, access the organization ID through
+  /// ``Clerk/session`` and ``Session/lastActiveOrganizationId``.
+  ///
   /// - Parameter ticket: The ticket string from the Backend API.
   /// - Returns: A `SignIn` object representing the sign-in attempt.
   /// - Throws: An error if the ticket sign-in fails.

--- a/Tests/Domains/Auth/AuthTests.swift
+++ b/Tests/Domains/Auth/AuthTests.swift
@@ -343,6 +343,7 @@ struct AuthTests {
     _ = try await Clerk.shared.auth.signInWithTicket("mock_ticket_value")
 
     let params = try #require(signInParams.value)
+    #expect(params.strategy == .ticket)
     #expect(params.ticket == "mock_ticket_value")
   }
 

--- a/Tests/Middleware/ClerkClientSyncResponseMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkClientSyncResponseMiddlewareTests.swift
@@ -67,7 +67,7 @@ struct ClerkClientSyncResponseMiddlewareTests {
   }
 
   @Test
-  func validateAppliesClientFromClientResponseEnvelope() async throws {
+  func validateAppliesOrganizationScopedTicketSessionFromClientResponseEnvelope() async throws {
     configureClerkForTesting()
     let clerk = Clerk()
     let middleware = ClerkClientSyncResponseMiddleware(runtimeScope: .current(clerkProvider: { clerk }))
@@ -76,8 +76,11 @@ struct ClerkClientSyncResponseMiddlewareTests {
     var expectedClient = Client.mock
     expectedClient.lastActiveSessionId = session.id
     expectedClient.sessions = [session]
-    let data = try JSONEncoder.clerkEncoder.encode(ClientResponse<Session>(response: session, client: expectedClient))
-    let url = try #require(URL(string: "https://example.com/v1/client/sessions/\(session.id)/touch"))
+    var signIn = SignIn.mock
+    signIn.status = .complete
+    signIn.createdSessionId = session.id
+    let data = try JSONEncoder.clerkEncoder.encode(ClientResponse<SignIn>(response: signIn, client: expectedClient))
+    let url = try #require(URL(string: "https://example.com/v1/client/sign_ins"))
     let response = try #require(HTTPURLResponse(
       url: url,
       statusCode: 200,


### PR DESCRIPTION
## Summary

- document that organization-scoped Backend API tickets activate the Organization for the resulting session
- verify `signInWithTicket(_:)` uses the ticket strategy
- cover synchronization of `Session.lastActiveOrganizationId` from a completed sign-in response

## Context

When the Backend API creates a sign-in token with `org_id`, consuming that token activates the Organization for the new session. Clerk iOS already synchronizes the Client envelope returned by the Frontend API; this change documents that behavior and adds focused regression coverage.

Related work:

- [clerk/clerk_go#20464](https://github.com/clerk/clerk_go/pull/20464)
- [clerk/clerk-android#815](https://github.com/clerk/clerk-android/pull/815)
- [clerk/clerk#2977](https://github.com/clerk/clerk/pull/2977)
- [clerk/javascript#9192](https://github.com/clerk/javascript/pull/9192)

## Testing

- `make format-check`
- `swift test --filter AuthTests`
- `swift test --filter ClerkClientSyncResponseMiddlewareTests`

Linear: MOBILE-591

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document organization-scoped ticket sessions in `Auth.signInWithTicket`
> - Expands the doc comment on `Auth.signInWithTicket` to clarify that organization-scoped tickets activate that organization, accessible via `Clerk/session` and `Session/lastActiveOrganizationId`.
> - Updates the middleware test to validate client sync behavior using a completed `SignIn` response (via `/v1/client/sign_ins`) instead of a session touch response.
> - Adds an assertion in `AuthTests` to verify the sign-in strategy is set to `.ticket` when `signInWithTicket` is called.
>
> #### 🖇️ Linked Issues
> Partially addresses [MOBILE-591](https://linear.app/clerk/issue/MOBILE-591), which tracks adding `org_id` support to the sign-in token API for hybrid iOS/Android flows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57249de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->