### PR TITLE
Sean/fix startup signup race

### DIFF
--- a/Sources/ClerkKit/Core/Clerk+DeviceToken.swift
+++ b/Sources/ClerkKit/Core/Clerk+DeviceToken.swift
@@ -5,6 +5,14 @@
 
 import Foundation
 
+extension ClerkIdentityController {
+  enum DeviceTokenTransitionResult: Equatable {
+    case applied
+    case unchanged
+    case rejected
+  }
+}
+
 extension Clerk {
   @_spi(FrameworkIntegration) public enum DeviceTokenError: Error, LocalizedError {
     case emptyToken
@@ -41,8 +49,7 @@ extension Clerk {
   @discardableResult
   public func updateDeviceToken(_ token: String) async throws -> Client? {
     try runtimeScope.validateStableRuntime()
-    let normalizedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !normalizedToken.isEmpty else {
+    guard let normalizedToken = Optional(token).nilIfEmpty else {
       throw DeviceTokenError.emptyToken
     }
 

--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -140,6 +140,11 @@ public final class Clerk {
     identityController.lastServerDate
   }
 
+  /// The client that has crossed an authoritative persistence or response boundary.
+  var authoritativeClient: Client? {
+    identityController.authoritativeClient
+  }
+
   /// Changes when local device-token ownership changes.
   /// Client responses prepared before this value changes must not update state.
   var clientResponseGeneration: ClientResponseGeneration {
@@ -311,12 +316,15 @@ extension Clerk {
     )
     try dependencies.discardPendingPublicationWhenSharedSyncDisabled()
 
-    performConfiguration(dependencies: dependencies)
+    try performConfiguration(dependencies: dependencies)
   }
 
   /// Internal helper method that installs a prebuilt dependency container and starts managers.
   @MainActor
-  func performConfiguration(dependencies: any Dependencies) {
+  func performConfiguration(dependencies: any Dependencies) throws {
+    try SharedSessionOwnerSlotClearRecovery.recoverIfNeeded(
+      in: dependencies.sharedSessionOwnerSlotClearRecovery
+    )
     cancelStartupClientRefresh()
     identityController.prepareForConfiguration()
     taskCoordinator?.cancelAll()
@@ -566,6 +574,7 @@ extension Clerk {
       )
       let plan = existing.reconfigurationPlan(with: newDependencies)
       let rollbackState = existing.captureReconfigurationRollbackState()
+      var topologyMigrationRollback: SharedSessionTopologyMigration.Rollback?
 
       existing.setConfigurationEpoch(to: nextEpoch)
       await existing.cleanupManagersAndDrainCache(
@@ -577,9 +586,9 @@ extension Clerk {
         case .preserveIdentityAndSlot:
           try newDependencies.performDeferredSharedSessionAdoptionIfNeeded()
         case .preserveIdentityAndMigrateSlot:
-          try preserveAcceptedIdentityAcrossTopologyChange(
-            from: rollbackState.dependencies.atomicIdentityStore,
-            to: newDependencies.atomicIdentityStore
+          topologyMigrationRollback = try prepareAcceptedIdentityForTopologyChange(
+            from: rollbackState.dependencies,
+            to: newDependencies
           )
           try rollbackState.dependencies.atomicIdentityStore?
             .clearPendingPublication()
@@ -598,13 +607,26 @@ extension Clerk {
             in: rollbackState.dependencies
           )
         }
+        if topologyMigrationRollback?.publishedDestinationSlot == true {
+          notifySharedSessionTopologyChange(in: newDependencies)
+        }
       } catch {
-        existing.restoreAfterFailedReconfiguration(rollbackState)
+        if let topologyMigrationRollback {
+          do {
+            try topologyMigrationRollback.restore()
+          } catch let rollbackError {
+            ClerkLogger.logError(
+              rollbackError,
+              message: "Failed to roll back shared-session topology migration"
+            )
+          }
+        }
+        try existing.restoreAfterFailedReconfiguration(rollbackState)
         throw error
       }
 
       await existing.resetRuntimeStateForReconfiguration()
-      existing.performConfiguration(dependencies: newDependencies)
+      try existing.performConfiguration(dependencies: newDependencies)
       return existing
     }
 
@@ -619,7 +641,7 @@ extension Clerk {
     try await clearLocalClerkStorageStrictly(in: newDependencies)
     try newDependencies.markSharedSessionAdoptedWithoutMigratingCredentialsIfNeeded()
     try newDependencies.discardPendingPublicationWhenSharedSyncDisabled()
-    clerk.performConfiguration(dependencies: newDependencies)
+    try clerk.performConfiguration(dependencies: newDependencies)
     _shared = clerk
     return clerk
   }
@@ -761,6 +783,10 @@ extension Clerk: CacheCoordinator {
 
   func setClientIfNeeded(_ client: Client?, serverFetchDate: Date?) {
     identityController.hydrateLegacyClientIfNeeded(client, serverDate: serverFetchDate)
+  }
+
+  func setProvisionalClientIfNeeded(_ client: Client?) {
+    identityController.hydrateProvisionalLegacyClientIfNeeded(client)
   }
 
   func setServerFetchDateIfNeeded(_ date: Date) {
@@ -914,23 +940,53 @@ extension Clerk {
     )
   }
 
-  private func restoreAfterFailedReconfiguration(_ state: ReconfigurationRollbackState) {
+  private func restoreAfterFailedReconfiguration(
+    _ state: ReconfigurationRollbackState
+  ) throws {
     setConfigurationEpoch(to: state.configurationEpoch)
     identityController.restoreRollbackState(state.identity)
-    performConfiguration(dependencies: state.dependencies)
+    try performConfiguration(dependencies: state.dependencies)
   }
 
-  private static func preserveAcceptedIdentityAcrossTopologyChange(
-    from source: (any SharedSessionLocalIdentityStoring)?,
-    to destination: (any SharedSessionLocalIdentityStoring)?
-  ) throws {
-    guard let identity = try source?.load(), let destination else { return }
-    try destination.updateRecord { _ in
-      SharedSessionLocalIdentityRecord(
-        acceptedIdentity: identity,
-        pendingPublication: nil
-      )
+  private static func prepareAcceptedIdentityForTopologyChange(
+    from source: any Dependencies,
+    to destination: any Dependencies
+  ) throws -> SharedSessionTopologyMigration.Rollback? {
+    guard let identity = try source.atomicIdentityStore?.load(),
+          let destinationIdentityStore = destination.atomicIdentityStore
+    else {
+      return nil
     }
+
+    let sourceTopology = SharedSessionSlotTopology(dependencies: source)
+    let destinationTopology = SharedSessionSlotTopology(dependencies: destination)
+    let sourceOwnerToExclude: String? = if let sourceTopology,
+                                           let destinationTopology,
+                                           sourceTopology.hasSameStore(as: destinationTopology)
+    {
+      sourceTopology.ownerIdentifier
+    } else {
+      nil
+    }
+
+    return try SharedSessionTopologyMigration.prepare(
+      identity: identity,
+      destinationIdentityStore: destinationIdentityStore,
+      destinationSlotStore: destinationTopology?.makeOwnerSlotStore(),
+      destinationInstanceFingerprint: destinationTopology?.instanceFingerprint,
+      destinationOwnerIdentifier: destinationTopology?.ownerIdentifier,
+      excludingSourceOwnerIdentifier: sourceOwnerToExclude
+    )
+  }
+
+  private static func notifySharedSessionTopologyChange(
+    in dependencies: any Dependencies
+  ) {
+    guard let topology = SharedSessionSlotTopology(dependencies: dependencies) else { return }
+    SharedSessionSyncDarwinNotifier(
+      keychainConfig: topology.keychainConfig,
+      instanceFingerprint: topology.instanceFingerprint
+    ).post()
   }
 
   private func reconfigurationPlan(
@@ -1027,28 +1083,15 @@ extension Clerk {
   func canReuseSharedSessionOwnerSlot(
     with newDependencies: any Dependencies
   ) -> Bool {
-    let currentOptions = dependencies.configurationManager.options
-    let newOptions = newDependencies.configurationManager.options
-    guard dependencies.configurationManager.publishableKey
-      == newDependencies.configurationManager.publishableKey,
-      currentOptions.sharedSessionSync != nil,
-      newOptions.sharedSessionSync != nil,
-      currentOptions.keychainConfig.service == newOptions.keychainConfig.service,
-      currentOptions.keychainConfig.normalizedAccessGroup
-      == newOptions.keychainConfig.normalizedAccessGroup,
-      dependencies.sharedSessionOwnerIdentifier
-      == newDependencies.sharedSessionOwnerIdentifier
+    guard let currentTopology = SharedSessionSlotTopology(
+      dependencies: dependencies
+    ),
+      let newTopology = SharedSessionSlotTopology(dependencies: newDependencies)
     else {
       return false
     }
 
-    return SharedSessionNamespace(
-      frontendApiUrl: dependencies.configurationManager.frontendApiUrl,
-      publishableKey: dependencies.configurationManager.publishableKey
-    ) == SharedSessionNamespace(
-      frontendApiUrl: newDependencies.configurationManager.frontendApiUrl,
-      publishableKey: newDependencies.configurationManager.publishableKey
-    )
+    return currentTopology.hasSameOwnerSlot(as: newTopology)
   }
 
   private func resetManagerStateForCleanup(finishAuthEventStreams: Bool) {

--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -316,8 +316,7 @@ extension Clerk {
       runtimeScope: runtimeScope
     )
     try dependencies.discardPendingPublicationWhenSharedSyncDisabled()
-
-    try performConfiguration(dependencies: dependencies)
+    installConfiguration(dependencies: dependencies)
   }
 
   /// Internal helper method that installs a prebuilt dependency container and starts managers.

--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -33,6 +33,7 @@ public final class Clerk {
   }
 
   private static var isRuntimeReconfigurationInProgress = false
+  private static var runtimeReconfigurationWaiters: [CheckedContinuation<Void, Never>] = []
 
   private struct ReconfigurationRollbackState {
     let configurationEpoch: ClerkConfigurationEpoch
@@ -325,6 +326,12 @@ extension Clerk {
     try SharedSessionOwnerSlotClearRecovery.recoverIfNeeded(
       in: dependencies.sharedSessionOwnerSlotClearRecovery
     )
+    installConfiguration(dependencies: dependencies)
+  }
+
+  /// Installs dependencies whose pending clear recovery has already been checked.
+  @MainActor
+  private func installConfiguration(dependencies: any Dependencies) {
     cancelStartupClientRefresh()
     identityController.prepareForConfiguration()
     taskCoordinator?.cancelAll()
@@ -564,6 +571,9 @@ extension Clerk {
       // Let that transaction commit before reconfiguration invalidates the old
       // runtime's identity queue or decides whether local state can be reused.
       try await existing.keychainClearTask?.value
+      try SharedSessionOwnerSlotClearRecovery.recoverIfNeeded(
+        in: existing.dependencies.sharedSessionOwnerSlotClearRecovery
+      )
 
       let nextEpoch = existing.nextConfigurationEpoch
       let newDependencies = try DependencyContainer(
@@ -607,7 +617,7 @@ extension Clerk {
             in: rollbackState.dependencies
           )
         }
-        if topologyMigrationRollback?.publishedDestinationSlot == true {
+        if topologyMigrationRollback?.publishedDestinationSlot != nil {
           notifySharedSessionTopologyChange(in: newDependencies)
         }
       } catch {
@@ -621,12 +631,12 @@ extension Clerk {
             )
           }
         }
-        try existing.restoreAfterFailedReconfiguration(rollbackState)
+        existing.restoreAfterFailedReconfiguration(rollbackState)
         throw error
       }
 
       await existing.resetRuntimeStateForReconfiguration()
-      try existing.performConfiguration(dependencies: newDependencies)
+      existing.installConfiguration(dependencies: newDependencies)
       return existing
     }
 
@@ -641,7 +651,7 @@ extension Clerk {
     try await clearLocalClerkStorageStrictly(in: newDependencies)
     try newDependencies.markSharedSessionAdoptedWithoutMigratingCredentialsIfNeeded()
     try newDependencies.discardPendingPublicationWhenSharedSyncDisabled()
-    try clerk.performConfiguration(dependencies: newDependencies)
+    clerk.installConfiguration(dependencies: newDependencies)
     _shared = clerk
     return clerk
   }
@@ -904,6 +914,22 @@ extension Clerk {
   static func endRuntimeReconfiguration() {
     isRuntimeReconfigurationInProgress = false
     _shared?.runtimeState.endReconfiguration()
+    let waiters = runtimeReconfigurationWaiters
+    runtimeReconfigurationWaiters.removeAll()
+    waiters.forEach { $0.resume() }
+  }
+
+  @MainActor
+  static var runtimeReconfigurationIsInProgress: Bool {
+    isRuntimeReconfigurationInProgress
+  }
+
+  @MainActor
+  static func waitForRuntimeReconfigurationIfNeeded() async {
+    guard isRuntimeReconfigurationInProgress else { return }
+    await withCheckedContinuation {
+      runtimeReconfigurationWaiters.append($0)
+    }
   }
 
   @MainActor
@@ -942,10 +968,10 @@ extension Clerk {
 
   private func restoreAfterFailedReconfiguration(
     _ state: ReconfigurationRollbackState
-  ) throws {
+  ) {
     setConfigurationEpoch(to: state.configurationEpoch)
     identityController.restoreRollbackState(state.identity)
-    try performConfiguration(dependencies: state.dependencies)
+    installConfiguration(dependencies: state.dependencies)
   }
 
   private static func prepareAcceptedIdentityForTopologyChange(

--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -583,6 +583,9 @@ extension Clerk {
         deferSharedSessionAdoption: true
       )
       let plan = existing.reconfigurationPlan(with: newDependencies)
+      if plan == .preserveIdentityAndMigrateSlot {
+        try await existing.settlePendingPublicationForTopologyChange()
+      }
       let rollbackState = existing.captureReconfigurationRollbackState()
       var topologyMigrationRollback: SharedSessionTopologyMigration.Rollback?
 
@@ -600,8 +603,6 @@ extension Clerk {
             from: rollbackState.dependencies,
             to: newDependencies
           )
-          try rollbackState.dependencies.atomicIdentityStore?
-            .clearPendingPublication()
           try newDependencies.performDeferredSharedSessionAdoptionIfNeeded()
         case .replaceIdentity:
           try await clearLocalClerkStorageStrictly(in: newDependencies)
@@ -974,11 +975,26 @@ extension Clerk {
     installConfiguration(dependencies: state.dependencies)
   }
 
+  private func settlePendingPublicationForTopologyChange() async throws {
+    try await sharedSessionSyncCoordinator?
+      .settlePendingPublicationForTopologyChange()
+
+    guard try dependencies.atomicIdentityStore?
+      .loadPendingPublication() == nil
+    else {
+      throw SharedSessionSyncCoordinatorError.pendingPublicationDidNotSettle
+    }
+  }
+
   private static func prepareAcceptedIdentityForTopologyChange(
     from source: any Dependencies,
     to destination: any Dependencies
   ) throws -> SharedSessionTopologyMigration.Rollback? {
-    guard let identity = try source.atomicIdentityStore?.load(),
+    let sourceRecord = try source.atomicIdentityStore?.loadRecord()
+    guard sourceRecord?.pendingPublication == nil else {
+      throw SharedSessionSyncCoordinatorError.pendingPublicationDidNotSettle
+    }
+    guard let identity = sourceRecord?.acceptedIdentity,
           let destinationIdentityStore = destination.atomicIdentityStore
     else {
       return nil

--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -153,6 +153,9 @@ public final class Clerk {
   private var startupClientRefreshTask: Task<Void, Never>?
   private var startupClientRefreshID: UUID?
 
+  @ObservationIgnored
+  lazy var startupClientRefreshTakeover = StartupClientRefreshTakeover(clerk: self)
+
   /// Changes every time this instance is reconfigured.
   /// SDK-owned requests capture this value so stale responses cannot mutate new state.
   private(set) var configurationEpoch: ClerkConfigurationEpoch = .initial
@@ -314,6 +317,7 @@ extension Clerk {
   /// Internal helper method that installs a prebuilt dependency container and starts managers.
   @MainActor
   func performConfiguration(dependencies: any Dependencies) {
+    cancelStartupClientRefresh()
     identityController.prepareForConfiguration()
     taskCoordinator?.cancelAll()
     watchConnectivityCoordinator?.stopAcceptingIdentityUpdates()
@@ -386,9 +390,22 @@ extension Clerk {
       }
     }
 
+    startStartupClientRefreshIfNeeded(after: initialSharedSessionReconciliation)
+  }
+
+  func startStartupClientRefreshIfNeeded(
+    after initialSharedSessionReconciliation: Task<Bool, Never>? = nil
+  ) {
+    guard startupClientRefreshTask == nil,
+          let taskCoordinator
+    else {
+      return
+    }
+
+    let retryPolicy = Self.startupRefreshRetryPolicy
     let startupClientRefreshID = UUID()
     self.startupClientRefreshID = startupClientRefreshID
-    startupClientRefreshTask = taskCoordinator?.task { @MainActor [weak self] in
+    startupClientRefreshTask = taskCoordinator.task { @MainActor [weak self] in
       guard let self else { return }
       defer {
         if self.startupClientRefreshID == startupClientRefreshID {
@@ -830,12 +847,22 @@ extension Clerk {
   }
 
   @discardableResult
-  func cancelStartupClientRefresh() -> Bool {
+  func cancelStartupClientRefreshTask() -> Bool {
     guard let startupClientRefreshTask else { return false }
     self.startupClientRefreshTask = nil
     startupClientRefreshID = nil
     startupClientRefreshTask.cancel()
     return true
+  }
+
+  var isStartupClientRefreshInProgress: Bool {
+    startupClientRefreshTask != nil
+  }
+
+  @discardableResult
+  func cancelStartupClientRefresh() -> Bool {
+    startupClientRefreshTakeover.cancel()
+    return cancelStartupClientRefreshTask()
   }
 
   @MainActor

--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -139,6 +139,10 @@ public final class Clerk {
   /// Shared refresh task used to coalesce invalid-auth recovery refreshes.
   private var invalidAuthRefreshTask: Task<Void, Never>?
 
+  /// Configure-time client refresh, canceled when tokenless client creation starts.
+  private var startupClientRefreshTask: Task<Void, Never>?
+  private var startupClientRefreshID: UUID?
+
   /// Changes every time this instance is reconfigured.
   /// SDK-owned requests capture this value so stale responses cannot mutate new state.
   private(set) var configurationEpoch: ClerkConfigurationEpoch = .initial
@@ -360,27 +364,43 @@ extension Clerk {
     taskCoordinator?.task { @MainActor [weak self] in
       do {
         guard let self else { return }
-        async let environment = retryingOperation(
+        _ = try await retryingOperation(
           policy: retryPolicy,
           operationName: "environment refresh"
         ) {
           try await self.refreshEnvironment()
         }
-
-        _ = await initialSharedSessionReconciliation?.value
-        let client = try await retryingOperation(
-          policy: retryPolicy,
-          operationName: "client refresh"
-        ) {
-          try await self.refreshClient()
-        }
-
-        _ = try await environment
-        _ = client
       } catch is CancellationError {
         return
       } catch {
-        ClerkLogger.logError(error, message: "Failed to load client or environment")
+        ClerkLogger.logError(error, message: "Failed to load environment")
+      }
+    }
+
+    let startupClientRefreshID = UUID()
+    self.startupClientRefreshID = startupClientRefreshID
+    startupClientRefreshTask = taskCoordinator?.task { @MainActor [weak self] in
+      guard let self else { return }
+      defer {
+        if self.startupClientRefreshID == startupClientRefreshID {
+          self.startupClientRefreshTask = nil
+          self.startupClientRefreshID = nil
+        }
+      }
+      do {
+        _ = await initialSharedSessionReconciliation?.value
+        try Task.checkCancellation()
+        _ = try await retryingOperation(
+          policy: retryPolicy,
+          operationName: "client refresh"
+        ) {
+          try Task.checkCancellation()
+          try await self.refreshClient(skipClientId: false)
+        }
+      } catch is CancellationError {
+        return
+      } catch {
+        ClerkLogger.logError(error, message: "Failed to load client")
       }
     }
   }
@@ -610,9 +630,11 @@ extension Clerk {
   ///   native client cannot conflict with the newly stored token.
   @discardableResult
   func refreshClient(skipClientId: Bool) async throws -> Client? {
+    try Task.checkCancellation()
     let runtime = runtimeScope
     let clientResponseGeneration = clientResponseGeneration
     let response = try await dependencies.clientService.getResponse(skipClientId: skipClientId)
+    try Task.checkCancellation()
     try runtime.validateStableRuntime()
     switch response.update {
     case .client(let responseClient):
@@ -797,6 +819,15 @@ extension Clerk {
     taskCoordinator?.task(priority: priority, operation: operation)
   }
 
+  @discardableResult
+  func cancelStartupClientRefresh() -> Bool {
+    guard let startupClientRefreshTask else { return false }
+    self.startupClientRefreshTask = nil
+    startupClientRefreshID = nil
+    startupClientRefreshTask.cancel()
+    return true
+  }
+
   @MainActor
   static func beginRuntimeReconfiguration() throws {
     guard !isRuntimeReconfigurationInProgress else {
@@ -898,6 +929,7 @@ extension Clerk {
   package func cleanupManagers() {
     watchConnectivityCoordinator?.stopAcceptingIdentityUpdates()
     identityController.invalidateLocalOperations()
+    cancelStartupClientRefresh()
     invalidAuthRefreshTask?.cancel()
     invalidAuthRefreshTask = nil
     urlHandlingCoordinator.cancelAll()
@@ -918,6 +950,7 @@ extension Clerk {
     await identityController.invalidateAndDrainLocalOperations(
       through: dependencies.atomicIdentityIO
     )
+    cancelStartupClientRefresh()
     invalidAuthRefreshTask?.cancel()
     await invalidAuthRefreshTask?.value
     invalidAuthRefreshTask = nil

--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -40,6 +40,16 @@ public final class Clerk {
     let identity: ClerkIdentityController.RollbackState
   }
 
+  private enum ReconfigurationPlan: Equatable {
+    case preserveIdentityAndSlot
+    case preserveIdentityAndMigrateSlot
+    case replaceIdentity
+
+    var reusesOwnerSlot: Bool {
+      self == .preserveIdentityAndSlot
+    }
+  }
+
   /// A getter to see if the Clerk object is ready for use or not.
   /// Returns true when both environment and client are loaded.
   public var isLoaded: Bool {
@@ -216,7 +226,6 @@ public final class Clerk {
   /// Coalesces overlapping public Keychain clears so persistence remains frozen
   /// until the single clear transaction has completed.
   var keychainClearTask: Task<Void, Error>?
-  var keychainClearTaskID: UUID?
 
   /// Dispatches Clerk state changes to optional internal observers.
   var internalStateChanges = ClerkInternalStateChangeEmitter()
@@ -297,7 +306,7 @@ extension Clerk {
       options: options,
       runtimeScope: runtimeScope
     )
-    try dependencies.prepareForInstallationAfterIdentityProducersDrain()
+    try dependencies.discardPendingPublicationWhenSharedSyncDisabled()
 
     performConfiguration(dependencies: dependencies)
   }
@@ -538,12 +547,7 @@ extension Clerk {
         runtimeScope: .init(epoch: nextEpoch, runtimeState: existing.runtimeState),
         deferSharedSessionAdoption: true
       )
-      let preservesAdoptedLocalState = existing.publishableKey
-        == newDependencies.configurationManager.publishableKey
-        && (existing.options.sharedSessionSync != nil || options.sharedSessionSync != nil)
-      let preservesSharedSessionOwnerSlot = existing.canReuseSharedSessionOwnerSlot(
-        with: newDependencies
-      )
+      let plan = existing.reconfigurationPlan(with: newDependencies)
       let rollbackState = existing.captureReconfigurationRollbackState()
 
       existing.setConfigurationEpoch(to: nextEpoch)
@@ -552,17 +556,18 @@ extension Clerk {
       )
 
       do {
-        if preservesAdoptedLocalState, !preservesSharedSessionOwnerSlot {
+        switch plan {
+        case .preserveIdentityAndSlot:
+          try newDependencies.performDeferredSharedSessionAdoptionIfNeeded()
+        case .preserveIdentityAndMigrateSlot:
           try preserveAcceptedIdentityAcrossTopologyChange(
             from: rollbackState.dependencies.atomicIdentityStore,
             to: newDependencies.atomicIdentityStore
           )
           try rollbackState.dependencies.atomicIdentityStore?
             .clearPendingPublication()
-        }
-        if preservesAdoptedLocalState {
           try newDependencies.performDeferredSharedSessionAdoptionIfNeeded()
-        } else {
+        case .replaceIdentity:
           try await clearLocalClerkStorageStrictly(in: newDependencies)
           try await clearLocalClerkStorageStrictly(
             in: rollbackState.dependencies,
@@ -570,8 +575,8 @@ extension Clerk {
           )
           try newDependencies.markSharedSessionAdoptedWithoutMigratingCredentialsIfNeeded()
         }
-        try newDependencies.prepareForInstallationAfterIdentityProducersDrain()
-        if !preservesSharedSessionOwnerSlot {
+        try newDependencies.discardPendingPublicationWhenSharedSyncDisabled()
+        if !plan.reusesOwnerSlot {
           try await SharedSessionOwnerSlotCleanup.deleteIfConfigured(
             in: rollbackState.dependencies
           )
@@ -596,7 +601,7 @@ extension Clerk {
 
     try await clearLocalClerkStorageStrictly(in: newDependencies)
     try newDependencies.markSharedSessionAdoptedWithoutMigratingCredentialsIfNeeded()
-    try newDependencies.prepareForInstallationAfterIdentityProducersDrain()
+    try newDependencies.discardPendingPublicationWhenSharedSyncDisabled()
     clerk.performConfiguration(dependencies: newDependencies)
     _shared = clerk
     return clerk
@@ -803,6 +808,11 @@ extension Clerk: LifecycleEventHandling {
 }
 
 extension Clerk {
+  /// Applies a client value after the identity controller has established its mutation boundary.
+  func setClientFromIdentityController(_ client: Client?) {
+    self.client = client
+  }
+
   func emitInternalStateChange(_ change: ClerkInternalStateChange) {
     do {
       try internalStateChanges.emit(change, from: self)
@@ -894,6 +904,21 @@ extension Clerk {
         pendingPublication: nil
       )
     }
+  }
+
+  private func reconfigurationPlan(
+    with newDependencies: any Dependencies
+  ) -> ReconfigurationPlan {
+    let preservesIdentity = publishableKey
+      == newDependencies.configurationManager.publishableKey
+      && (options.sharedSessionSync != nil
+        || newDependencies.configurationManager.options.sharedSessionSync != nil)
+    guard preservesIdentity else {
+      return .replaceIdentity
+    }
+    return canReuseSharedSessionOwnerSlot(with: newDependencies)
+      ? .preserveIdentityAndSlot
+      : .preserveIdentityAndMigrateSlot
   }
 
   func isCurrentConfigurationEpoch(_ epoch: ClerkConfigurationEpoch) -> Bool {

--- a/Sources/ClerkKit/Dependencies/Dependencies.swift
+++ b/Sources/ClerkKit/Dependencies/Dependencies.swift
@@ -37,6 +37,9 @@ protocol Dependencies: AnyObject {
   /// Stable owner used for this app's discoverable shared-session slot.
   var sharedSessionOwnerIdentifier: String? { get }
 
+  /// Bundle-local journal and exact Keychain targets used to finish interrupted identity clears.
+  var sharedSessionOwnerSlotClearRecovery: SharedSessionOwnerSlotClearRecovery.Context? { get }
+
   /// Whether this configuration just adopted legacy shared-session state and may
   /// use the legacy Client as provisional launch UI.
   var shouldHydrateProvisionalLegacyClient: Bool { get }

--- a/Sources/ClerkKit/Dependencies/DependencyContainer.swift
+++ b/Sources/ClerkKit/Dependencies/DependencyContainer.swift
@@ -266,8 +266,9 @@ final class DependencyContainer: Dependencies {
     ).migrateIfNeeded()
   }
 
+  /// Removes an interrupted shared-session publication before installing a non-shared runtime.
   @MainActor
-  func prepareForInstallationAfterIdentityProducersDrain() throws {
+  func discardPendingPublicationWhenSharedSyncDisabled() throws {
     guard configurationManager.options.sharedSessionSync == nil else { return }
     try atomicIdentityStore?.clearPendingPublication()
   }

--- a/Sources/ClerkKit/Dependencies/DependencyContainer.swift
+++ b/Sources/ClerkKit/Dependencies/DependencyContainer.swift
@@ -29,6 +29,7 @@ final class DependencyContainer: Dependencies {
   let atomicIdentityStore: (any SharedSessionLocalIdentityStoring)?
   let atomicIdentityIO: SharedSessionLocalIdentityIO?
   let sharedSessionOwnerIdentifier: String?
+  let sharedSessionOwnerSlotClearRecovery: SharedSessionOwnerSlotClearRecovery.Context?
   let shouldHydrateProvisionalLegacyClient: Bool
   private let persistentAdoptionEnabled: Bool
   let configurationManager: ConfigurationManager
@@ -106,6 +107,15 @@ final class DependencyContainer: Dependencies {
       .trimmingCharacters(in: .whitespacesAndNewlines)
     persistentAdoptionEnabled = persistentAdoptionEnabledOverride
       ?? (!publishableKey.isEmpty && !EnvironmentDetection.isRunningInTests)
+    sharedSessionOwnerSlotClearRecovery = Self.makeOwnerSlotClearRecovery(
+      configuration: configurationManager,
+      ownerIdentifier: sharedSessionOwnerIdentifier
+    )
+    if !publishableKey.isEmpty {
+      try SharedSessionOwnerSlotClearRecovery.recoverIfNeeded(
+        in: sharedSessionOwnerSlotClearRecovery
+      )
+    }
     let keychainStorages = try Self.makeKeychainStorages(
       options: options,
       frontendApiUrl: configurationManager.frontendApiUrl,
@@ -373,6 +383,49 @@ final class DependencyContainer: Dependencies {
         instanceType: instanceType,
         telemetryEnabled: options.telemetryEnabled
       )
+    )
+  }
+}
+
+extension DependencyContainer {
+  @MainActor
+  private static func makeOwnerSlotClearRecovery(
+    configuration: ConfigurationManager,
+    ownerIdentifier: String?
+  ) -> SharedSessionOwnerSlotClearRecovery.Context? {
+    let namespace = SharedSessionNamespace(
+      frontendApiUrl: configuration.frontendApiUrl,
+      publishableKey: configuration.publishableKey
+    )
+    let intent: SharedSessionOwnerSlotClearRecovery.Intent? = if configuration.options.sharedSessionSync != nil,
+                                                                 let ownerIdentifier,
+                                                                 !ownerIdentifier.isEmpty,
+                                                                 let accessGroup = configuration.options.keychainConfig.normalizedAccessGroup
+    {
+      SharedSessionOwnerSlotClearRecovery.Intent(
+        localIdentityService: stableIdentityService(
+          configuredService: configuration.options.keychainConfig.service,
+          instanceFingerprint: namespace.fingerprint,
+          ownerIdentifier: ownerIdentifier
+        ),
+        slotService: SharedSessionOwnerSlotStore.service(
+          configuredService: configuration.options.keychainConfig.service,
+          instanceFingerprint: namespace.fingerprint
+        ),
+        slotAccessGroup: accessGroup,
+        slotAccount: SharedSessionOwnerSlotStore.account(
+          instanceFingerprint: namespace.fingerprint,
+          ownerIdentifier: ownerIdentifier
+        ),
+        instanceFingerprint: namespace.fingerprint,
+        ownerIdentifier: ownerIdentifier
+      )
+    } else {
+      nil
+    }
+    return SharedSessionOwnerSlotClearRecovery.liveContext(
+      ownerIdentifier: ownerIdentifier,
+      currentIntent: intent
     )
   }
 }

--- a/Sources/ClerkKit/Dependencies/DependencyContainer.swift
+++ b/Sources/ClerkKit/Dependencies/DependencyContainer.swift
@@ -107,11 +107,15 @@ final class DependencyContainer: Dependencies {
       .trimmingCharacters(in: .whitespacesAndNewlines)
     persistentAdoptionEnabled = persistentAdoptionEnabledOverride
       ?? (!publishableKey.isEmpty && !EnvironmentDetection.isRunningInTests)
-    sharedSessionOwnerSlotClearRecovery = Self.makeOwnerSlotClearRecovery(
-      configuration: configurationManager,
-      ownerIdentifier: sharedSessionOwnerIdentifier
-    )
-    if !publishableKey.isEmpty {
+    sharedSessionOwnerSlotClearRecovery = if persistentAdoptionEnabled {
+      Self.makeOwnerSlotClearRecovery(
+        configuration: configurationManager,
+        ownerIdentifier: sharedSessionOwnerIdentifier
+      )
+    } else {
+      nil
+    }
+    if persistentAdoptionEnabled, !publishableKey.isEmpty {
       try SharedSessionOwnerSlotClearRecovery.recoverIfNeeded(
         in: sharedSessionOwnerSlotClearRecovery
       )
@@ -389,7 +393,7 @@ final class DependencyContainer: Dependencies {
 
 extension DependencyContainer {
   @MainActor
-  private static func makeOwnerSlotClearRecovery(
+  static func makeOwnerSlotClearRecovery(
     configuration: ConfigurationManager,
     ownerIdentifier: String?
   ) -> SharedSessionOwnerSlotClearRecovery.Context? {

--- a/Sources/ClerkKit/Domains/Auth/MagicLinkService.swift
+++ b/Sources/ClerkKit/Domains/Auth/MagicLinkService.swift
@@ -21,7 +21,7 @@ final class MagicLinkService: MagicLinkServiceProtocol {
     let request = Request<ClientResponse<MagicLinkCompleteResult>>(
       path: "/v1/client/magic_links/complete",
       method: .post,
-      createsClientWhenTokenless: true,
+      canEstablishClientWhenTokenless: true,
       body: params
     )
 

--- a/Sources/ClerkKit/Domains/Auth/MagicLinkService.swift
+++ b/Sources/ClerkKit/Domains/Auth/MagicLinkService.swift
@@ -21,6 +21,7 @@ final class MagicLinkService: MagicLinkServiceProtocol {
     let request = Request<ClientResponse<MagicLinkCompleteResult>>(
       path: "/v1/client/magic_links/complete",
       method: .post,
+      createsClientWhenTokenless: true,
       body: params
     )
 

--- a/Sources/ClerkKit/Domains/Auth/SignIn/SignInService.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignIn/SignInService.swift
@@ -39,7 +39,7 @@ final class SignInService: SignInServiceProtocol {
     let request = Request<ClientResponse<SignIn>>(
       path: "/v1/client/sign_ins",
       method: .post,
-      createsClientWhenTokenless: true,
+      canEstablishClientWhenTokenless: true,
       body: params
     )
 

--- a/Sources/ClerkKit/Domains/Auth/SignIn/SignInService.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignIn/SignInService.swift
@@ -39,6 +39,7 @@ final class SignInService: SignInServiceProtocol {
     let request = Request<ClientResponse<SignIn>>(
       path: "/v1/client/sign_ins",
       method: .post,
+      createsClientWhenTokenless: true,
       body: params
     )
 

--- a/Sources/ClerkKit/Domains/Auth/SignUp/SignUpService.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignUp/SignUpService.swift
@@ -35,7 +35,7 @@ final class SignUpService: SignUpServiceProtocol {
     let request = Request<ClientResponse<SignUp>>(
       path: "/v1/client/sign_ups",
       method: .post,
-      createsClientWhenTokenless: true,
+      canEstablishClientWhenTokenless: true,
       body: params
     )
 

--- a/Sources/ClerkKit/Domains/Auth/SignUp/SignUpService.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignUp/SignUpService.swift
@@ -35,6 +35,7 @@ final class SignUpService: SignUpServiceProtocol {
     let request = Request<ClientResponse<SignUp>>(
       path: "/v1/client/sign_ups",
       method: .post,
+      createsClientWhenTokenless: true,
       body: params
     )
 

--- a/Sources/ClerkKit/Identity/ClerkIdentityController.swift
+++ b/Sources/ClerkKit/Identity/ClerkIdentityController.swift
@@ -426,7 +426,8 @@ extension ClerkIdentityController {
 
   func applySharedEvent(
     _ event: SharedSessionIdentityEvent,
-    previousDeviceToken: String?
+    previousDeviceToken: String?,
+    clientPresentationPolicy: SharedSessionClientPresentationPolicy = .replaceWithIdentity
   ) {
     guard let clerk else { return }
     localDeviceToken = event.deviceToken
@@ -443,7 +444,8 @@ extension ClerkIdentityController {
       clerk: clerk,
       fenceAllClientResponses: false,
       emitIdentityChange: true,
-      fenceTokenChange: false
+      fenceTokenChange: false,
+      clientPresentationPolicy: clientPresentationPolicy
     )
   }
 }
@@ -923,20 +925,23 @@ extension ClerkIdentityController {
     clerk: Clerk,
     fenceAllClientResponses: Bool,
     emitIdentityChange: Bool,
-    fenceTokenChange: Bool = true
+    fenceTokenChange: Bool = true,
+    clientPresentationPolicy: SharedSessionClientPresentationPolicy = .replaceWithIdentity
   ) {
     let previousToken = currentDeviceToken
     if fenceAllClientResponses || (fenceTokenChange && previousToken != identity.deviceToken) {
       fenceClientResponses()
     }
     withApplyingIdentityTransition {
-      isClientProvisional = false
       if identity.state == .cleared, identity.serverDate == nil {
         lastServerDate = identity.serverDate
       } else {
         recordAcceptedServerDate(identity.serverDate)
       }
-      clerk.setClientFromIdentityController(identity.client)
+      if clientPresentationPolicy == .replaceWithIdentity || !isClientProvisional {
+        isClientProvisional = false
+        clerk.setClientFromIdentityController(identity.client)
+      }
     }
     if emitIdentityChange {
       clerk.emitInternalStateChange(.identityDidChange)

--- a/Sources/ClerkKit/Identity/ClerkIdentityController.swift
+++ b/Sources/ClerkKit/Identity/ClerkIdentityController.swift
@@ -259,9 +259,7 @@ extension ClerkIdentityController {
       return
     }
 
-    if let serverDate {
-      lastServerDate = serverDate
-    }
+    recordAcceptedServerDate(serverDate)
     setClient(incoming, on: clerk)
     responseOrderingGate.record(sequence: responseSequence)
   }
@@ -733,9 +731,7 @@ extension ClerkIdentityController {
       }
 
       let previousDate = lastServerDate
-      if let serverDate = snapshot.serverDate {
-        lastServerDate = serverDate
-      }
+      recordAcceptedServerDate(snapshot.serverDate)
       if incomingClient != clerk.client {
         setClient(incomingClient, on: clerk)
         return true
@@ -942,8 +938,10 @@ extension ClerkIdentityController {
       fenceClientResponses()
     }
     withApplyingIdentityTransition {
-      if identity.serverDate != nil || identity.state == .cleared {
+      if identity.state == .cleared, identity.serverDate == nil {
         lastServerDate = identity.serverDate
+      } else {
+        recordAcceptedServerDate(identity.serverDate)
       }
       clerk.setClientFromIdentityController(identity.client)
     }
@@ -963,6 +961,10 @@ extension ClerkIdentityController {
     isApplyingIdentityTransition = true
     defer { isApplyingIdentityTransition = previousApplyingState }
     operation()
+  }
+
+  private func recordAcceptedServerDate(_ serverDate: Date?) {
+    responseOrderingGate.advanceServerDateWatermark(to: serverDate)
   }
 
   private func responseCanBeAccepted(

--- a/Sources/ClerkKit/Identity/ClerkIdentityController.swift
+++ b/Sources/ClerkKit/Identity/ClerkIdentityController.swift
@@ -447,7 +447,7 @@ extension ClerkIdentityController {
     guard let clerk else { return }
     localDeviceToken = event.deviceToken
     if previousDeviceToken != event.deviceToken {
-      fenceResponsesAfterDeviceTokenChange()
+      fenceClientResponses()
     }
     applyIdentityToMemory(
       ClerkIdentitySnapshot(
@@ -535,14 +535,14 @@ extension ClerkIdentityController {
     return true
   }
 
-  func fenceResponsesAfterDeviceTokenChange() {
+  func fenceClientResponses() {
     clientResponseGeneration = clientResponseGeneration.next()
     lastAppliedResponseSequence = nil
   }
 
   func clearCachedClientStateAfterDeviceTokenChange() {
     guard let clerk else { return }
-    fenceResponsesAfterDeviceTokenChange()
+    fenceClientResponses()
     lastServerDate = nil
     setClient(nil, on: clerk)
 
@@ -575,7 +575,7 @@ extension ClerkIdentityController {
   func clearAtomicIdentityFromMemory() {
     guard let clerk else { return }
     localDeviceToken = nil
-    fenceResponsesAfterDeviceTokenChange()
+    fenceClientResponses()
     applyIdentityToMemory(
       ClerkIdentitySnapshot(
         state: .cleared,
@@ -615,7 +615,7 @@ extension ClerkIdentityController {
     if context.usesAtomicLocalPersistence {
       clearAtomicIdentityFromMemory()
     } else {
-      fenceResponsesAfterDeviceTokenChange()
+      fenceClientResponses()
     }
   }
 
@@ -929,7 +929,7 @@ extension ClerkIdentityController {
   ) {
     let previousToken = currentDeviceToken
     if fenceAllClientResponses || (fenceTokenChange && previousToken != identity.deviceToken) {
-      fenceResponsesAfterDeviceTokenChange()
+      fenceClientResponses()
     }
     let previousApplyingState = isApplyingIdentityTransition
     isApplyingIdentityTransition = true

--- a/Sources/ClerkKit/Identity/ClerkIdentityController.swift
+++ b/Sources/ClerkKit/Identity/ClerkIdentityController.swift
@@ -63,7 +63,7 @@ final class ClerkIdentityController {
     case legacy
   }
 
-  private weak var clerk: Clerk?
+  weak var clerk: Clerk?
 
   var localDeviceToken: String?
   var localOperationRevision: UInt64 = 0
@@ -89,14 +89,15 @@ final class ClerkIdentityController {
 
   var currentDeviceToken: String? {
     guard let clerk else { return nil }
+    let deviceToken: String?
     switch persistenceMode(for: clerk) {
     case .shared(let coordinator):
-      return coordinator.currentDeviceToken
+      deviceToken = coordinator.currentDeviceToken
     case .atomicLocal:
-      return localDeviceToken
+      deviceToken = localDeviceToken
     case .legacy:
       do {
-        return try clerk.dependencies.identityKeychain.string(
+        deviceToken = try clerk.dependencies.identityKeychain.string(
           forKey: ClerkKeychainKey.clerkDeviceToken.rawValue
         )
       } catch {
@@ -104,6 +105,7 @@ final class ClerkIdentityController {
         return nil
       }
     }
+    return deviceToken.nilIfEmpty
   }
 
   func validateClientMutation() {
@@ -195,34 +197,6 @@ extension ClerkIdentityController {
 // MARK: - Request and Response Routing
 
 extension ClerkIdentityController {
-  func captureRequestIdentity() async throws -> ClerkIdentityRequestSnapshot {
-    guard let clerk else { throw CancellationError() }
-    switch persistenceMode(for: clerk) {
-    case .shared(let coordinator):
-      try await coordinator.waitForInitialReconciliation()
-      await waitForPendingLocalOperations()
-      return try await coordinator.captureRequestIdentity()
-    case .atomicLocal:
-      let task = enqueueLocalOperation { [weak self, weak clerk] _ in
-        guard let self, let clerk else { throw CancellationError() }
-        return ClerkIdentityRequestSnapshot(
-          baseGeneration: 0,
-          deviceToken: localDeviceToken,
-          clientID: clerk.client?.id,
-          clientResponseGeneration: clientResponseGeneration
-        )
-      }
-      return try await task.value
-    case .legacy:
-      return ClerkIdentityRequestSnapshot(
-        baseGeneration: 0,
-        deviceToken: currentDeviceToken,
-        clientID: clerk.client?.id,
-        clientResponseGeneration: clientResponseGeneration
-      )
-    }
-  }
-
   func applyNetworkResponse(_ context: ClientSyncResponseContext) async throws {
     guard let clerk else { throw CancellationError() }
     switch persistenceMode(for: clerk) {

--- a/Sources/ClerkKit/Identity/ClerkIdentityController.swift
+++ b/Sources/ClerkKit/Identity/ClerkIdentityController.swift
@@ -54,6 +54,7 @@ final class ClerkIdentityController {
   struct StorageClearContext {
     let usesAtomicLocalPersistence: Bool
     let invalidatedThroughRevision: UInt64
+    let requiresOwnerSlotWithdrawal: Bool
     fileprivate let sharedCoordinator: SharedSessionSyncCoordinator?
   }
 
@@ -78,6 +79,7 @@ final class ClerkIdentityController {
   }
 
   private(set) var isApplyingIdentityTransition = false
+  private(set) var isClientProvisional = false
 
   init(clerk: Clerk) {
     self.clerk = clerk
@@ -85,6 +87,11 @@ final class ClerkIdentityController {
 
   var usesAtomicLocalPersistence: Bool {
     clerk?.dependencies.atomicIdentityStore != nil
+  }
+
+  var authoritativeClient: Client? {
+    guard !isClientProvisional else { return nil }
+    return clerk?.client
   }
 
   var currentDeviceToken: String? {
@@ -462,6 +469,14 @@ extension ClerkIdentityController {
     setClient(client, on: clerk)
   }
 
+  func hydrateProvisionalLegacyClientIfNeeded(_ client: Client?) {
+    guard let clerk, clerk.client == nil, let client else { return }
+    isClientProvisional = true
+    withApplyingIdentityTransition {
+      clerk.setClientFromIdentityController(client)
+    }
+  }
+
   func hydrateLegacyServerDateIfNeeded(_ date: Date) {
     guard let clerk, clerk.client == nil, lastServerDate == nil else { return }
     lastServerDate = date
@@ -577,6 +592,7 @@ extension ClerkIdentityController {
       return StorageClearContext(
         usesAtomicLocalPersistence: false,
         invalidatedThroughRevision: localOperationRevision,
+        requiresOwnerSlotWithdrawal: false,
         sharedCoordinator: nil
       )
     }
@@ -588,6 +604,7 @@ extension ClerkIdentityController {
     return StorageClearContext(
       usesAtomicLocalPersistence: usesAtomicLocalPersistence,
       invalidatedThroughRevision: invalidatedThroughRevision,
+      requiresOwnerSlotWithdrawal: sharedCoordinator != nil,
       sharedCoordinator: sharedCoordinator
     )
   }
@@ -610,9 +627,9 @@ extension ClerkIdentityController {
 
   func finishStorageClear(
     _ context: StorageClearContext,
-    sharedTransportWithdrawn: Bool
+    canReleaseSharedClearBarrier: Bool
   ) {
-    if sharedTransportWithdrawn {
+    if canReleaseSharedClearBarrier {
       context.sharedCoordinator?.endLocalClear()
     }
   }
@@ -621,6 +638,7 @@ extension ClerkIdentityController {
     guard let clerk else { return }
     localDeviceToken = nil
     lastServerDate = nil
+    isClientProvisional = false
     withApplyingIdentityTransition {
       clerk.setClientFromIdentityController(nil)
     }
@@ -822,7 +840,7 @@ extension ClerkIdentityController {
       }
       guard let identity = try context.resolvedIdentityPayload(
         currentDeviceToken: currentDeviceToken,
-        currentClient: clerk.client,
+        currentClient: clerk.authoritativeClient,
         currentServerDate: lastServerDate
       ) else {
         return false
@@ -856,7 +874,7 @@ extension ClerkIdentityController {
   ) throws {
     guard let identity = try context.resolvedIdentityPayload(
       currentDeviceToken: currentDeviceToken,
-      currentClient: clerk.client,
+      currentClient: clerk.authoritativeClient,
       currentServerDate: lastServerDate
     ) else {
       return
@@ -912,6 +930,7 @@ extension ClerkIdentityController {
       fenceClientResponses()
     }
     withApplyingIdentityTransition {
+      isClientProvisional = false
       if identity.state == .cleared, identity.serverDate == nil {
         lastServerDate = identity.serverDate
       } else {
@@ -925,6 +944,7 @@ extension ClerkIdentityController {
   }
 
   private func setClient(_ client: Client?, on clerk: Clerk) {
+    isClientProvisional = false
     withApplyingIdentityTransition {
       clerk.setClientFromIdentityController(client)
     }
@@ -961,7 +981,7 @@ extension ClerkIdentityController {
       sequence: responseSequence,
       serverDate: serverDate,
       incomingUpdatedAt: incoming?.updatedAt,
-      currentUpdatedAt: clerk.client?.updatedAt
+      currentUpdatedAt: clerk.authoritativeClient?.updatedAt
     ) else {
       ClerkLogger.debug(
         "Ignoring stale client response. Current sequence: \(String(describing: responseOrderingGate.lastAcceptedSequence)), incoming sequence: \(String(describing: responseSequence))"

--- a/Sources/ClerkKit/Identity/ClerkIdentityController.swift
+++ b/Sources/ClerkKit/Identity/ClerkIdentityController.swift
@@ -13,12 +13,6 @@ import Foundation
 /// app-local atomic persistence, legacy persistence, and `Clerk` memory.
 @MainActor
 final class ClerkIdentityController {
-  enum DeviceTokenTransitionResult: Equatable {
-    case applied
-    case unchanged
-    case rejected
-  }
-
   private struct PersistedClientSnapshot {
     let state: String?
     let client: Client?
@@ -77,9 +71,13 @@ final class ClerkIdentityController {
   private var localOperationTail: Task<Void, Never>?
 
   private(set) var clientResponseGeneration: ClientResponseGeneration = .initial
-  private var lastAppliedResponseSequence: Int?
-  var lastServerDate: Date?
-  var isApplyingIdentityTransition = false
+  private var responseOrderingGate = ClientResponseOrderingGate()
+  var lastServerDate: Date? {
+    get { responseOrderingGate.lastAcceptedServerDate }
+    set { responseOrderingGate.lastAcceptedServerDate = newValue }
+  }
+
+  private(set) var isApplyingIdentityTransition = false
 
   init(clerk: Clerk) {
     self.clerk = clerk
@@ -121,6 +119,8 @@ final class ClerkIdentityController {
   }
 }
 
+// MARK: - Runtime Lifecycle and Local Operations
+
 extension ClerkIdentityController {
   func prepareForConfiguration() {
     localOperationRevision &+= 1
@@ -129,19 +129,20 @@ extension ClerkIdentityController {
 
   func captureRollbackState() -> RollbackState {
     RollbackState(
-      lastAppliedResponseSequence: lastAppliedResponseSequence,
+      lastAppliedResponseSequence: responseOrderingGate.lastAcceptedSequence,
       lastServerDate: lastServerDate
     )
   }
 
   func restoreRollbackState(_ state: RollbackState) {
-    lastAppliedResponseSequence = state.lastAppliedResponseSequence
-    lastServerDate = state.lastServerDate
+    responseOrderingGate = ClientResponseOrderingGate(
+      lastAcceptedSequence: state.lastAppliedResponseSequence,
+      lastAcceptedServerDate: state.lastServerDate
+    )
   }
 
   func resetOrderingState() {
-    lastAppliedResponseSequence = nil
-    lastServerDate = nil
+    responseOrderingGate.reset()
   }
 
   func enqueueLocalOperation<T: Sendable>(
@@ -190,6 +191,8 @@ extension ClerkIdentityController {
     localOperationTail = nil
   }
 }
+
+// MARK: - Request and Response Routing
 
 extension ClerkIdentityController {
   func captureRequestIdentity() async throws -> ClerkIdentityRequestSnapshot {
@@ -260,7 +263,7 @@ extension ClerkIdentityController {
       lastServerDate = serverDate
     }
     setClient(incoming, on: clerk)
-    recordAcceptedResponse(sequence: responseSequence)
+    responseOrderingGate.record(sequence: responseSequence)
   }
 
   func applyDecodedClientFallback(
@@ -279,6 +282,8 @@ extension ClerkIdentityController {
     )
   }
 }
+
+// MARK: - Identity Transitions
 
 extension ClerkIdentityController {
   /// Enqueues a complete external identity transition on the active persistence
@@ -464,6 +469,8 @@ extension ClerkIdentityController {
   }
 }
 
+// MARK: - Hydration and Atomic Persistence
+
 extension ClerkIdentityController {
   func hydrateAtomicIdentityIfNeeded(_ identity: ClerkIdentitySnapshot) {
     guard let clerk else { return }
@@ -537,7 +544,7 @@ extension ClerkIdentityController {
 
   func fenceClientResponses() {
     clientResponseGeneration = clientResponseGeneration.next()
-    lastAppliedResponseSequence = nil
+    responseOrderingGate.resetSequence()
   }
 
   func clearCachedClientStateAfterDeviceTokenChange() {
@@ -570,6 +577,8 @@ extension ClerkIdentityController {
     }
   }
 }
+
+// MARK: - Storage Clearing and Reloading
 
 extension ClerkIdentityController {
   func clearAtomicIdentityFromMemory() {
@@ -640,10 +649,9 @@ extension ClerkIdentityController {
     guard let clerk else { return }
     localDeviceToken = nil
     lastServerDate = nil
-    let previousApplyingState = isApplyingIdentityTransition
-    isApplyingIdentityTransition = true
-    clerk.client = nil
-    isApplyingIdentityTransition = previousApplyingState
+    withApplyingIdentityTransition {
+      clerk.setClientFromIdentityController(nil)
+    }
   }
 
   func reloadPersistedState() async -> Bool {
@@ -692,6 +700,8 @@ extension ClerkIdentityController {
     return reloadPersistedEnvironment(in: clerk) || identityChanged
   }
 }
+
+// MARK: - Persistence Implementations
 
 extension ClerkIdentityController {
   private func persistenceMode(for clerk: Clerk) -> PersistenceMode {
@@ -863,7 +873,7 @@ extension ClerkIdentityController {
         fenceAllClientResponses: false
       )
       if didApply {
-        recordAcceptedResponse(sequence: context.responseSequence)
+        responseOrderingGate.record(sequence: context.responseSequence)
       }
       return didApply
     }
@@ -900,7 +910,7 @@ extension ClerkIdentityController {
       emitIdentityChange: true,
       fenceTokenChange: false
     )
-    recordAcceptedResponse(sequence: context.responseSequence)
+    responseOrderingGate.record(sequence: context.responseSequence)
   }
 
   private func persistLegacyIdentity(
@@ -931,23 +941,28 @@ extension ClerkIdentityController {
     if fenceAllClientResponses || (fenceTokenChange && previousToken != identity.deviceToken) {
       fenceClientResponses()
     }
-    let previousApplyingState = isApplyingIdentityTransition
-    isApplyingIdentityTransition = true
-    if identity.serverDate != nil || identity.state == .cleared {
-      lastServerDate = identity.serverDate
+    withApplyingIdentityTransition {
+      if identity.serverDate != nil || identity.state == .cleared {
+        lastServerDate = identity.serverDate
+      }
+      clerk.setClientFromIdentityController(identity.client)
     }
-    clerk.client = identity.client
-    isApplyingIdentityTransition = previousApplyingState
     if emitIdentityChange {
       clerk.emitInternalStateChange(.identityDidChange)
     }
   }
 
   private func setClient(_ client: Client?, on clerk: Clerk) {
+    withApplyingIdentityTransition {
+      clerk.setClientFromIdentityController(client)
+    }
+  }
+
+  private func withApplyingIdentityTransition(_ operation: () -> Void) {
     let previousApplyingState = isApplyingIdentityTransition
     isApplyingIdentityTransition = true
-    clerk.client = client
-    isApplyingIdentityTransition = previousApplyingState
+    defer { isApplyingIdentityTransition = previousApplyingState }
+    operation()
   }
 
   private func responseCanBeAccepted(
@@ -966,34 +981,17 @@ extension ClerkIdentityController {
       return false
     }
 
-    if let responseSequence,
-       let lastAppliedResponseSequence,
-       responseSequence <= lastAppliedResponseSequence,
-       !responseIsNewerThanCurrent(incoming, serverDate: serverDate, clerk: clerk)
-    {
+    guard responseOrderingGate.accepts(
+      sequence: responseSequence,
+      serverDate: serverDate,
+      incomingUpdatedAt: incoming?.updatedAt,
+      currentUpdatedAt: clerk.client?.updatedAt
+    ) else {
       ClerkLogger.debug(
-        "Ignoring stale client response. Current sequence: \(lastAppliedResponseSequence), incoming sequence: \(responseSequence)"
+        "Ignoring stale client response. Current sequence: \(String(describing: responseOrderingGate.lastAcceptedSequence)), incoming sequence: \(String(describing: responseSequence))"
       )
       return false
     }
     return true
-  }
-
-  private func recordAcceptedResponse(sequence: Int?) {
-    guard let sequence else { return }
-    lastAppliedResponseSequence = max(lastAppliedResponseSequence ?? sequence, sequence)
-  }
-
-  private func responseIsNewerThanCurrent(
-    _ incoming: Client?,
-    serverDate: Date?,
-    clerk: Clerk
-  ) -> Bool {
-    guard let serverDate, let lastServerDate else { return false }
-    if serverDate > lastServerDate { return true }
-    guard serverDate == lastServerDate, let incoming, let currentClient = clerk.client else {
-      return false
-    }
-    return incoming.updatedAt > currentClient.updatedAt
   }
 }

--- a/Sources/ClerkKit/Identity/ClerkIdentitySnapshot.swift
+++ b/Sources/ClerkKit/Identity/ClerkIdentitySnapshot.swift
@@ -27,7 +27,7 @@ struct ClerkIdentitySnapshot: Codable, Equatable {
   let serverDate: Date?
 
   func validated() throws -> Self {
-    let hasToken = deviceToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+    let hasToken = deviceToken.nilIfEmpty != nil
     switch state {
     case .present:
       guard hasToken, client != nil else {

--- a/Sources/ClerkKit/Identity/ClientResponseOrderingGate.swift
+++ b/Sources/ClerkKit/Identity/ClientResponseOrderingGate.swift
@@ -1,0 +1,71 @@
+//
+//  ClientResponseOrderingGate.swift
+//  Clerk
+//
+
+import Foundation
+
+struct ClientResponseOrderingGate {
+  private(set) var lastAcceptedSequence: Int?
+  var lastAcceptedServerDate: Date?
+
+  init(
+    lastAcceptedSequence: Int? = nil,
+    lastAcceptedServerDate: Date? = nil
+  ) {
+    self.lastAcceptedSequence = lastAcceptedSequence
+    self.lastAcceptedServerDate = lastAcceptedServerDate
+  }
+
+  func accepts(
+    sequence: Int?,
+    serverDate: Date?,
+    incomingUpdatedAt: Date?,
+    currentUpdatedAt: Date?
+  ) -> Bool {
+    guard let sequence,
+          let lastAcceptedSequence,
+          sequence <= lastAcceptedSequence
+    else {
+      return true
+    }
+    return responseIsNewer(
+      serverDate: serverDate,
+      incomingUpdatedAt: incomingUpdatedAt,
+      currentUpdatedAt: currentUpdatedAt
+    )
+  }
+
+  mutating func record(sequence: Int?, serverDate: Date? = nil) {
+    guard let sequence else { return }
+    lastAcceptedSequence = max(lastAcceptedSequence ?? sequence, sequence)
+    if let serverDate {
+      lastAcceptedServerDate = serverDate
+    }
+  }
+
+  mutating func reset() {
+    lastAcceptedSequence = nil
+    lastAcceptedServerDate = nil
+  }
+
+  mutating func resetSequence() {
+    lastAcceptedSequence = nil
+  }
+
+  private func responseIsNewer(
+    serverDate: Date?,
+    incomingUpdatedAt: Date?,
+    currentUpdatedAt: Date?
+  ) -> Bool {
+    guard let serverDate, let lastAcceptedServerDate else { return false }
+    if serverDate > lastAcceptedServerDate { return true }
+    guard serverDate == lastAcceptedServerDate,
+          let incomingUpdatedAt,
+          let currentUpdatedAt
+    else {
+      return false
+    }
+    return incomingUpdatedAt > currentUpdatedAt
+  }
+}

--- a/Sources/ClerkKit/Identity/ClientResponseOrderingGate.swift
+++ b/Sources/ClerkKit/Identity/ClientResponseOrderingGate.swift
@@ -39,9 +39,12 @@ struct ClientResponseOrderingGate {
   mutating func record(sequence: Int?, serverDate: Date? = nil) {
     guard let sequence else { return }
     lastAcceptedSequence = max(lastAcceptedSequence ?? sequence, sequence)
-    if let serverDate {
-      lastAcceptedServerDate = serverDate
-    }
+    advanceServerDateWatermark(to: serverDate)
+  }
+
+  mutating func advanceServerDateWatermark(to serverDate: Date?) {
+    guard let serverDate else { return }
+    lastAcceptedServerDate = max(lastAcceptedServerDate ?? serverDate, serverDate)
   }
 
   mutating func reset() {

--- a/Sources/ClerkKit/Lifecycle/StartupClientRefreshTakeover.swift
+++ b/Sources/ClerkKit/Lifecycle/StartupClientRefreshTakeover.swift
@@ -165,7 +165,7 @@ extension ClerkIdentityController {
     return ClerkIdentityRequestSnapshot(
       baseGeneration: baseGeneration,
       deviceToken: deviceToken,
-      clientID: clerk.client?.id,
+      clientID: clerk.authoritativeClient?.id,
       clientResponseGeneration: clientResponseGeneration
     )
   }

--- a/Sources/ClerkKit/Lifecycle/StartupClientRefreshTakeover.swift
+++ b/Sources/ClerkKit/Lifecycle/StartupClientRefreshTakeover.swift
@@ -157,6 +157,7 @@ extension ClerkIdentityController {
     startupClientRefreshTakeoverID: UUID?
   ) throws -> ClerkIdentityRequestSnapshot {
     guard let clerk else { throw CancellationError() }
+    let deviceToken = deviceToken.nilIfEmpty
     clerk.startupClientRefreshTakeover.beginIfNeeded(
       id: startupClientRefreshTakeoverID,
       deviceToken: deviceToken

--- a/Sources/ClerkKit/Lifecycle/StartupClientRefreshTakeover.swift
+++ b/Sources/ClerkKit/Lifecycle/StartupClientRefreshTakeover.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// Coordinates temporary ownership of configure-time client loading by
+/// tokenless authentication requests.
+@MainActor
+final class StartupClientRefreshTakeover {
+  private struct Checkpoint: Equatable {
+    let clientResponseGeneration: ClientResponseGeneration
+    let deviceToken: String?
+    let client: Client?
+    let serverDate: Date?
+  }
+
+  private struct ActiveTakeover {
+    let checkpoint: Checkpoint
+    var requestIDs: Set<UUID>
+  }
+
+  private weak var clerk: Clerk?
+  private var activeTakeover: ActiveTakeover?
+
+  init(clerk: Clerk) {
+    self.clerk = clerk
+  }
+
+  func beginIfNeeded(id: UUID?, deviceToken: String?) {
+    guard deviceToken == nil,
+          let id,
+          let clerk
+    else {
+      return
+    }
+
+    if var activeTakeover {
+      activeTakeover.requestIDs.insert(id)
+      self.activeTakeover = activeTakeover
+      return
+    }
+
+    guard clerk.cancelStartupClientRefreshTask() else { return }
+    clerk.identityController.fenceClientResponses()
+    activeTakeover = ActiveTakeover(
+      checkpoint: checkpoint(deviceToken: deviceToken, clerk: clerk),
+      requestIDs: [id]
+    )
+  }
+
+  func finish(id: UUID) async {
+    guard let clerk,
+          activeTakeover?.requestIDs.contains(id) == true
+    else {
+      return
+    }
+
+    if let coordinator = clerk.sharedSessionSyncCoordinator {
+      let task = coordinator.enqueueSerializedLocalIdentityOperation { [weak self] in
+        guard let self else { throw CancellationError() }
+        finishSerialized(id: id)
+      }
+      await finish(task: task, id: id)
+    } else if clerk.dependencies.atomicIdentityIO != nil {
+      let task = clerk.identityController.enqueueLocalOperation { [weak self] _ in
+        guard let self else { throw CancellationError() }
+        finishSerialized(id: id)
+      }
+      await finish(task: task, id: id)
+    } else {
+      finishSerialized(id: id)
+    }
+  }
+
+  func cancel() {
+    activeTakeover = nil
+  }
+
+  private func finish(task: Task<Void, Error>, id: UUID) async {
+    do {
+      try await task.value
+    } catch {
+      guard activeTakeover?.requestIDs.contains(id) == true else { return }
+      ClerkLogger.logError(
+        error,
+        message: "Failed to serialize startup client refresh takeover completion"
+      )
+      finishSerialized(id: id)
+    }
+  }
+
+  private func finishSerialized(id: UUID) {
+    guard let clerk,
+          var activeTakeover,
+          activeTakeover.requestIDs.remove(id) != nil
+    else {
+      return
+    }
+
+    guard activeTakeover.requestIDs.isEmpty else {
+      self.activeTakeover = activeTakeover
+      return
+    }
+
+    self.activeTakeover = nil
+    guard checkpoint(
+      deviceToken: clerk.identityController.currentDeviceToken,
+      clerk: clerk
+    ) == activeTakeover.checkpoint else {
+      return
+    }
+    clerk.startStartupClientRefreshIfNeeded()
+  }
+
+  private func checkpoint(deviceToken: String?, clerk: Clerk) -> Checkpoint {
+    Checkpoint(
+      clientResponseGeneration: clerk.clientResponseGeneration,
+      deviceToken: deviceToken,
+      client: clerk.client,
+      serverDate: clerk.lastClientServerFetchDate
+    )
+  }
+}
+
+extension ClerkIdentityController {
+  func captureRequestIdentity(
+    startupClientRefreshTakeoverID: UUID? = nil
+  ) async throws -> ClerkIdentityRequestSnapshot {
+    guard let clerk else { throw CancellationError() }
+    if let coordinator = clerk.sharedSessionSyncCoordinator {
+      try await coordinator.waitForInitialReconciliation()
+      await waitForPendingLocalOperations()
+      return try await coordinator.captureRequestIdentity(
+        startupClientRefreshTakeoverID: startupClientRefreshTakeoverID
+      )
+    }
+
+    if clerk.dependencies.atomicIdentityIO != nil {
+      let task = enqueueLocalOperation { [weak self] _ in
+        guard let self else { throw CancellationError() }
+        return try captureSerializedRequestIdentity(
+          baseGeneration: 0,
+          deviceToken: localDeviceToken,
+          startupClientRefreshTakeoverID: startupClientRefreshTakeoverID
+        )
+      }
+      return try await task.value
+    }
+
+    return try captureSerializedRequestIdentity(
+      baseGeneration: 0,
+      deviceToken: currentDeviceToken,
+      startupClientRefreshTakeoverID: startupClientRefreshTakeoverID
+    )
+  }
+
+  func captureSerializedRequestIdentity(
+    baseGeneration: UInt64,
+    deviceToken: String?,
+    startupClientRefreshTakeoverID: UUID?
+  ) throws -> ClerkIdentityRequestSnapshot {
+    guard let clerk else { throw CancellationError() }
+    clerk.startupClientRefreshTakeover.beginIfNeeded(
+      id: startupClientRefreshTakeoverID,
+      deviceToken: deviceToken
+    )
+    return ClerkIdentityRequestSnapshot(
+      baseGeneration: baseGeneration,
+      deviceToken: deviceToken,
+      clientID: clerk.client?.id,
+      clientResponseGeneration: clientResponseGeneration
+    )
+  }
+}

--- a/Sources/ClerkKit/Mocks/Clerk+Preview.swift
+++ b/Sources/ClerkKit/Mocks/Clerk+Preview.swift
@@ -140,7 +140,7 @@ extension Clerk {
 
     // Replace dependencies with mock services
     clerk.dependencies = container
-    clerk.client = mockClient
+    clerk.setClientFromIdentityController(mockClient)
     clerk.environment = mockEnvironment
 
     return clerk

--- a/Sources/ClerkKit/Mocks/MockDependencyContainer.swift
+++ b/Sources/ClerkKit/Mocks/MockDependencyContainer.swift
@@ -21,6 +21,7 @@ final class MockDependencyContainer: Dependencies {
   let atomicIdentityStore: (any SharedSessionLocalIdentityStoring)?
   let atomicIdentityIO: SharedSessionLocalIdentityIO?
   let sharedSessionOwnerIdentifier: String?
+  let sharedSessionOwnerSlotClearRecovery: SharedSessionOwnerSlotClearRecovery.Context?
   let shouldHydrateProvisionalLegacyClient: Bool
   let configurationManager: ConfigurationManager
   let apiClient: APIClient
@@ -68,6 +69,7 @@ final class MockDependencyContainer: Dependencies {
     legacyAppLocalKeychain: (any KeychainStorage)? = nil,
     atomicIdentityStore: (any SharedSessionLocalIdentityStoring)? = nil,
     sharedSessionOwnerIdentifier: String? = Bundle.main.bundleIdentifier,
+    sharedSessionOwnerSlotClearRecovery: SharedSessionOwnerSlotClearRecovery.Context? = nil,
     shouldHydrateProvisionalLegacyClient: Bool = false,
     telemetryCollector: (any TelemetryCollectorProtocol)? = nil,
     clientService: (any ClientServiceProtocol)? = nil,
@@ -93,6 +95,7 @@ final class MockDependencyContainer: Dependencies {
       SharedSessionLocalIdentityIO(store: $0)
     }
     self.sharedSessionOwnerIdentifier = sharedSessionOwnerIdentifier
+    self.sharedSessionOwnerSlotClearRecovery = sharedSessionOwnerSlotClearRecovery
     self.shouldHydrateProvisionalLegacyClient = shouldHydrateProvisionalLegacyClient
     configurationManager = ConfigurationManager()
     self.apiClient = apiClient

--- a/Sources/ClerkKit/Mocks/MockModels.swift
+++ b/Sources/ClerkKit/Mocks/MockModels.swift
@@ -14,7 +14,7 @@ import Foundation
 extension Clerk {
   public static var mock: Clerk {
     let clerk = Clerk()
-    clerk.client = .mock
+    clerk.setClientFromIdentityController(.mock)
     clerk.environment = .mock
     clerk.sessionsByUserId = [User.mock.id: [.mock, .mock2]]
     return clerk
@@ -22,7 +22,7 @@ extension Clerk {
 
   public static var mockSignedOut: Clerk {
     let clerk = Clerk()
-    clerk.client = .mockSignedOut
+    clerk.setClientFromIdentityController(.mockSignedOut)
     clerk.environment = .mock
     clerk.sessionsByUserId = [:]
     return clerk

--- a/Sources/ClerkKit/Networking/APIRequest.swift
+++ b/Sources/ClerkKit/Networking/APIRequest.swift
@@ -127,7 +127,6 @@ struct Request<Response: Decodable & Sendable> {
 
     var urlRequest = URLRequest(url: finalURL)
     urlRequest.httpMethod = method.rawValue
-    urlRequest.setClerkCanEstablishClientWhenTokenless(canEstablishClientWhenTokenless)
     if !headers.isEmpty {
       var headerFields = urlRequest.allHTTPHeaderFields ?? [:]
       headers.forEach { headerFields[$0.key] = $0.value }

--- a/Sources/ClerkKit/Networking/APIRequest.swift
+++ b/Sources/ClerkKit/Networking/APIRequest.swift
@@ -64,6 +64,7 @@ struct Request<Response: Decodable & Sendable> {
   let path: String
   let method: HTTPMethod
   let headers: [String: String]
+  let createsClientWhenTokenless: Bool
 
   private let queryItems: [URLQueryItem]
   private let body: RequestBody?
@@ -73,6 +74,7 @@ struct Request<Response: Decodable & Sendable> {
     path: String,
     method: HTTPMethod = .get,
     headers: [String: String] = [:],
+    createsClientWhenTokenless: Bool = false,
     query: [(String, String?)] = [],
     body: (any Encodable & Sendable)? = nil,
     decode: @escaping @Sendable (Data, JSONDecoder) throws -> Response = { data, decoder in
@@ -90,6 +92,7 @@ struct Request<Response: Decodable & Sendable> {
     self.path = path
     self.method = method
     self.headers = headers
+    self.createsClientWhenTokenless = createsClientWhenTokenless
     queryItems = query.map { URLQueryItem(name: $0.0, value: $0.1) }
     self.body = body.map { .encodable(AnyEncodable($0)) }
     decodeClosure = decode
@@ -124,6 +127,7 @@ struct Request<Response: Decodable & Sendable> {
 
     var urlRequest = URLRequest(url: finalURL)
     urlRequest.httpMethod = method.rawValue
+    urlRequest.setClerkCreatesClientWhenTokenless(createsClientWhenTokenless)
     if !headers.isEmpty {
       var headerFields = urlRequest.allHTTPHeaderFields ?? [:]
       headers.forEach { headerFields[$0.key] = $0.value }

--- a/Sources/ClerkKit/Networking/APIRequest.swift
+++ b/Sources/ClerkKit/Networking/APIRequest.swift
@@ -64,7 +64,7 @@ struct Request<Response: Decodable & Sendable> {
   let path: String
   let method: HTTPMethod
   let headers: [String: String]
-  let createsClientWhenTokenless: Bool
+  let canEstablishClientWhenTokenless: Bool
 
   private let queryItems: [URLQueryItem]
   private let body: RequestBody?
@@ -74,7 +74,7 @@ struct Request<Response: Decodable & Sendable> {
     path: String,
     method: HTTPMethod = .get,
     headers: [String: String] = [:],
-    createsClientWhenTokenless: Bool = false,
+    canEstablishClientWhenTokenless: Bool = false,
     query: [(String, String?)] = [],
     body: (any Encodable & Sendable)? = nil,
     decode: @escaping @Sendable (Data, JSONDecoder) throws -> Response = { data, decoder in
@@ -92,7 +92,7 @@ struct Request<Response: Decodable & Sendable> {
     self.path = path
     self.method = method
     self.headers = headers
-    self.createsClientWhenTokenless = createsClientWhenTokenless
+    self.canEstablishClientWhenTokenless = canEstablishClientWhenTokenless
     queryItems = query.map { URLQueryItem(name: $0.0, value: $0.1) }
     self.body = body.map { .encodable(AnyEncodable($0)) }
     decodeClosure = decode
@@ -127,7 +127,7 @@ struct Request<Response: Decodable & Sendable> {
 
     var urlRequest = URLRequest(url: finalURL)
     urlRequest.httpMethod = method.rawValue
-    urlRequest.setClerkCreatesClientWhenTokenless(createsClientWhenTokenless)
+    urlRequest.setClerkCanEstablishClientWhenTokenless(canEstablishClientWhenTokenless)
     if !headers.isEmpty {
       var headerFields = urlRequest.allHTTPHeaderFields ?? [:]
       headers.forEach { headerFields[$0.key] = $0.value }

--- a/Sources/ClerkKit/Networking/ClerkAPIClient.swift
+++ b/Sources/ClerkKit/Networking/ClerkAPIClient.swift
@@ -84,6 +84,7 @@ actor APIClient {
     var clerkRequestContext: ClerkRequestContext?
 
     while true {
+      try Task.checkCancellation()
       try ensureCurrentRuntimeScope()
       attempts += 1
 
@@ -112,6 +113,7 @@ actor APIClient {
           (data, response) = try await session.data(for: urlRequest)
         }
 
+        try Task.checkCancellation()
         try ensureCurrentRuntimeScope()
 
         guard let httpResponse = response as? HTTPURLResponse else {

--- a/Sources/ClerkKit/Networking/ClerkAPIClient.swift
+++ b/Sources/ClerkKit/Networking/ClerkAPIClient.swift
@@ -79,6 +79,28 @@ actor APIClient {
     _ request: Request<Value>,
     uploadBody: Data?
   ) async throws -> APIResponse<Value> {
+    let startupClientRefreshTakeoverID = request.canEstablishClientWhenTokenless
+      ? UUID()
+      : nil
+    do {
+      let response = try await executeAttempts(
+        request,
+        uploadBody: uploadBody,
+        startupClientRefreshTakeoverID: startupClientRefreshTakeoverID
+      )
+      await finishStartupClientRefreshTakeover(startupClientRefreshTakeoverID)
+      return response
+    } catch {
+      await finishStartupClientRefreshTakeover(startupClientRefreshTakeoverID)
+      throw error
+    }
+  }
+
+  private func executeAttempts<Value: Decodable & Sendable>(
+    _ request: Request<Value>,
+    uploadBody: Data?,
+    startupClientRefreshTakeoverID: UUID?
+  ) async throws -> APIResponse<Value> {
     var attempts = 0
     let requestSequence = makeRequestSequence()
     var clerkRequestContext: ClerkRequestContext?
@@ -89,7 +111,10 @@ actor APIClient {
       attempts += 1
 
       var urlRequest = try request.makeURLRequest(baseURL: baseURL, encoder: encoder)
-      urlRequest.setClerkRequestSequence(requestSequence)
+      urlRequest.setClerkRequestMetadata(
+        sequence: requestSequence,
+        startupClientRefreshTakeoverID: startupClientRefreshTakeoverID
+      )
       try await pipeline.prepareClerkRequest(&urlRequest)
       let preparedContext = ClerkRequestContext(request: urlRequest)
       if let clerkRequestContext {
@@ -163,6 +188,12 @@ actor APIClient {
 
   private func ensureCurrentRuntimeScope() throws {
     try runtimeScope.validateStableRuntime()
+  }
+
+  private func finishStartupClientRefreshTakeover(_ id: UUID?) async {
+    guard let id else { return }
+    guard let clerk = try? await runtimeScope.requireCurrentClerk() else { return }
+    await clerk.startupClientRefreshTakeover.finish(id: id)
   }
 }
 

--- a/Sources/ClerkKit/Networking/Middleware/ClerkClientSyncResponseMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkClientSyncResponseMiddleware.swift
@@ -101,6 +101,7 @@ struct ClerkClientSyncResponseMiddleware: ClerkResponseMiddleware {
   }
 
   func validate(_ response: HTTPURLResponse, data: Data, for request: URLRequest) async throws {
+    try Task.checkCancellation()
     let deviceTokenUpdate = ClerkDeviceTokenResponseUpdate(
       authorizationHeader: response.value(forHTTPHeaderField: "Authorization")
     )
@@ -121,6 +122,7 @@ struct ClerkClientSyncResponseMiddleware: ClerkResponseMiddleware {
     )
 
     let clerk = try await runtimeScope.requireCurrentClerk()
+    try Task.checkCancellation()
     try await clerk.identityController.applyNetworkResponse(context)
   }
 

--- a/Sources/ClerkKit/Networking/Middleware/ClerkClientSyncResponseMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkClientSyncResponseMiddleware.swift
@@ -75,21 +75,12 @@ struct ClientSyncResponseContext {
   private var resolvedDeviceToken: String? {
     switch deviceTokenUpdate {
     case .absent:
-      normalizedToken(requestDeviceToken)
+      requestDeviceToken.nilIfEmpty
     case .set(let deviceToken):
       deviceToken
     case .clear:
       nil
     }
-  }
-
-  private func normalizedToken(_ token: String?) -> String? {
-    guard let token = token?.trimmingCharacters(in: .whitespacesAndNewlines),
-          !token.isEmpty
-    else {
-      return nil
-    }
-    return token
   }
 }
 

--- a/Sources/ClerkKit/Networking/Middleware/ClerkHeaderRequestMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkHeaderRequestMiddleware.swift
@@ -21,7 +21,7 @@ struct ClerkHeaderRequestMiddleware: ClerkRequestMiddleware {
     let identity = try await clerk.identityController.captureRequestIdentity()
     _ = try runtimeScope.requireCurrentClerk()
     var clientResponseGeneration = identity.clientResponseGeneration
-    if request.clerkCreatesClientWhenTokenless,
+    if request.clerkCanEstablishClientWhenTokenless,
        identity.deviceToken == nil,
        clerk.cancelStartupClientRefresh()
     {

--- a/Sources/ClerkKit/Networking/Middleware/ClerkHeaderRequestMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkHeaderRequestMiddleware.swift
@@ -18,17 +18,11 @@ struct ClerkHeaderRequestMiddleware: ClerkRequestMiddleware {
   @MainActor
   func prepare(_ request: inout URLRequest) async throws {
     let clerk = try runtimeScope.requireCurrentClerk()
-    let identity = try await clerk.identityController.captureRequestIdentity()
+    let identity = try await clerk.identityController.captureRequestIdentity(
+      startupClientRefreshTakeoverID: request.clerkStartupClientRefreshTakeoverID
+    )
     _ = try runtimeScope.requireCurrentClerk()
-    var clientResponseGeneration = identity.clientResponseGeneration
-    if request.clerkCanEstablishClientWhenTokenless,
-       identity.deviceToken == nil,
-       clerk.cancelStartupClientRefresh()
-    {
-      clerk.identityController.fenceClientResponses()
-      clientResponseGeneration = clerk.clientResponseGeneration
-    }
-    request.setClerkClientResponseGeneration(clientResponseGeneration)
+    request.setClerkClientResponseGeneration(identity.clientResponseGeneration)
     request.setClerkSharedSessionBaseGeneration(identity.baseGeneration)
     let isCanonicalClientRequest = request.value(
       forHTTPHeaderField: Self.canonicalClientRequestHeader
@@ -39,7 +33,7 @@ struct ClerkHeaderRequestMiddleware: ClerkRequestMiddleware {
 
     request.setClerkRequestCheckpoint(ClerkRequestCheckpoint(
       requestSequence: request.clerkRequestSequence,
-      clientResponseGeneration: clientResponseGeneration,
+      clientResponseGeneration: identity.clientResponseGeneration,
       sharedSessionBaseGeneration: identity.baseGeneration,
       isCanonicalClientRequest: isCanonicalClientRequest,
       requestDeviceToken: identity.deviceToken

--- a/Sources/ClerkKit/Networking/Middleware/ClerkHeaderRequestMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/ClerkHeaderRequestMiddleware.swift
@@ -20,7 +20,15 @@ struct ClerkHeaderRequestMiddleware: ClerkRequestMiddleware {
     let clerk = try runtimeScope.requireCurrentClerk()
     let identity = try await clerk.identityController.captureRequestIdentity()
     _ = try runtimeScope.requireCurrentClerk()
-    request.setClerkClientResponseGeneration(identity.clientResponseGeneration)
+    var clientResponseGeneration = identity.clientResponseGeneration
+    if request.clerkCreatesClientWhenTokenless,
+       identity.deviceToken == nil,
+       clerk.cancelStartupClientRefresh()
+    {
+      clerk.identityController.fenceClientResponses()
+      clientResponseGeneration = clerk.clientResponseGeneration
+    }
+    request.setClerkClientResponseGeneration(clientResponseGeneration)
     request.setClerkSharedSessionBaseGeneration(identity.baseGeneration)
     let isCanonicalClientRequest = request.value(
       forHTTPHeaderField: Self.canonicalClientRequestHeader
@@ -31,7 +39,7 @@ struct ClerkHeaderRequestMiddleware: ClerkRequestMiddleware {
 
     request.setClerkRequestCheckpoint(ClerkRequestCheckpoint(
       requestSequence: request.clerkRequestSequence,
-      clientResponseGeneration: identity.clientResponseGeneration,
+      clientResponseGeneration: clientResponseGeneration,
       sharedSessionBaseGeneration: identity.baseGeneration,
       isCanonicalClientRequest: isCanonicalClientRequest,
       requestDeviceToken: identity.deviceToken

--- a/Sources/ClerkKit/Networking/Middleware/NetworkMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/NetworkMiddleware.swift
@@ -178,11 +178,11 @@ struct ClerkRequestCheckpoint: Equatable {
 
 extension URLRequest {
   private static let clerkRequestSequenceKey = "com.clerk.request-sequence"
+  private static let clerkStartupClientRefreshTakeoverIDKey = "com.clerk.startup-client-refresh-takeover-id"
   private static let clerkClientResponseGenerationKey = "com.clerk.client-response-generation"
   private static let clerkSharedSessionBaseGenerationKey = "com.clerk.shared-session-base-generation"
   private static let clerkCanonicalClientRequestKey = "com.clerk.canonical-client-request"
   private static let clerkRequestDeviceTokenKey = "com.clerk.request-device-token"
-  private static let clerkCanEstablishClientWhenTokenlessKey = "com.clerk.can-establish-client-when-tokenless"
 
   var clerkRequestCheckpoint: ClerkRequestCheckpoint {
     ClerkRequestCheckpoint(request: self)
@@ -190,6 +190,16 @@ extension URLRequest {
 
   var clerkRequestSequence: Int? {
     URLProtocol.property(forKey: Self.clerkRequestSequenceKey, in: self) as? Int
+  }
+
+  var clerkStartupClientRefreshTakeoverID: UUID? {
+    guard let value = URLProtocol.property(
+      forKey: Self.clerkStartupClientRefreshTakeoverIDKey,
+      in: self
+    ) as? String else {
+      return nil
+    }
+    return UUID(uuidString: value)
   }
 
   var clerkClientResponseGeneration: ClientResponseGeneration? {
@@ -216,15 +226,28 @@ extension URLRequest {
     URLProtocol.property(forKey: Self.clerkRequestDeviceTokenKey, in: self) as? String
   }
 
-  var clerkCanEstablishClientWhenTokenless: Bool {
-    (URLProtocol.property(
-      forKey: Self.clerkCanEstablishClientWhenTokenlessKey,
-      in: self
-    ) as? NSNumber)?.boolValue == true
-  }
-
   mutating func setClerkRequestSequence(_ sequence: Int) {
     setClerkProperty(sequence, key: Self.clerkRequestSequenceKey)
+  }
+
+  mutating func setClerkRequestMetadata(
+    sequence: Int,
+    startupClientRefreshTakeoverID: UUID?
+  ) {
+    setClerkProperties([
+      (value: sequence, key: Self.clerkRequestSequenceKey),
+      (
+        value: startupClientRefreshTakeoverID?.uuidString,
+        key: Self.clerkStartupClientRefreshTakeoverIDKey
+      ),
+    ])
+  }
+
+  mutating func setClerkStartupClientRefreshTakeoverID(_ id: UUID) {
+    setClerkProperty(
+      id.uuidString,
+      key: Self.clerkStartupClientRefreshTakeoverIDKey
+    )
   }
 
   mutating func setClerkClientResponseGeneration(_ generation: ClientResponseGeneration) {
@@ -250,13 +273,6 @@ extension URLRequest {
 
   mutating func setClerkRequestDeviceToken(_ deviceToken: String) {
     setClerkProperty(deviceToken, key: Self.clerkRequestDeviceTokenKey)
-  }
-
-  mutating func setClerkCanEstablishClientWhenTokenless(_ canEstablishClient: Bool) {
-    setClerkProperty(
-      canEstablishClient ? NSNumber(value: true) : nil,
-      key: Self.clerkCanEstablishClientWhenTokenlessKey
-    )
   }
 
   mutating func setClerkRequestCheckpoint(_ checkpoint: ClerkRequestCheckpoint) {

--- a/Sources/ClerkKit/Networking/Middleware/NetworkMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/NetworkMiddleware.swift
@@ -182,7 +182,7 @@ extension URLRequest {
   private static let clerkSharedSessionBaseGenerationKey = "com.clerk.shared-session-base-generation"
   private static let clerkCanonicalClientRequestKey = "com.clerk.canonical-client-request"
   private static let clerkRequestDeviceTokenKey = "com.clerk.request-device-token"
-  private static let clerkCreatesClientWhenTokenlessKey = "com.clerk.creates-client-when-tokenless"
+  private static let clerkCanEstablishClientWhenTokenlessKey = "com.clerk.can-establish-client-when-tokenless"
 
   var clerkRequestCheckpoint: ClerkRequestCheckpoint {
     ClerkRequestCheckpoint(request: self)
@@ -216,9 +216,9 @@ extension URLRequest {
     URLProtocol.property(forKey: Self.clerkRequestDeviceTokenKey, in: self) as? String
   }
 
-  var clerkCreatesClientWhenTokenless: Bool {
+  var clerkCanEstablishClientWhenTokenless: Bool {
     (URLProtocol.property(
-      forKey: Self.clerkCreatesClientWhenTokenlessKey,
+      forKey: Self.clerkCanEstablishClientWhenTokenlessKey,
       in: self
     ) as? NSNumber)?.boolValue == true
   }
@@ -252,10 +252,10 @@ extension URLRequest {
     setClerkProperty(deviceToken, key: Self.clerkRequestDeviceTokenKey)
   }
 
-  mutating func setClerkCreatesClientWhenTokenless(_ createsClient: Bool) {
+  mutating func setClerkCanEstablishClientWhenTokenless(_ canEstablishClient: Bool) {
     setClerkProperty(
-      createsClient ? NSNumber(value: true) : nil,
-      key: Self.clerkCreatesClientWhenTokenlessKey
+      canEstablishClient ? NSNumber(value: true) : nil,
+      key: Self.clerkCanEstablishClientWhenTokenlessKey
     )
   }
 

--- a/Sources/ClerkKit/Networking/Middleware/NetworkMiddleware.swift
+++ b/Sources/ClerkKit/Networking/Middleware/NetworkMiddleware.swift
@@ -182,6 +182,7 @@ extension URLRequest {
   private static let clerkSharedSessionBaseGenerationKey = "com.clerk.shared-session-base-generation"
   private static let clerkCanonicalClientRequestKey = "com.clerk.canonical-client-request"
   private static let clerkRequestDeviceTokenKey = "com.clerk.request-device-token"
+  private static let clerkCreatesClientWhenTokenlessKey = "com.clerk.creates-client-when-tokenless"
 
   var clerkRequestCheckpoint: ClerkRequestCheckpoint {
     ClerkRequestCheckpoint(request: self)
@@ -215,6 +216,13 @@ extension URLRequest {
     URLProtocol.property(forKey: Self.clerkRequestDeviceTokenKey, in: self) as? String
   }
 
+  var clerkCreatesClientWhenTokenless: Bool {
+    (URLProtocol.property(
+      forKey: Self.clerkCreatesClientWhenTokenlessKey,
+      in: self
+    ) as? NSNumber)?.boolValue == true
+  }
+
   mutating func setClerkRequestSequence(_ sequence: Int) {
     setClerkProperty(sequence, key: Self.clerkRequestSequenceKey)
   }
@@ -242,6 +250,13 @@ extension URLRequest {
 
   mutating func setClerkRequestDeviceToken(_ deviceToken: String) {
     setClerkProperty(deviceToken, key: Self.clerkRequestDeviceTokenKey)
+  }
+
+  mutating func setClerkCreatesClientWhenTokenless(_ createsClient: Bool) {
+    setClerkProperty(
+      createsClient ? NSNumber(value: true) : nil,
+      key: Self.clerkCreatesClientWhenTokenlessKey
+    )
   }
 
   mutating func setClerkRequestCheckpoint(_ checkpoint: ClerkRequestCheckpoint) {

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionLocalIdentityStore.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionLocalIdentityStore.swift
@@ -61,6 +61,26 @@ struct SharedSessionLocalIdentityRecord: Codable, Equatable {
     _ = try pendingPublication?.validated()
     return self
   }
+
+  func pendingLegacyAdoptionEventID(for ownerIdentifier: String) -> UUID? {
+    guard requiresLegacyAdoptionPublication,
+          let acceptedIdentity,
+          acceptedIdentity.state == .cleared,
+          acceptedIdentity.deviceToken.nilIfEmpty != nil,
+          acceptedIdentity.client == nil,
+          let pendingPublication,
+          pendingPublication.originOwnerIdentifier == ownerIdentifier,
+          SharedSessionLocalIdentity(
+            state: pendingPublication.state,
+            deviceToken: pendingPublication.deviceToken,
+            client: pendingPublication.client,
+            serverDate: pendingPublication.serverDate
+          ) == acceptedIdentity
+    else {
+      return nil
+    }
+    return pendingPublication.id
+  }
 }
 
 enum SharedSessionLocalIdentityStoreError: Error, Equatable {

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionLocalIdentityStore.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionLocalIdentityStore.swift
@@ -13,19 +13,49 @@ struct SharedSessionLocalIdentityRecord: Codable, Equatable {
   let schemaVersion: Int
   let acceptedIdentity: SharedSessionLocalIdentity?
   let pendingPublication: SharedSessionIdentityEvent?
+  let requiresLegacyAdoptionPublication: Bool
 
   init(
     acceptedIdentity: SharedSessionLocalIdentity?,
-    pendingPublication: SharedSessionIdentityEvent?
+    pendingPublication: SharedSessionIdentityEvent?,
+    requiresLegacyAdoptionPublication: Bool = false
   ) {
     schemaVersion = Self.schemaVersion
     self.acceptedIdentity = acceptedIdentity
     self.pendingPublication = pendingPublication
+    self.requiresLegacyAdoptionPublication = requiresLegacyAdoptionPublication
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case schemaVersion
+    case acceptedIdentity
+    case pendingPublication
+    case requiresLegacyAdoptionPublication
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+    acceptedIdentity = try container.decodeIfPresent(
+      SharedSessionLocalIdentity.self,
+      forKey: .acceptedIdentity
+    )
+    pendingPublication = try container.decodeIfPresent(
+      SharedSessionIdentityEvent.self,
+      forKey: .pendingPublication
+    )
+    requiresLegacyAdoptionPublication = try container.decodeIfPresent(
+      Bool.self,
+      forKey: .requiresLegacyAdoptionPublication
+    ) ?? false
   }
 
   func validated() throws -> Self {
     guard schemaVersion == Self.schemaVersion else {
       throw SharedSessionLocalIdentityStoreError.unsupportedSchemaVersion
+    }
+    guard !requiresLegacyAdoptionPublication || acceptedIdentity != nil else {
+      throw SharedSessionLocalIdentityStoreError.missingLegacyAdoptionIdentity
     }
     _ = try acceptedIdentity?.validated()
     _ = try pendingPublication?.validated()
@@ -35,6 +65,7 @@ struct SharedSessionLocalIdentityRecord: Codable, Equatable {
 
 enum SharedSessionLocalIdentityStoreError: Error, Equatable {
   case unsupportedSchemaVersion
+  case missingLegacyAdoptionIdentity
   case pendingPublicationAlreadyExists
   case pendingPublicationMismatch
 }
@@ -75,6 +106,20 @@ extension SharedSessionLocalIdentityStoring {
     }
   }
 
+  func saveLegacyAdoption(_ identity: SharedSessionLocalIdentity) throws {
+    let identity = try identity.validated()
+    try updateRecord { record in
+      guard record?.pendingPublication == nil else {
+        throw SharedSessionLocalIdentityStoreError.pendingPublicationAlreadyExists
+      }
+      return SharedSessionLocalIdentityRecord(
+        acceptedIdentity: identity,
+        pendingPublication: nil,
+        requiresLegacyAdoptionPublication: true
+      )
+    }
+  }
+
   func stagePendingPublication(_ event: SharedSessionIdentityEvent) throws {
     let event = try event.validated()
     try updateRecord { record in
@@ -86,7 +131,8 @@ extension SharedSessionLocalIdentityStoring {
       }
       return SharedSessionLocalIdentityRecord(
         acceptedIdentity: record?.acceptedIdentity,
-        pendingPublication: event
+        pendingPublication: event,
+        requiresLegacyAdoptionPublication: record?.requiresLegacyAdoptionPublication ?? false
       )
     }
   }
@@ -117,7 +163,8 @@ extension SharedSessionLocalIdentityStoring {
       }
       return SharedSessionLocalIdentityRecord(
         acceptedIdentity: acceptedIdentity,
-        pendingPublication: nil
+        pendingPublication: nil,
+        requiresLegacyAdoptionPublication: record.requiresLegacyAdoptionPublication
       )
     }
   }

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionOwnerSlotCleanup.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionOwnerSlotCleanup.swift
@@ -7,23 +7,16 @@ import Foundation
 
 enum SharedSessionOwnerSlotCleanup {
   @MainActor
-  static func deleteIfConfigured(in dependencies: any Dependencies) async throws {
-    let configuration = dependencies.configurationManager
-    guard configuration.options.sharedSessionSync != nil,
-          let ownerIdentifier = dependencies.sharedSessionOwnerIdentifier
-    else {
-      return
-    }
+  static func storeIfConfigured(
+    in dependencies: any Dependencies
+  ) throws -> SharedSessionOwnerSlotStore? {
+    try SharedSessionSlotTopology(dependencies: dependencies)?
+      .makeOwnerSlotStore()
+  }
 
-    let namespace = SharedSessionNamespace(
-      frontendApiUrl: configuration.frontendApiUrl,
-      publishableKey: configuration.publishableKey
-    )
-    let slotStore = try SharedSessionOwnerSlotStore(
-      keychainConfig: configuration.options.keychainConfig,
-      namespace: namespace,
-      ownerIdentifier: ownerIdentifier
-    )
+  @MainActor
+  static func deleteIfConfigured(in dependencies: any Dependencies) async throws {
+    guard let slotStore = try storeIfConfigured(in: dependencies) else { return }
     try await SharedSessionSlotIO(store: slotStore).deleteOwnSlot()
   }
 }

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionOwnerSlotClearRecovery.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionOwnerSlotClearRecovery.swift
@@ -1,0 +1,165 @@
+//
+//  SharedSessionOwnerSlotClearRecovery.swift
+//  Clerk
+//
+
+import Foundation
+
+enum SharedSessionOwnerSlotClearRecoveryError: Error, Equatable {
+  case unsupportedSchemaVersion
+  case invalidIntent
+  case missingCurrentTopology
+  case pendingIntentConflict
+}
+
+protocol SharedSessionClearRecoveryTargets: Sendable {
+  func localIdentityStore(
+    for intent: SharedSessionOwnerSlotClearRecovery.Intent
+  ) throws -> any SharedSessionLocalIdentityStoring
+
+  func slotStore(
+    for intent: SharedSessionOwnerSlotClearRecovery.Intent
+  ) throws -> any SharedSessionSlotStoring
+}
+
+enum SharedSessionOwnerSlotClearRecovery {
+  static let storageKey = "clerkSharedSessionOwnerSlotClearIntentV1"
+
+  struct Intent: Codable, Equatable {
+    static let schemaVersion = 1
+
+    let schemaVersion: Int
+    let localIdentityService: String
+    let slotService: String
+    let slotAccessGroup: String
+    let slotAccount: String
+    let instanceFingerprint: String
+    let ownerIdentifier: String
+
+    init(
+      localIdentityService: String,
+      slotService: String,
+      slotAccessGroup: String,
+      slotAccount: String,
+      instanceFingerprint: String,
+      ownerIdentifier: String
+    ) {
+      schemaVersion = Self.schemaVersion
+      self.localIdentityService = localIdentityService
+      self.slotService = slotService
+      self.slotAccessGroup = slotAccessGroup
+      self.slotAccount = slotAccount
+      self.instanceFingerprint = instanceFingerprint
+      self.ownerIdentifier = ownerIdentifier
+    }
+
+    func validated() throws -> Self {
+      guard schemaVersion == Self.schemaVersion else {
+        throw SharedSessionOwnerSlotClearRecoveryError.unsupportedSchemaVersion
+      }
+      let requiredValues = [
+        localIdentityService,
+        slotService,
+        slotAccessGroup,
+        slotAccount,
+        instanceFingerprint,
+        ownerIdentifier,
+      ]
+      guard requiredValues.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) else {
+        throw SharedSessionOwnerSlotClearRecoveryError.invalidIntent
+      }
+      return self
+    }
+  }
+
+  struct Context {
+    let journal: any KeychainStorage
+    let currentIntent: Intent?
+    let targetProvider: any SharedSessionClearRecoveryTargets
+  }
+
+  struct LiveTargetProvider: SharedSessionClearRecoveryTargets {
+    func localIdentityStore(
+      for intent: Intent
+    ) throws -> any SharedSessionLocalIdentityStoring {
+      let intent = try intent.validated()
+      return SharedSessionLocalIdentityStore(
+        keychain: SystemKeychain(service: intent.localIdentityService)
+      )
+    }
+
+    func slotStore(
+      for intent: Intent
+    ) throws -> any SharedSessionSlotStoring {
+      try SharedSessionOwnerSlotStore(clearRecoveryIntent: intent)
+    }
+  }
+
+  static func liveContext(
+    ownerIdentifier: String?,
+    currentIntent: Intent?
+  ) -> Context? {
+    guard let ownerIdentifier = ownerIdentifier?.trimmingCharacters(
+      in: .whitespacesAndNewlines
+    ), !ownerIdentifier.isEmpty else {
+      return nil
+    }
+    return Context(
+      journal: SystemKeychain(
+        service: "\(ownerIdentifier).clerk.shared-session-clear-recovery.v1"
+      ),
+      currentIntent: currentIntent,
+      targetProvider: LiveTargetProvider()
+    )
+  }
+
+  static func markPending(in context: Context) throws {
+    guard let intent = try context.currentIntent?.validated() else {
+      throw SharedSessionOwnerSlotClearRecoveryError.missingCurrentTopology
+    }
+    if let pending = try loadPendingIntent(in: context.journal) {
+      guard pending == intent else {
+        throw SharedSessionOwnerSlotClearRecoveryError.pendingIntentConflict
+      }
+      return
+    }
+    try context.journal.set(
+      JSONEncoder.clerkEncoder.encode(intent),
+      forKey: storageKey
+    )
+  }
+
+  static func clearPendingIntent(
+    matching expectedIntent: Intent,
+    in context: Context
+  ) throws {
+    guard let pending = try loadPendingIntent(in: context.journal) else {
+      return
+    }
+    guard pending == expectedIntent else {
+      throw SharedSessionOwnerSlotClearRecoveryError.pendingIntentConflict
+    }
+    try context.journal.deleteItem(forKey: storageKey)
+  }
+
+  @discardableResult
+  static func recoverIfNeeded(in context: Context?) throws -> Bool {
+    guard let context,
+          let intent = try loadPendingIntent(in: context.journal)
+    else {
+      return false
+    }
+
+    try context.targetProvider.localIdentityStore(for: intent).delete()
+    try context.targetProvider.slotStore(for: intent).deleteOwnSlot()
+    try context.journal.deleteItem(forKey: storageKey)
+    return true
+  }
+
+  static func loadPendingIntent(
+    in journal: any KeychainStorage
+  ) throws -> Intent? {
+    guard let data = try journal.data(forKey: storageKey) else { return nil }
+    return try JSONDecoder.clerkDecoder.decode(Intent.self, from: data).validated()
+  }
+}

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionOwnerSlotStore.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionOwnerSlotStore.swift
@@ -57,17 +57,56 @@ struct SharedSessionOwnerSlotStore: SharedSessionSlotStoring {
       throw SharedSessionOwnerSlotStoreError.missingOwnerIdentifier
     }
 
-    service = Self.service(
-      configuredService: keychainConfig.service,
-      instanceFingerprint: namespace.fingerprint
-    )
-    self.accessGroup = accessGroup
-    instanceFingerprint = namespace.fingerprint
-    self.ownerIdentifier = ownerIdentifier
-    ownerAccount = Self.account(
+    self.init(
+      service: Self.service(
+        configuredService: keychainConfig.service,
+        instanceFingerprint: namespace.fingerprint
+      ),
+      accessGroup: accessGroup,
       instanceFingerprint: namespace.fingerprint,
-      ownerIdentifier: ownerIdentifier
+      ownerIdentifier: ownerIdentifier,
+      ownerAccount: Self.account(
+        instanceFingerprint: namespace.fingerprint,
+        ownerIdentifier: ownerIdentifier
+      ),
+      secItemClient: secItemClient,
+      diagnostics: diagnostics
     )
+  }
+
+  init(
+    clearRecoveryIntent intent: SharedSessionOwnerSlotClearRecovery.Intent,
+    secItemClient: SystemKeychain.SecItemClient = .live,
+    diagnostics: @escaping @Sendable (String) -> Void = {
+      ClerkLogger.debug($0)
+    }
+  ) throws {
+    let intent = try intent.validated()
+    self.init(
+      service: intent.slotService,
+      accessGroup: intent.slotAccessGroup,
+      instanceFingerprint: intent.instanceFingerprint,
+      ownerIdentifier: intent.ownerIdentifier,
+      ownerAccount: intent.slotAccount,
+      secItemClient: secItemClient,
+      diagnostics: diagnostics
+    )
+  }
+
+  private init(
+    service: String,
+    accessGroup: String,
+    instanceFingerprint: String,
+    ownerIdentifier: String,
+    ownerAccount: String,
+    secItemClient: SystemKeychain.SecItemClient,
+    diagnostics: @escaping @Sendable (String) -> Void
+  ) {
+    self.service = service
+    self.accessGroup = accessGroup
+    self.instanceFingerprint = instanceFingerprint
+    self.ownerIdentifier = ownerIdentifier
+    self.ownerAccount = ownerAccount
     #if os(macOS)
     useDataProtectionKeychain = true
     #else
@@ -143,7 +182,9 @@ struct SharedSessionOwnerSlotStore: SharedSessionSlotStoring {
        let header = try? JSONDecoder.clerkDecoder.decode(SchemaVersionHeader.self, from: data),
        header.schemaVersion > SharedSessionOwnerSlot.schemaVersion
     {
-      return
+      throw SharedSessionOwnerSlotStoreError.futureSchemaVersion(
+        header.schemaVersion
+      )
     }
 
     let status = secItemClient.delete(query(account: ownerAccount) as CFDictionary)

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionOwnerSlotStore.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionOwnerSlotStore.swift
@@ -22,6 +22,8 @@ enum SharedSessionOwnerSlotStoreError: Error, Equatable {
 }
 
 struct SharedSessionOwnerSlotStore: SharedSessionSlotStoring {
+  private static let mutationLock = NSLock()
+
   private struct SchemaVersionHeader: Decodable {
     let schemaVersion: Int
   }
@@ -117,10 +119,9 @@ struct SharedSessionOwnerSlotStore: SharedSessionSlotStoring {
   }
 
   func loadOwnSlot() throws -> SharedSessionOwnerSlot? {
-    guard let data = try loadData(account: ownerAccount) else {
-      return nil
+    try Self.mutationLock.withLock {
+      try loadOwnSlotWithoutLocking()
     }
-    return decodeCompatibleSlot(data: data, account: ownerAccount, requireOwnOwner: true)
   }
 
   func loadAllSlots() throws -> [SharedSessionOwnerSlot] {
@@ -160,6 +161,12 @@ struct SharedSessionOwnerSlotStore: SharedSessionSlotStoring {
   }
 
   func saveOwnSlot(_ slot: SharedSessionOwnerSlot) throws {
+    try Self.mutationLock.withLock {
+      try saveOwnSlotWithoutLocking(slot)
+    }
+  }
+
+  private func saveOwnSlotWithoutLocking(_ slot: SharedSessionOwnerSlot) throws {
     guard slot.schemaVersion == SharedSessionOwnerSlot.schemaVersion,
           slot.instanceFingerprint == instanceFingerprint,
           slot.slotOwnerIdentifier == ownerIdentifier,
@@ -178,6 +185,12 @@ struct SharedSessionOwnerSlotStore: SharedSessionSlotStoring {
   }
 
   func deleteOwnSlot() throws {
+    try Self.mutationLock.withLock {
+      try deleteOwnSlotWithoutLocking()
+    }
+  }
+
+  private func deleteOwnSlotWithoutLocking() throws {
     if let data = try loadData(account: ownerAccount),
        let header = try? JSONDecoder.clerkDecoder.decode(SchemaVersionHeader.self, from: data),
        header.schemaVersion > SharedSessionOwnerSlot.schemaVersion
@@ -283,6 +296,32 @@ struct SharedSessionOwnerSlotStore: SharedSessionSlotStoring {
 }
 
 extension SharedSessionOwnerSlotStore {
+  private func loadOwnSlotWithoutLocking() throws -> SharedSessionOwnerSlot? {
+    guard let data = try loadData(account: ownerAccount) else {
+      return nil
+    }
+    return decodeCompatibleSlot(data: data, account: ownerAccount, requireOwnOwner: true)
+  }
+
+  @discardableResult
+  func restoreOwnSlot(
+    _ previousSlot: SharedSessionOwnerSlot?,
+    ifCurrentMatchesPublication expectedSlot: SharedSessionOwnerSlot
+  ) throws -> Bool {
+    try Self.mutationLock.withLock {
+      guard try loadOwnSlotWithoutLocking()?.matchesPublication(expectedSlot) == true else {
+        return false
+      }
+
+      if let previousSlot {
+        try saveOwnSlotWithoutLocking(previousSlot)
+      } else {
+        try deleteOwnSlotWithoutLocking()
+      }
+      return true
+    }
+  }
+
   private func validateExistingOwnSlot(_ data: Data) throws {
     if let versionHeader = try? JSONDecoder.clerkDecoder.decode(
       SchemaVersionHeader.self,

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionSlotIO.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionSlotIO.swift
@@ -3,6 +3,7 @@
 //  Clerk
 //
 
+/// Serializes Security-backed owner-slot operations outside the main actor.
 actor SharedSessionSlotIO {
   private let store: any SharedSessionSlotStoring
 

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionSlotRollback.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionSlotRollback.swift
@@ -1,0 +1,32 @@
+//
+//  SharedSessionSlotRollback.swift
+//  Clerk
+//
+
+extension SharedSessionSlotStoring {
+  @discardableResult
+  func restoreOwnSlot(
+    _ previousSlot: SharedSessionOwnerSlot?,
+    ifCurrentMatchesPublication expectedSlot: SharedSessionOwnerSlot
+  ) throws -> Bool {
+    guard try loadOwnSlot()?.matchesPublication(expectedSlot) == true else {
+      return false
+    }
+
+    if let previousSlot {
+      try saveOwnSlot(previousSlot)
+    } else {
+      try deleteOwnSlot()
+    }
+    return true
+  }
+}
+
+extension SharedSessionOwnerSlot {
+  func matchesPublication(_ other: SharedSessionOwnerSlot) -> Bool {
+    schemaVersion == other.schemaVersion
+      && instanceFingerprint == other.instanceFingerprint
+      && slotOwnerIdentifier == other.slotOwnerIdentifier
+      && event.id == other.event.id
+  }
+}

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionSlotTopology.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionSlotTopology.swift
@@ -1,0 +1,66 @@
+//
+//  SharedSessionSlotTopology.swift
+//  Clerk
+//
+
+import Foundation
+
+struct SharedSessionSlotTopology: Equatable {
+  struct StoreIdentity: Equatable {
+    let service: String
+    let accessGroup: String
+    let namespace: SharedSessionNamespace
+  }
+
+  let storeIdentity: StoreIdentity
+  let ownerIdentifier: String
+
+  var instanceFingerprint: String {
+    storeIdentity.namespace.fingerprint
+  }
+
+  var keychainConfig: Clerk.Options.KeychainConfig {
+    Clerk.Options.KeychainConfig(
+      service: storeIdentity.service,
+      accessGroup: storeIdentity.accessGroup
+    )
+  }
+
+  @MainActor
+  init?(dependencies: any Dependencies) {
+    let configuration = dependencies.configurationManager
+    guard configuration.options.sharedSessionSync != nil,
+          let accessGroup = configuration.options.keychainConfig.normalizedAccessGroup,
+          let ownerIdentifier = dependencies.sharedSessionOwnerIdentifier,
+          !ownerIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else {
+      return nil
+    }
+
+    storeIdentity = StoreIdentity(
+      service: configuration.options.keychainConfig.service,
+      accessGroup: accessGroup,
+      namespace: SharedSessionNamespace(
+        frontendApiUrl: configuration.frontendApiUrl,
+        publishableKey: configuration.publishableKey
+      )
+    )
+    self.ownerIdentifier = ownerIdentifier
+  }
+
+  func hasSameStore(as other: Self) -> Bool {
+    storeIdentity == other.storeIdentity
+  }
+
+  func hasSameOwnerSlot(as other: Self) -> Bool {
+    self == other
+  }
+
+  func makeOwnerSlotStore() throws -> SharedSessionOwnerSlotStore {
+    try SharedSessionOwnerSlotStore(
+      keychainConfig: keychainConfig,
+      namespace: storeIdentity.namespace,
+      ownerIdentifier: ownerIdentifier
+    )
+  }
+}

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncAdoption.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncAdoption.swift
@@ -40,16 +40,22 @@ struct SharedSessionSyncAdoption {
     }
 
     if try destinationIdentityStore.load() == nil {
-      let identitySources = [
+      let appLocalIdentitySources = [
         configuredAppLocalIdentity,
         previousAppLocalIdentity,
-        legacyShared,
       ].compactMap { $0 }
-      for source in identitySources {
+      var migratedAppLocalIdentity = false
+      for source in appLocalIdentitySources {
         if let identity = try loadCoherentIdentity(from: source) {
-          try destinationIdentityStore.save(identity)
+          try destinationIdentityStore.saveLegacyAdoption(identity)
+          migratedAppLocalIdentity = true
           break
         }
+      }
+      if !migratedAppLocalIdentity,
+         let identity = try loadCoherentIdentity(from: legacyShared)
+      {
+        try destinationIdentityStore.save(identity)
       }
     }
 

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator+ResponseOrdering.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator+ResponseOrdering.swift
@@ -1,0 +1,83 @@
+//
+//  SharedSessionSyncCoordinator+ResponseOrdering.swift
+//  Clerk
+//
+
+import Foundation
+
+extension SharedSessionSyncCoordinator {
+  func responseCanBeAccepted(
+    sequence: Int?,
+    serverDate: Date?,
+    incomingClient: Client?,
+    currentClient: Client?
+  ) -> Bool {
+    responseOrderingGate.accepts(
+      sequence: sequence,
+      serverDate: serverDate,
+      incomingUpdatedAt: incomingClient?.updatedAt,
+      currentUpdatedAt: currentClient?.updatedAt
+    )
+  }
+
+  func checkpointAllowsPublication(_ checkpoint: PublicationCheckpoint) -> Bool {
+    switch checkpoint {
+    case .none:
+      true
+    case let .response(baseGeneration, requestDeviceToken):
+      responseCanPublish(
+        from: baseGeneration,
+        requestDeviceToken: requestDeviceToken
+      )
+    }
+  }
+
+  func responseCanPublish(
+    from baseGeneration: UInt64,
+    requestDeviceToken: String?
+  ) -> Bool {
+    guard requestDeviceToken == currentDeviceToken else { return false }
+    if baseGeneration == currentMaximumGeneration {
+      return true
+    }
+    guard let networkResponseLineage else { return false }
+    return baseGeneration >= networkResponseLineage.rootGeneration
+      && baseGeneration <= networkResponseLineage.frontierGeneration
+      && networkResponseLineage.frontierGeneration == currentMaximumGeneration
+      && networkResponseLineage.deviceToken == currentDeviceToken
+  }
+
+  func networkResponseCandidate(
+    for checkpoint: PublicationCheckpoint,
+    eventID: UUID
+  ) -> (eventID: UUID, rootGeneration: UInt64)? {
+    guard case .response(let baseGeneration, _) = checkpoint else { return nil }
+    return (eventID, baseGeneration)
+  }
+
+  func updateNetworkResponseLineage(
+    winner: SharedSessionIdentityEvent,
+    previousAcceptedEventID: UUID?,
+    candidate: (eventID: UUID, rootGeneration: UInt64)?
+  ) {
+    if let candidate, winner.id == candidate.eventID {
+      let rootGeneration = if let networkResponseLineage,
+                              networkResponseLineage.deviceToken == currentDeviceToken,
+                              networkResponseLineage.frontierGeneration < winner.generation,
+                              candidate.rootGeneration >= networkResponseLineage.rootGeneration,
+                              candidate.rootGeneration <= networkResponseLineage.frontierGeneration
+      {
+        networkResponseLineage.rootGeneration
+      } else {
+        candidate.rootGeneration
+      }
+      networkResponseLineage = NetworkResponseLineage(
+        rootGeneration: rootGeneration,
+        frontierGeneration: winner.generation,
+        deviceToken: currentDeviceToken
+      )
+    } else if candidate != nil || winner.id != previousAcceptedEventID {
+      networkResponseLineage = nil
+    }
+  }
+}

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator.swift
@@ -10,6 +10,7 @@ enum SharedSessionSyncCoordinatorError: Error, Equatable {
   case reconciliationFailed
   case missingWinnerForPendingPublication
   case pendingPublicationOwnerMismatch
+  case pendingPublicationDidNotSettle
 }
 
 @MainActor
@@ -285,6 +286,33 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
 }
 
 extension SharedSessionSyncCoordinator {
+  func settlePendingPublicationForTopologyChange() async throws {
+    let task = enqueueSerializedOperation { [weak self] in
+      guard let self,
+            let clerk,
+            isCurrent(clerk: clerk),
+            !isLocalClearInProgress
+      else {
+        throw CancellationError()
+      }
+
+      let settlementRevision = operationRevision
+      try await ensureSuccessfulReconciliationIfNeeded()
+      _ = try await resumePendingPublicationIfNeeded()
+
+      let pendingPublication = try await performCheckedOperation(
+        revision: settlementRevision,
+        clerk: clerk
+      ) {
+        try await self.localIdentityIO.loadRecord()?.pendingPublication
+      }
+      guard pendingPublication == nil else {
+        throw SharedSessionSyncCoordinatorError.pendingPublicationDidNotSettle
+      }
+    }
+    try await task.value
+  }
+
   private func enqueuePublication(_ publication: Publication) async throws -> Bool {
     let task = enqueueSerializedOperation { [weak self] in
       guard let self else { throw CancellationError() }

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator.swift
@@ -143,7 +143,9 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
     _ = await serializedOperationTail?.value
   }
 
-  func captureRequestIdentity() async throws -> ClerkIdentityRequestSnapshot {
+  func captureRequestIdentity(
+    startupClientRefreshTakeoverID: UUID? = nil
+  ) async throws -> ClerkIdentityRequestSnapshot {
     let task = enqueueSerializedOperation { [weak self] in
       guard let self,
             let clerk,
@@ -153,11 +155,10 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
         throw CancellationError()
       }
       try await ensureSuccessfulReconciliationIfNeeded()
-      return ClerkIdentityRequestSnapshot(
+      return try clerk.identityController.captureSerializedRequestIdentity(
         baseGeneration: currentMaximumGeneration,
         deviceToken: currentDeviceToken,
-        clientID: clerk.client?.id,
-        clientResponseGeneration: clerk.clientResponseGeneration
+        startupClientRefreshTakeoverID: startupClientRefreshTakeoverID
       )
     }
     return try await task.value

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator.swift
@@ -199,14 +199,14 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
               ),
               let identity = try context.resolvedIdentityPayload(
                 currentDeviceToken: currentDeviceToken,
-                currentClient: clerk.client,
+                currentClient: clerk.authoritativeClient,
                 currentServerDate: clerk.lastClientServerFetchDate
               ),
               responseCanBeAccepted(
                 sequence: context.responseSequence,
                 serverDate: context.serverDate,
                 incomingClient: identity.client,
-                currentClient: clerk.client
+                currentClient: clerk.authoritativeClient
               )
         else {
           return nil

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator.swift
@@ -15,7 +15,7 @@ enum SharedSessionSyncCoordinatorError: Error, Equatable {
 
 @MainActor
 final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
-  private enum PublicationCheckpoint {
+  enum PublicationCheckpoint {
     case none
     case response(
       baseGeneration: UInt64,
@@ -32,7 +32,7 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
     let checkpoint: PublicationCheckpoint
   }
 
-  private struct NetworkResponseLineage {
+  struct NetworkResponseLineage {
     let rootGeneration: UInt64
     let frontierGeneration: UInt64
     let deviceToken: String?
@@ -66,8 +66,8 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
   private var reconcileAgain = false
   private var isInstalled = true
   private var operationRevision: UInt64 = 0
-  private var responseOrderingGate = ClientResponseOrderingGate()
-  private var networkResponseLineage: NetworkResponseLineage?
+  var responseOrderingGate = ClientResponseOrderingGate()
+  var networkResponseLineage: NetworkResponseLineage?
   private var isLocalClearInProgress = false
   private var requiresSuccessfulReconciliation = false
 
@@ -98,24 +98,6 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
 
     notifier.setHandler { [weak self] in
       self?.requestReconciliation()
-    }
-  }
-
-  @discardableResult
-  func hydrateInitialSharedState() -> Bool {
-    guard initialReconciliationTask == nil,
-          reconciliationTask == nil,
-          serializedOperationTail == nil
-    else {
-      return false
-    }
-
-    do {
-      return try reduceApplyAndReplicateSynchronously()
-    } catch {
-      requiresSuccessfulReconciliation = true
-      logError(error, "Failed to hydrate initial shared-session owner slots")
-      return false
     }
   }
 
@@ -286,6 +268,31 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
 }
 
 extension SharedSessionSyncCoordinator {
+  @discardableResult
+  func hydrateInitialSharedState() -> Bool {
+    guard initialReconciliationTask == nil,
+          reconciliationTask == nil,
+          serializedOperationTail == nil
+    else {
+      return false
+    }
+
+    do {
+      if let record = try localIdentityStore.loadRecord(),
+         record.requiresLegacyAdoptionPublication
+      {
+        currentDeviceToken = record.acceptedIdentity?.deviceToken
+        requiresSuccessfulReconciliation = true
+        return false
+      }
+      return try reduceApplyAndReplicateSynchronously()
+    } catch {
+      requiresSuccessfulReconciliation = true
+      logError(error, "Failed to hydrate initial shared-session owner slots")
+      return false
+    }
+  }
+
   func settlePendingPublicationForTopologyChange() async throws {
     let task = enqueueSerializedOperation { [weak self] in
       guard let self,
@@ -325,18 +332,26 @@ extension SharedSessionSyncCoordinator {
     }
   }
 
-  private func performPublication(_ publication: Publication) async throws -> Bool {
-    try await performPublication { publication }
+  private func performPublication(
+    _ publication: Publication,
+    ensuringSuccessfulReconciliation: Bool = true
+  ) async throws -> Bool {
+    try await performPublication(
+      ensuringSuccessfulReconciliation: ensuringSuccessfulReconciliation
+    ) { publication }
   }
 
   private func performPublication(
+    ensuringSuccessfulReconciliation: Bool = true,
     resolve: @MainActor () throws -> Publication?
   ) async throws -> Bool {
     guard let clerk, isCurrent(clerk: clerk), !isLocalClearInProgress else {
       throw CancellationError()
     }
 
-    try await ensureSuccessfulReconciliationIfNeeded()
+    if ensuringSuccessfulReconciliation {
+      try await ensureSuccessfulReconciliationIfNeeded()
+    }
     _ = try await resumePendingPublicationIfNeeded()
     guard let publication = try resolve() else { return false }
     guard isCurrent(clerk: clerk),
@@ -559,6 +574,8 @@ extension SharedSessionSyncCoordinator {
       do {
         if try await resumePendingPublicationIfNeeded() {
           didChange = true
+        } else if try await publishLegacyAdoptionIfNeeded() {
+          didChange = true
         } else if try await reduceApplyAndReplicate() {
           didChange = true
         }
@@ -574,6 +591,48 @@ extension SharedSessionSyncCoordinator {
 
     requiresSuccessfulReconciliation = false
     return ReconciliationResult(didChange: didChange, succeeded: true)
+  }
+
+  private func publishLegacyAdoptionIfNeeded() async throws -> Bool {
+    guard let clerk, isCurrent(clerk: clerk), !isLocalClearInProgress else {
+      throw CancellationError()
+    }
+    let preparationRevision = operationRevision
+    guard let record = try await performCheckedOperation(
+      revision: preparationRevision,
+      clerk: clerk,
+      operation: {
+        try await self.localIdentityIO.loadRecord()
+      }
+    ),
+      record.requiresLegacyAdoptionPublication,
+      let identity = record.acceptedIdentity
+    else {
+      return false
+    }
+
+    let slots = try await performCheckedOperation(
+      revision: preparationRevision,
+      clerk: clerk
+    ) {
+      try await self.slotIO.loadAllSlots()
+    }
+    currentMaximumGeneration = max(
+      currentMaximumGeneration,
+      SharedSessionIdentityReducer.reduce(slots).maximumGeneration
+    )
+
+    return try await performPublication(
+      Publication(
+        state: identity.state,
+        deviceToken: identity.deviceToken,
+        client: identity.client,
+        serverDate: identity.serverDate,
+        baseGeneration: currentMaximumGeneration,
+        checkpoint: .none
+      ),
+      ensuringSuccessfulReconciliation: false
+    )
   }
 
   @discardableResult
@@ -898,82 +957,5 @@ extension SharedSessionSyncCoordinator {
       && !isLocalClearInProgress
       && clerk.sharedSessionSyncCoordinator === self
       && clerk.isCurrentConfigurationEpoch(configurationEpoch)
-  }
-}
-
-extension SharedSessionSyncCoordinator {
-  private func responseCanBeAccepted(
-    sequence: Int?,
-    serverDate: Date?,
-    incomingClient: Client?,
-    currentClient: Client?
-  ) -> Bool {
-    responseOrderingGate.accepts(
-      sequence: sequence,
-      serverDate: serverDate,
-      incomingUpdatedAt: incomingClient?.updatedAt,
-      currentUpdatedAt: currentClient?.updatedAt
-    )
-  }
-
-  private func checkpointAllowsPublication(_ checkpoint: PublicationCheckpoint) -> Bool {
-    switch checkpoint {
-    case .none:
-      true
-    case let .response(baseGeneration, requestDeviceToken):
-      responseCanPublish(
-        from: baseGeneration,
-        requestDeviceToken: requestDeviceToken
-      )
-    }
-  }
-
-  private func responseCanPublish(
-    from baseGeneration: UInt64,
-    requestDeviceToken: String?
-  ) -> Bool {
-    guard requestDeviceToken == currentDeviceToken else { return false }
-    if baseGeneration == currentMaximumGeneration {
-      return true
-    }
-    guard let networkResponseLineage else { return false }
-    return baseGeneration >= networkResponseLineage.rootGeneration
-      && baseGeneration <= networkResponseLineage.frontierGeneration
-      && networkResponseLineage.frontierGeneration == currentMaximumGeneration
-      && networkResponseLineage.deviceToken == currentDeviceToken
-  }
-
-  private func networkResponseCandidate(
-    for checkpoint: PublicationCheckpoint,
-    eventID: UUID
-  ) -> (eventID: UUID, rootGeneration: UInt64)? {
-    guard case .response(let baseGeneration, _) = checkpoint else { return nil }
-    return (eventID, baseGeneration)
-  }
-
-  private func updateNetworkResponseLineage(
-    winner: SharedSessionIdentityEvent,
-    previousAcceptedEventID: UUID?,
-    candidate: (eventID: UUID, rootGeneration: UInt64)?
-  ) {
-    if let candidate, winner.id == candidate.eventID {
-      let rootGeneration = if let networkResponseLineage,
-                              networkResponseLineage.deviceToken == currentDeviceToken,
-                              networkResponseLineage.frontierGeneration < winner.generation,
-                              candidate.rootGeneration >= networkResponseLineage.rootGeneration,
-                              candidate.rootGeneration <= networkResponseLineage.frontierGeneration
-      {
-        networkResponseLineage.rootGeneration
-      } else {
-        candidate.rootGeneration
-      }
-      networkResponseLineage = NetworkResponseLineage(
-        rootGeneration: rootGeneration,
-        frontierGeneration: winner.generation,
-        deviceToken: currentDeviceToken
-      )
-    } else if candidate != nil || winner.id != previousAcceptedEventID {
-      networkResponseLineage = nil
-    }
   }
 }

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator.swift
@@ -5,6 +5,11 @@
 
 import Foundation
 
+enum SharedSessionClientPresentationPolicy {
+  case replaceWithIdentity
+  case preserveProvisional
+}
+
 enum SharedSessionSyncCoordinatorError: Error, Equatable {
   case initialReconciliationFailed
   case reconciliationFailed
@@ -30,6 +35,7 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
     let serverDate: Date?
     let baseGeneration: UInt64?
     let checkpoint: PublicationCheckpoint
+    let clientPresentationPolicy: SharedSessionClientPresentationPolicy
   }
 
   struct NetworkResponseLineage {
@@ -203,7 +209,8 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
           checkpoint: .response(
             baseGeneration: baseGeneration,
             requestDeviceToken: context.requestDeviceToken
-          )
+          ),
+          clientPresentationPolicy: .replaceWithIdentity
         )
       }
       if didApply {
@@ -236,7 +243,8 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
         client: client,
         serverDate: serverDate,
         baseGeneration: baseGeneration,
-        checkpoint: .none
+        checkpoint: .none,
+        clientPresentationPolicy: .replaceWithIdentity
       )
     )
   }
@@ -261,7 +269,8 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
         client: client,
         serverDate: serverDate,
         baseGeneration: baseGeneration,
-        checkpoint: .none
+        checkpoint: .none,
+        clientPresentationPolicy: .replaceWithIdentity
       )
     )
   }
@@ -303,10 +312,10 @@ extension SharedSessionSyncCoordinator {
         throw CancellationError()
       }
 
-      let settlementRevision = operationRevision
       try await ensureSuccessfulReconciliationIfNeeded()
       _ = try await resumePendingPublicationIfNeeded()
 
+      let settlementRevision = operationRevision
       let pendingPublication = try await performCheckedOperation(
         revision: settlementRevision,
         clerk: clerk
@@ -424,7 +433,9 @@ extension SharedSessionSyncCoordinator {
           networkResponseCandidate: self.networkResponseCandidate(
             for: publication.checkpoint,
             eventID: event.id
-          )
+          ),
+          provisionalClientPreservingEventID: publication.clientPresentationPolicy
+            == .preserveProvisional ? event.id : nil
         )
       }
       notifier.post()
@@ -629,7 +640,11 @@ extension SharedSessionSyncCoordinator {
         client: identity.client,
         serverDate: identity.serverDate,
         baseGeneration: currentMaximumGeneration,
-        checkpoint: .none
+        checkpoint: .none,
+        clientPresentationPolicy: identity.state == .cleared
+          && identity.deviceToken.nilIfEmpty != nil
+          ? .preserveProvisional
+          : .replaceWithIdentity
       ),
       ensuringSuccessfulReconciliation: false
     )
@@ -701,15 +716,18 @@ extension SharedSessionSyncCoordinator {
       throw CancellationError()
     }
     let recoveryRevision = operationRevision
-    guard let pending = try await performCheckedOperation(
+    guard let record = try await performCheckedOperation(
       revision: recoveryRevision,
       clerk: clerk,
       operation: {
-        try await self.localIdentityIO.loadRecord()?.pendingPublication
+        try await self.localIdentityIO.loadRecord()
       }
-    ) else {
+    ), let pending = record.pendingPublication else {
       return false
     }
+    let provisionalClientPreservingEventID = record.pendingLegacyAdoptionEventID(
+      for: ownerIdentifier
+    )
     guard pending.originOwnerIdentifier == ownerIdentifier else {
       throw SharedSessionSyncCoordinatorError.pendingPublicationOwnerMismatch
     }
@@ -759,7 +777,8 @@ extension SharedSessionSyncCoordinator {
 
     try validateActiveOperation(recoveryRevision, clerk: clerk)
     let didChange = try await reduceApplyAndReplicate(
-      clearingPendingPublicationID: pending.id
+      clearingPendingPublicationID: pending.id,
+      provisionalClientPreservingEventID: provisionalClientPreservingEventID
     )
     if pendingWasPeerVisible {
       notifier.post()
@@ -770,7 +789,8 @@ extension SharedSessionSyncCoordinator {
   @discardableResult
   private func reduceApplyAndReplicate(
     clearingPendingPublicationID pendingPublicationID: UUID? = nil,
-    networkResponseCandidate: (eventID: UUID, rootGeneration: UInt64)? = nil
+    networkResponseCandidate: (eventID: UUID, rootGeneration: UInt64)? = nil,
+    provisionalClientPreservingEventID: UUID? = nil
   ) async throws -> Bool {
     guard let clerk, isCurrent(clerk: clerk), !isLocalClearInProgress else {
       throw CancellationError()
@@ -836,7 +856,13 @@ extension SharedSessionSyncCoordinator {
     let previousAcceptedEventID = acceptedEventID
     let didChange = winner.id != previousAcceptedEventID
     if didChange {
-      applyToMemory(winner, clerk: clerk)
+      applyToMemory(
+        winner,
+        clerk: clerk,
+        clientPresentationPolicy: winner.id == provisionalClientPreservingEventID
+          ? .preserveProvisional
+          : .replaceWithIdentity
+      )
     }
     updateNetworkResponseLineage(
       winner: winner,
@@ -847,7 +873,11 @@ extension SharedSessionSyncCoordinator {
     return didChange
   }
 
-  private func applyToMemory(_ event: SharedSessionIdentityEvent, clerk: Clerk) {
+  private func applyToMemory(
+    _ event: SharedSessionIdentityEvent,
+    clerk: Clerk,
+    clientPresentationPolicy: SharedSessionClientPresentationPolicy = .replaceWithIdentity
+  ) {
     let previousToken = currentDeviceToken
     currentDeviceToken = event.deviceToken
     if previousToken != currentDeviceToken {
@@ -855,7 +885,8 @@ extension SharedSessionSyncCoordinator {
     }
     clerk.identityController.applySharedEvent(
       event,
-      previousDeviceToken: previousToken
+      previousDeviceToken: previousToken,
+      clientPresentationPolicy: clientPresentationPolicy
     )
     acceptedEventID = event.id
     currentMaximumGeneration = max(currentMaximumGeneration, event.generation)

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionSyncCoordinator.swift
@@ -65,8 +65,7 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
   private var reconcileAgain = false
   private var isInstalled = true
   private var operationRevision: UInt64 = 0
-  private var lastHandledResponseSequence: Int?
-  private var lastHandledResponseServerDate: Date?
+  private var responseOrderingGate = ClientResponseOrderingGate()
   private var networkResponseLineage: NetworkResponseLineage?
   private var isLocalClearInProgress = false
   private var requiresSuccessfulReconciliation = false
@@ -224,7 +223,7 @@ final class SharedSessionSyncCoordinator: ClerkInternalStateChangeObserver {
         )
       }
       if didApply {
-        recordAcceptedResponse(
+        responseOrderingGate.record(
           sequence: context.responseSequence,
           serverDate: context.serverDate
         )
@@ -328,41 +327,62 @@ extension SharedSessionSyncCoordinator {
       originOwnerIdentifier: ownerIdentifier,
       generation: generation,
       state: publication.state,
-      deviceToken: normalizedToken(publication.deviceToken),
+      deviceToken: publication.deviceToken.nilIfEmpty,
       client: publication.client,
       serverDate: publication.serverDate
     ).validated()
 
     var didStage = false
     do {
-      try await localIdentityIO.stagePendingPublication(event)
-      didStage = true
-      requiresSuccessfulReconciliation = true
-      try Task.checkCancellation()
-      try validateActiveOperation(publicationRevision, clerk: clerk)
+      try await performCheckedOperation(
+        revision: publicationRevision,
+        clerk: clerk,
+        operation: {
+          try await self.localIdentityIO.stagePendingPublication(event)
+        },
+        didComplete: {
+          didStage = true
+          self.requiresSuccessfulReconciliation = true
+        }
+      )
 
       do {
-        try await saveOwn(event)
+        try await performCheckedOperation(
+          revision: publicationRevision,
+          clerk: clerk
+        ) {
+          try await self.saveOwn(event)
+        }
       } catch let error as SharedSessionOwnerSlotStoreError {
         if case .futureSchemaVersion = error {
-          try await localIdentityIO.clearPendingPublication()
-          didStage = false
+          try await performCheckedOperation(
+            revision: publicationRevision,
+            clerk: clerk,
+            operation: {
+              try await self.localIdentityIO.clearPendingPublication()
+            },
+            didComplete: {
+              didStage = false
+            }
+          )
           _ = try await reduceApplyAndReplicate()
           return false
         }
         throw error
       }
-      try Task.checkCancellation()
-      try validateActiveOperation(publicationRevision, clerk: clerk)
 
-      _ = try await reduceApplyAndReplicate(
-        clearingPendingPublicationID: event.id,
-        networkResponseCandidate: networkResponseCandidate(
-          for: publication.checkpoint,
-          eventID: event.id
+      _ = try await performCheckedOperation(
+        revision: publicationRevision,
+        clerk: clerk
+      ) {
+        try await self.reduceApplyAndReplicate(
+          clearingPendingPublicationID: event.id,
+          networkResponseCandidate: self.networkResponseCandidate(
+            for: publication.checkpoint,
+            eventID: event.id
+          )
         )
-      )
-      try validateActiveOperation(publicationRevision, clerk: clerk)
+      }
       notifier.post()
       return acceptedEventID == event.id
     } catch {
@@ -376,8 +396,7 @@ extension SharedSessionSyncCoordinator {
   func deactivate() {
     isInstalled = false
     operationRevision &+= 1
-    lastHandledResponseSequence = nil
-    lastHandledResponseServerDate = nil
+    responseOrderingGate.reset()
     networkResponseLineage = nil
     notifier.setHandler {}
     reconciliationTask?.cancel()
@@ -409,8 +428,7 @@ extension SharedSessionSyncCoordinator {
     guard !isLocalClearInProgress else { return }
     isLocalClearInProgress = true
     operationRevision &+= 1
-    lastHandledResponseSequence = nil
-    lastHandledResponseServerDate = nil
+    responseOrderingGate.reset()
     networkResponseLineage = nil
     acceptedEventID = nil
     currentDeviceToken = nil
@@ -595,45 +613,60 @@ extension SharedSessionSyncCoordinator {
       throw CancellationError()
     }
     let recoveryRevision = operationRevision
-    guard let pending = try await localIdentityIO.loadRecord()?.pendingPublication else {
+    guard let pending = try await performCheckedOperation(
+      revision: recoveryRevision,
+      clerk: clerk,
+      operation: {
+        try await self.localIdentityIO.loadRecord()?.pendingPublication
+      }
+    ) else {
       return false
     }
-    try Task.checkCancellation()
-    try validateActiveOperation(recoveryRevision, clerk: clerk)
     guard pending.originOwnerIdentifier == ownerIdentifier else {
       throw SharedSessionSyncCoordinatorError.pendingPublicationOwnerMismatch
     }
 
-    let observedSlots = try await slotIO.loadAllSlots()
-    try Task.checkCancellation()
-    try validateActiveOperation(recoveryRevision, clerk: clerk)
+    let observedSlots = try await performCheckedOperation(
+      revision: recoveryRevision,
+      clerk: clerk
+    ) {
+      try await self.slotIO.loadAllSlots()
+    }
 
     let prospectiveReduction = SharedSessionIdentityReducer.reduce(
       events: observedSlots.map(\.event) + [pending]
     )
     if prospectiveReduction.conflictingEventIDs.contains(pending.id) {
-      try validateActiveOperation(recoveryRevision, clerk: clerk)
-      try await localIdentityIO.clearPendingPublication()
-      try validateActiveOperation(recoveryRevision, clerk: clerk)
+      try await performCheckedOperation(
+        revision: recoveryRevision,
+        clerk: clerk
+      ) {
+        try await self.localIdentityIO.clearPendingPublication()
+      }
       return try await reduceApplyAndReplicate()
     }
     var pendingWasPeerVisible = observedSlots.contains {
       $0.slotOwnerIdentifier == ownerIdentifier && $0.event == pending
     }
     if prospectiveReduction.winner == pending, !pendingWasPeerVisible {
-      try validateActiveOperation(recoveryRevision, clerk: clerk)
       do {
-        try await saveOwn(pending)
+        try await performCheckedOperation(
+          revision: recoveryRevision,
+          clerk: clerk
+        ) {
+          try await self.saveOwn(pending)
+        }
       } catch let error as SharedSessionOwnerSlotStoreError {
         guard case .futureSchemaVersion = error else { throw error }
-        try validateActiveOperation(recoveryRevision, clerk: clerk)
-        try await localIdentityIO.clearPendingPublication()
-        try validateActiveOperation(recoveryRevision, clerk: clerk)
+        try await performCheckedOperation(
+          revision: recoveryRevision,
+          clerk: clerk
+        ) {
+          try await self.localIdentityIO.clearPendingPublication()
+        }
         return try await reduceApplyAndReplicate()
       }
       pendingWasPeerVisible = true
-      try Task.checkCancellation()
-      try validateActiveOperation(recoveryRevision, clerk: clerk)
     }
 
     try validateActiveOperation(recoveryRevision, clerk: clerk)
@@ -656,7 +689,6 @@ extension SharedSessionSyncCoordinator {
     }
     let reductionRevision = operationRevision
     let slots = try await slotIO.loadAllSlots()
-    try Task.checkCancellation()
     do {
       try validateActiveOperation(reductionRevision, clerk: clerk)
     } catch {
@@ -686,23 +718,32 @@ extension SharedSessionSyncCoordinator {
 
     let ownSlot = slots.first { $0.slotOwnerIdentifier == ownerIdentifier }
     if ownSlot?.event != winner {
-      try validateActiveOperation(reductionRevision, clerk: clerk)
-      _ = try await replicateOwnIfCompatible(winner)
-      try Task.checkCancellation()
-      try validateActiveOperation(reductionRevision, clerk: clerk)
+      _ = try await performCheckedOperation(
+        revision: reductionRevision,
+        clerk: clerk
+      ) {
+        try await self.replicateOwnIfCompatible(winner)
+      }
     }
-    try validateActiveOperation(reductionRevision, clerk: clerk)
 
     if let pendingPublicationID {
-      try await localIdentityIO.commitAcceptedIdentity(
-        identity,
-        clearingPendingPublicationID: pendingPublicationID
-      )
+      try await performCheckedOperation(
+        revision: reductionRevision,
+        clerk: clerk
+      ) {
+        try await self.localIdentityIO.commitAcceptedIdentity(
+          identity,
+          clearingPendingPublicationID: pendingPublicationID
+        )
+      }
     } else {
-      try await localIdentityIO.saveAcceptedIdentity(identity)
+      try await performCheckedOperation(
+        revision: reductionRevision,
+        clerk: clerk
+      ) {
+        try await self.localIdentityIO.saveAcceptedIdentity(identity)
+      }
     }
-    try Task.checkCancellation()
-    try validateActiveOperation(reductionRevision, clerk: clerk)
 
     let previousAcceptedEventID = acceptedEventID
     let didChange = winner.id != previousAcceptedEventID
@@ -722,8 +763,7 @@ extension SharedSessionSyncCoordinator {
     let previousToken = currentDeviceToken
     currentDeviceToken = event.deviceToken
     if previousToken != currentDeviceToken {
-      lastHandledResponseSequence = nil
-      lastHandledResponseServerDate = nil
+      responseOrderingGate.reset()
     }
     clerk.identityController.applySharedEvent(
       event,
@@ -811,6 +851,19 @@ extension SharedSessionSyncCoordinator {
     }
   }
 
+  private func performCheckedOperation<T>(
+    revision: UInt64,
+    clerk: Clerk,
+    operation: @MainActor () async throws -> T,
+    didComplete: @MainActor () -> Void = {}
+  ) async throws -> T {
+    try validateActiveOperation(revision, clerk: clerk)
+    let result = try await operation()
+    didComplete()
+    try validateActiveOperation(revision, clerk: clerk)
+    return result
+  }
+
   private func canScheduleRecovery(clerk: Clerk) -> Bool {
     isInstalled
       && !isLocalClearInProgress
@@ -820,43 +873,18 @@ extension SharedSessionSyncCoordinator {
 }
 
 extension SharedSessionSyncCoordinator {
-  private func normalizedToken(_ token: String?) -> String? {
-    guard let token = token?.trimmingCharacters(in: .whitespacesAndNewlines),
-          !token.isEmpty
-    else {
-      return nil
-    }
-    return token
-  }
-
   private func responseCanBeAccepted(
     sequence: Int?,
     serverDate: Date?,
     incomingClient: Client?,
     currentClient: Client?
   ) -> Bool {
-    guard let sequence else { return true }
-
-    if let lastHandledResponseSequence,
-       sequence <= lastHandledResponseSequence,
-       !responseIsNewer(
-         incomingClient,
-         than: currentClient,
-         serverDate: serverDate
-       )
-    {
-      return false
-    }
-
-    return true
-  }
-
-  private func recordAcceptedResponse(sequence: Int?, serverDate: Date?) {
-    guard let sequence else { return }
-    lastHandledResponseSequence = max(lastHandledResponseSequence ?? sequence, sequence)
-    if let serverDate {
-      lastHandledResponseServerDate = serverDate
-    }
+    responseOrderingGate.accepts(
+      sequence: sequence,
+      serverDate: serverDate,
+      incomingUpdatedAt: incomingClient?.updatedAt,
+      currentUpdatedAt: currentClient?.updatedAt
+    )
   }
 
   private func checkpointAllowsPublication(_ checkpoint: PublicationCheckpoint) -> Bool {
@@ -918,21 +946,5 @@ extension SharedSessionSyncCoordinator {
     } else if candidate != nil || winner.id != previousAcceptedEventID {
       networkResponseLineage = nil
     }
-  }
-
-  private func responseIsNewer(
-    _ incomingClient: Client?,
-    than currentClient: Client?,
-    serverDate: Date?
-  ) -> Bool {
-    guard let serverDate, let lastHandledResponseServerDate else { return false }
-    if serverDate > lastHandledResponseServerDate { return true }
-    guard serverDate == lastHandledResponseServerDate,
-          let incomingClient,
-          let currentClient
-    else {
-      return false
-    }
-    return incomingClient.updatedAt > currentClient.updatedAt
   }
 }

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionTopologyMigration.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionTopologyMigration.swift
@@ -1,0 +1,182 @@
+//
+//  SharedSessionTopologyMigration.swift
+//  Clerk
+//
+
+import Foundation
+
+enum SharedSessionTopologyMigrationError: Error, Equatable {
+  case destinationIdentityChanged
+}
+
+enum SharedSessionTopologyMigration {
+  private struct PersistenceContext {
+    let identity: ClerkIdentitySnapshot
+    let event: SharedSessionIdentityEvent?
+    let instanceFingerprint: String?
+    let previousRecord: SharedSessionLocalIdentityRecord?
+  }
+
+  struct Rollback {
+    let destinationIdentityStore: any SharedSessionLocalIdentityStoring
+    let previousDestinationRecord: SharedSessionLocalIdentityRecord?
+    let destinationSlotStore: (any SharedSessionSlotStoring)?
+    let previousDestinationSlot: SharedSessionOwnerSlot?
+    let publishedDestinationSlot: Bool
+
+    func restore() throws {
+      var firstError: (any Error)?
+      if publishedDestinationSlot, let destinationSlotStore {
+        do {
+          if let previousDestinationSlot {
+            try destinationSlotStore.saveOwnSlot(previousDestinationSlot)
+          } else {
+            try destinationSlotStore.deleteOwnSlot()
+          }
+        } catch {
+          firstError = error
+        }
+      }
+      do {
+        try destinationIdentityStore.updateRecord { _ in
+          previousDestinationRecord
+        }
+      } catch {
+        firstError = firstError ?? error
+      }
+      if let firstError {
+        throw firstError
+      }
+    }
+  }
+
+  static func prepare(
+    identity: ClerkIdentitySnapshot,
+    destinationIdentityStore: any SharedSessionLocalIdentityStoring,
+    destinationSlotStore: (any SharedSessionSlotStoring)?,
+    destinationInstanceFingerprint: String?,
+    destinationOwnerIdentifier: String?,
+    excludingSourceOwnerIdentifier: String? = nil
+  ) throws -> Rollback {
+    let identity = try identity.validated()
+    let previousDestinationRecord = try destinationIdentityStore.loadRecord()
+    let previousDestinationSlot = try destinationSlotStore?.loadOwnSlot()
+    let destinationSlots = try destinationSlotStore?.loadAllSlots() ?? []
+    let peerSlots = destinationSlots.filter {
+      $0.slotOwnerIdentifier != excludingSourceOwnerIdentifier
+        && $0.slotOwnerIdentifier != destinationOwnerIdentifier
+    }
+    let shouldPublishDestinationSlot = destinationSlotStore != nil
+      && peerSlots.isEmpty
+    let destinationEvent = try shouldPublishDestinationSlot
+      ? makeDestinationEvent(
+        identity: identity,
+        slots: destinationSlots,
+        pendingPublication: previousDestinationRecord?.pendingPublication,
+        ownerIdentifier: destinationOwnerIdentifier
+      )
+      : nil
+
+    let rollback = Rollback(
+      destinationIdentityStore: destinationIdentityStore,
+      previousDestinationRecord: previousDestinationRecord,
+      destinationSlotStore: destinationSlotStore,
+      previousDestinationSlot: previousDestinationSlot,
+      publishedDestinationSlot: shouldPublishDestinationSlot
+    )
+
+    do {
+      try persist(
+        PersistenceContext(
+          identity: identity,
+          event: destinationEvent,
+          instanceFingerprint: destinationInstanceFingerprint,
+          previousRecord: previousDestinationRecord
+        ),
+        identityStore: destinationIdentityStore,
+        slotStore: destinationSlotStore
+      )
+      return rollback
+    } catch SharedSessionTopologyMigrationError.destinationIdentityChanged {
+      throw SharedSessionTopologyMigrationError.destinationIdentityChanged
+    } catch {
+      do {
+        try rollback.restore()
+      } catch let rollbackError {
+        ClerkLogger.logError(
+          rollbackError,
+          message: "Failed to roll back shared-session topology preparation"
+        )
+      }
+      throw error
+    }
+  }
+
+  private static func makeDestinationEvent(
+    identity: ClerkIdentitySnapshot,
+    slots: [SharedSessionOwnerSlot],
+    pendingPublication: SharedSessionIdentityEvent?,
+    ownerIdentifier: String?
+  ) throws -> SharedSessionIdentityEvent {
+    guard let ownerIdentifier else {
+      throw ClerkClientError(message: "Shared-session topology migration is missing destination slot identity.")
+    }
+    return try SharedSessionIdentityEvent(
+      id: UUID(),
+      originOwnerIdentifier: ownerIdentifier,
+      generation: SharedSessionIdentityEvent.nextGeneration(
+        after: max(
+          SharedSessionIdentityReducer.reduce(slots).maximumGeneration,
+          pendingPublication?.generation ?? 0
+        )
+      ),
+      state: identity.state,
+      deviceToken: identity.deviceToken,
+      client: identity.client,
+      serverDate: identity.serverDate
+    ).validated()
+  }
+
+  private static func persist(
+    _ context: PersistenceContext,
+    identityStore: any SharedSessionLocalIdentityStoring,
+    slotStore: (any SharedSessionSlotStoring)?
+  ) throws {
+    guard let event = context.event else {
+      try identityStore.updateRecord { record in
+        guard record == context.previousRecord else {
+          throw SharedSessionTopologyMigrationError.destinationIdentityChanged
+        }
+        return SharedSessionLocalIdentityRecord(
+          acceptedIdentity: context.identity,
+          pendingPublication: nil
+        )
+      }
+      return
+    }
+    guard let slotStore, let instanceFingerprint = context.instanceFingerprint else {
+      throw ClerkClientError(message: "Shared-session topology migration is missing destination slot identity.")
+    }
+    try identityStore.updateRecord { record in
+      guard record == context.previousRecord else {
+        throw SharedSessionTopologyMigrationError.destinationIdentityChanged
+      }
+      return SharedSessionLocalIdentityRecord(
+        acceptedIdentity: record?.acceptedIdentity,
+        pendingPublication: event
+      )
+    }
+    try slotStore.saveOwnSlot(
+      SharedSessionOwnerSlot(
+        schemaVersion: SharedSessionOwnerSlot.schemaVersion,
+        instanceFingerprint: instanceFingerprint,
+        slotOwnerIdentifier: event.originOwnerIdentifier,
+        event: event
+      )
+    )
+    try identityStore.commitAcceptedIdentity(
+      context.identity,
+      clearingPendingPublicationID: event.id
+    )
+  }
+}

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionTopologyMigration.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionTopologyMigration.swift
@@ -7,39 +7,85 @@ import Foundation
 
 enum SharedSessionTopologyMigrationError: Error, Equatable {
   case destinationIdentityChanged
+  case destinationSlotChanged
 }
 
 enum SharedSessionTopologyMigration {
   private struct PersistenceContext {
     let identity: ClerkIdentitySnapshot
     let event: SharedSessionIdentityEvent?
-    let instanceFingerprint: String?
     let previousRecord: SharedSessionLocalIdentityRecord?
+  }
+
+  private struct DestinationTopology {
+    let hasSlotStore: Bool
+    let instanceFingerprint: String?
+    let ownerIdentifier: String?
+    let excludedOwnerIdentifier: String?
+  }
+
+  private struct PreparedDestination {
+    let event: SharedSessionIdentityEvent?
+    let slot: SharedSessionOwnerSlot?
+    let migratedRecord: SharedSessionLocalIdentityRecord
+    let stagedRecord: SharedSessionLocalIdentityRecord?
   }
 
   struct Rollback {
     let destinationIdentityStore: any SharedSessionLocalIdentityStoring
     let previousDestinationRecord: SharedSessionLocalIdentityRecord?
+    let migratedDestinationRecord: SharedSessionLocalIdentityRecord
     let destinationSlotStore: (any SharedSessionSlotStoring)?
     let previousDestinationSlot: SharedSessionOwnerSlot?
-    let publishedDestinationSlot: Bool
+    let publishedDestinationSlot: SharedSessionOwnerSlot?
 
     func restore() throws {
+      try restore(
+        whenIdentityMatches: [migratedDestinationRecord],
+        abortOnSlotConflict: true
+      )
+    }
+
+    fileprivate func restoreAfterPreparationFailure(
+      stagedDestinationRecord: SharedSessionLocalIdentityRecord?
+    ) throws {
+      try restore(
+        whenIdentityMatches: [
+          stagedDestinationRecord,
+          migratedDestinationRecord,
+        ].compactMap { $0 },
+        abortOnSlotConflict: false
+      )
+    }
+
+    private func restore(
+      whenIdentityMatches ownedDestinationRecords: [SharedSessionLocalIdentityRecord],
+      abortOnSlotConflict: Bool
+    ) throws {
       var firstError: (any Error)?
-      if publishedDestinationSlot, let destinationSlotStore {
+      if let publishedDestinationSlot, let destinationSlotStore {
         do {
-          if let previousDestinationSlot {
-            try destinationSlotStore.saveOwnSlot(previousDestinationSlot)
-          } else {
-            try destinationSlotStore.deleteOwnSlot()
+          guard try destinationSlotStore.restoreOwnSlot(
+            previousDestinationSlot,
+            ifCurrentMatchesPublication: publishedDestinationSlot
+          ) else {
+            throw SharedSessionTopologyMigrationError.destinationSlotChanged
           }
+        } catch let error as SharedSessionTopologyMigrationError {
+          if abortOnSlotConflict {
+            throw error
+          }
+          firstError = error
         } catch {
           firstError = error
         }
       }
       do {
-        try destinationIdentityStore.updateRecord { _ in
-          previousDestinationRecord
+        try destinationIdentityStore.updateRecord { record in
+          guard ownedDestinationRecords.contains(where: { record == $0 }) else {
+            throw SharedSessionTopologyMigrationError.destinationIdentityChanged
+          }
+          return previousDestinationRecord
         }
       } catch {
         firstError = firstError ?? error
@@ -62,46 +108,46 @@ enum SharedSessionTopologyMigration {
     let previousDestinationRecord = try destinationIdentityStore.loadRecord()
     let previousDestinationSlot = try destinationSlotStore?.loadOwnSlot()
     let destinationSlots = try destinationSlotStore?.loadAllSlots() ?? []
-    let peerSlots = destinationSlots.filter {
-      $0.slotOwnerIdentifier != excludingSourceOwnerIdentifier
-        && $0.slotOwnerIdentifier != destinationOwnerIdentifier
-    }
-    let shouldPublishDestinationSlot = destinationSlotStore != nil
-      && peerSlots.isEmpty
-    let destinationEvent = try shouldPublishDestinationSlot
-      ? makeDestinationEvent(
-        identity: identity,
-        slots: destinationSlots,
-        pendingPublication: previousDestinationRecord?.pendingPublication,
-        ownerIdentifier: destinationOwnerIdentifier
+    let destination = try makePreparedDestination(
+      identity: identity,
+      previousRecord: previousDestinationRecord,
+      slots: destinationSlots,
+      topology: DestinationTopology(
+        hasSlotStore: destinationSlotStore != nil,
+        instanceFingerprint: destinationInstanceFingerprint,
+        ownerIdentifier: destinationOwnerIdentifier,
+        excludedOwnerIdentifier: excludingSourceOwnerIdentifier
       )
-      : nil
+    )
 
     let rollback = Rollback(
       destinationIdentityStore: destinationIdentityStore,
       previousDestinationRecord: previousDestinationRecord,
+      migratedDestinationRecord: destination.migratedRecord,
       destinationSlotStore: destinationSlotStore,
       previousDestinationSlot: previousDestinationSlot,
-      publishedDestinationSlot: shouldPublishDestinationSlot
+      publishedDestinationSlot: destination.slot
     )
 
     do {
       try persist(
         PersistenceContext(
           identity: identity,
-          event: destinationEvent,
-          instanceFingerprint: destinationInstanceFingerprint,
+          event: destination.event,
           previousRecord: previousDestinationRecord
         ),
         identityStore: destinationIdentityStore,
-        slotStore: destinationSlotStore
+        slotStore: destinationSlotStore,
+        destinationSlot: destination.slot
       )
       return rollback
     } catch SharedSessionTopologyMigrationError.destinationIdentityChanged {
       throw SharedSessionTopologyMigrationError.destinationIdentityChanged
     } catch {
       do {
-        try rollback.restore()
+        try rollback.restoreAfterPreparationFailure(
+          stagedDestinationRecord: destination.stagedRecord
+        )
       } catch let rollbackError {
         ClerkLogger.logError(
           rollbackError,
@@ -110,6 +156,59 @@ enum SharedSessionTopologyMigration {
       }
       throw error
     }
+  }
+
+  private static func makePreparedDestination(
+    identity: ClerkIdentitySnapshot,
+    previousRecord: SharedSessionLocalIdentityRecord?,
+    slots: [SharedSessionOwnerSlot],
+    topology: DestinationTopology
+  ) throws -> PreparedDestination {
+    let hasPeerSlot = slots.contains {
+      $0.slotOwnerIdentifier != topology.excludedOwnerIdentifier
+        && $0.slotOwnerIdentifier != topology.ownerIdentifier
+    }
+    let event = try topology.hasSlotStore && !hasPeerSlot
+      ? makeDestinationEvent(
+        identity: identity,
+        slots: slots,
+        pendingPublication: previousRecord?.pendingPublication,
+        ownerIdentifier: topology.ownerIdentifier
+      )
+      : nil
+    return try PreparedDestination(
+      event: event,
+      slot: makeDestinationSlot(
+        event: event,
+        instanceFingerprint: topology.instanceFingerprint
+      ),
+      migratedRecord: SharedSessionLocalIdentityRecord(
+        acceptedIdentity: identity,
+        pendingPublication: nil
+      ),
+      stagedRecord: event.map {
+        SharedSessionLocalIdentityRecord(
+          acceptedIdentity: previousRecord?.acceptedIdentity,
+          pendingPublication: $0
+        )
+      }
+    )
+  }
+
+  private static func makeDestinationSlot(
+    event: SharedSessionIdentityEvent?,
+    instanceFingerprint: String?
+  ) throws -> SharedSessionOwnerSlot? {
+    guard let event else { return nil }
+    guard let instanceFingerprint else {
+      throw ClerkClientError(message: "Shared-session topology migration is missing destination slot identity.")
+    }
+    return SharedSessionOwnerSlot(
+      schemaVersion: SharedSessionOwnerSlot.schemaVersion,
+      instanceFingerprint: instanceFingerprint,
+      slotOwnerIdentifier: event.originOwnerIdentifier,
+      event: event
+    )
   }
 
   private static func makeDestinationEvent(
@@ -140,7 +239,8 @@ enum SharedSessionTopologyMigration {
   private static func persist(
     _ context: PersistenceContext,
     identityStore: any SharedSessionLocalIdentityStoring,
-    slotStore: (any SharedSessionSlotStoring)?
+    slotStore: (any SharedSessionSlotStoring)?,
+    destinationSlot: SharedSessionOwnerSlot?
   ) throws {
     guard let event = context.event else {
       try identityStore.updateRecord { record in
@@ -154,7 +254,7 @@ enum SharedSessionTopologyMigration {
       }
       return
     }
-    guard let slotStore, let instanceFingerprint = context.instanceFingerprint else {
+    guard let slotStore, let destinationSlot else {
       throw ClerkClientError(message: "Shared-session topology migration is missing destination slot identity.")
     }
     try identityStore.updateRecord { record in
@@ -166,14 +266,7 @@ enum SharedSessionTopologyMigration {
         pendingPublication: event
       )
     }
-    try slotStore.saveOwnSlot(
-      SharedSessionOwnerSlot(
-        schemaVersion: SharedSessionOwnerSlot.schemaVersion,
-        instanceFingerprint: instanceFingerprint,
-        slotOwnerIdentifier: event.originOwnerIdentifier,
-        event: event
-      )
-    )
+    try slotStore.saveOwnSlot(destinationSlot)
     try identityStore.commitAcceptedIdentity(
       context.identity,
       clearingPendingPublicationID: event.id

--- a/Sources/ClerkKit/SharedSessionSync/SharedSessionTopologyMigration.swift
+++ b/Sources/ClerkKit/SharedSessionSync/SharedSessionTopologyMigration.swift
@@ -10,6 +10,10 @@ enum SharedSessionTopologyMigrationError: Error, Equatable {
   case destinationSlotChanged
 }
 
+private enum TopologyMigrationPreparationError: Error {
+  case destinationChangedBeforeWrite
+}
+
 enum SharedSessionTopologyMigration {
   private struct PersistenceContext {
     let identity: ClerkIdentitySnapshot
@@ -141,7 +145,7 @@ enum SharedSessionTopologyMigration {
         destinationSlot: destination.slot
       )
       return rollback
-    } catch SharedSessionTopologyMigrationError.destinationIdentityChanged {
+    } catch TopologyMigrationPreparationError.destinationChangedBeforeWrite {
       throw SharedSessionTopologyMigrationError.destinationIdentityChanged
     } catch {
       do {
@@ -245,7 +249,7 @@ enum SharedSessionTopologyMigration {
     guard let event = context.event else {
       try identityStore.updateRecord { record in
         guard record == context.previousRecord else {
-          throw SharedSessionTopologyMigrationError.destinationIdentityChanged
+          throw TopologyMigrationPreparationError.destinationChangedBeforeWrite
         }
         return SharedSessionLocalIdentityRecord(
           acceptedIdentity: context.identity,
@@ -259,7 +263,7 @@ enum SharedSessionTopologyMigration {
     }
     try identityStore.updateRecord { record in
       guard record == context.previousRecord else {
-        throw SharedSessionTopologyMigrationError.destinationIdentityChanged
+        throw TopologyMigrationPreparationError.destinationChangedBeforeWrite
       }
       return SharedSessionLocalIdentityRecord(
         acceptedIdentity: record?.acceptedIdentity,

--- a/Sources/ClerkKit/Storage/CacheManager.swift
+++ b/Sources/ClerkKit/Storage/CacheManager.swift
@@ -140,6 +140,9 @@ protocol CacheCoordinator: AnyObject, Sendable {
   ///   - serverFetchDate: The server timestamp persisted with this cached client.
   @MainActor func setClientIfNeeded(_ client: Client?, serverFetchDate: Date?)
 
+  /// Sets a legacy client for launch presentation without making it request identity.
+  @MainActor func setProvisionalClientIfNeeded(_ client: Client?)
+
   /// Sets the server fetch date if one is not already set and no client exists.
   @MainActor func setServerFetchDateIfNeeded(_ date: Date)
 
@@ -232,8 +235,7 @@ final class CacheManager {
       for keychain in provisionalClientKeychains {
         guard try loadDeviceTokenFromKeychain(keychain) != nil else { continue }
         guard let cachedClient = try loadClientFromKeychain(keychain) else { continue }
-        let serverFetchDate = try loadClientServerFetchDateFromKeychain(keychain)
-        coordinator?.setClientIfNeeded(cachedClient, serverFetchDate: serverFetchDate)
+        coordinator?.setProvisionalClientIfNeeded(cachedClient)
         return
       }
     } catch {

--- a/Sources/ClerkKit/Storage/Keychain/Clerk+Keychain.swift
+++ b/Sources/ClerkKit/Storage/Keychain/Clerk+Keychain.swift
@@ -38,6 +38,27 @@ extension Clerk {
     let loggingConfiguration: ClerkLogger.Configuration
   }
 
+  private static func attemptKeychainClear(
+    _ operation: String,
+    recording failures: inout [String],
+    logMessage: String? = nil,
+    configuration: ClerkLogger.Configuration,
+    perform: () throws -> Void
+  ) {
+    do {
+      try perform()
+    } catch {
+      if let logMessage {
+        ClerkLogger.logError(
+          error,
+          message: logMessage,
+          configuration: configuration
+        )
+      }
+      failures.append(operation)
+    }
+  }
+
   private static let legacySharedCredentialKeys: [ClerkKeychainKey] = [
     .cachedClient,
     .cachedClientServerDate,
@@ -108,7 +129,6 @@ extension Clerk {
       return keychainClearTask
     }
 
-    let taskID = UUID()
     let pendingClear = beginKeychainClear(for: clerk)
     let task = Task { @MainActor in
       let result: Result<Void, any Error>
@@ -123,14 +143,9 @@ extension Clerk {
         )
         result = .failure(error)
       }
-      guard clerk.keychainClearTaskID == taskID else {
-        return try result.get()
-      }
       clerk.keychainClearTask = nil
-      clerk.keychainClearTaskID = nil
       return try result.get()
     }
-    clerk.keychainClearTaskID = taskID
     clerk.keychainClearTask = task
     return task
   }
@@ -145,31 +160,27 @@ extension Clerk {
     let usesAtomicLocalIdentity = identityClear.usesAtomicLocalPersistence
     var initialFailedOperations: [String] = []
     if usesAtomicLocalIdentity {
-      do {
+      attemptKeychainClear(
+        "preserve Watch clear watermark",
+        recording: &initialFailedOperations,
+        logMessage: "Failed to preserve the Watch clear watermark",
+        configuration: loggingConfiguration
+      ) {
         _ = try WatchSyncMetadataStore(keychain: dependencies.watchSyncKeychain)
           .saveClearTombstone()
-      } catch {
-        ClerkLogger.logError(
-          error,
-          message: "Failed to preserve the Watch clear watermark",
-          configuration: loggingConfiguration
-        )
-        initialFailedOperations.append("preserve Watch clear watermark")
       }
     }
     clerk.identityController.applyStorageClearToMemory(identityClear)
     if let atomicIdentityStore = dependencies.atomicIdentityStore {
-      do {
+      attemptKeychainClear(
+        "delete atomic identity",
+        recording: &initialFailedOperations,
+        logMessage: "Failed to synchronously delete Clerk's atomic identity",
+        configuration: loggingConfiguration
+      ) {
         try atomicIdentityStore.deleteInvalidatingOperations(
           through: identityClear.invalidatedThroughRevision
         )
-      } catch {
-        ClerkLogger.logError(
-          error,
-          message: "Failed to synchronously delete Clerk's atomic identity",
-          configuration: loggingConfiguration
-        )
-        initialFailedOperations.append("delete atomic identity")
       }
     }
     let preservedKeys: Set<ClerkKeychainKey> = usesAtomicLocalIdentity
@@ -235,32 +246,38 @@ extension Clerk {
       }
 
       await cacheManager?.drainFrozenPersistence()
-      do {
+      attemptKeychainClear(
+        "clear app-local Keychain",
+        recording: &failedOperations,
+        configuration: loggingConfiguration
+      ) {
         try clearAllKeychainItemsStrictly(
           in: dependencies.appLocalKeychain,
           preserving: preservedKeys,
           configuration: loggingConfiguration
         )
-      } catch {
-        failedOperations.append("clear app-local Keychain")
       }
-      do {
+      attemptKeychainClear(
+        "clear identity Keychain",
+        recording: &failedOperations,
+        configuration: loggingConfiguration
+      ) {
         try clearAllKeychainItemsStrictly(
           in: dependencies.identityKeychain,
           preserving: preservedKeys,
           configuration: loggingConfiguration
         )
-      } catch {
-        failedOperations.append("clear identity Keychain")
       }
-      do {
+      attemptKeychainClear(
+        "clear legacy shared credentials",
+        recording: &failedOperations,
+        configuration: loggingConfiguration
+      ) {
         try clearKeychainItemsStrictly(
           legacySharedCredentialKeys,
           in: dependencies.keychain,
           configuration: loggingConfiguration
         )
-      } catch {
-        failedOperations.append("clear legacy shared credentials")
       }
 
       if let localIdentityIO = dependencies.atomicIdentityIO {

--- a/Sources/ClerkKit/Storage/Keychain/Clerk+Keychain.swift
+++ b/Sources/ClerkKit/Storage/Keychain/Clerk+Keychain.swift
@@ -8,24 +8,65 @@
 import Foundation
 
 extension Clerk {
+  private enum KeychainClearOperation: Equatable {
+    case persistOwnerSlotWithdrawalIntent
+    case preserveWatchClearWatermark
+    case deleteAtomicIdentity
+    case withdrawSharedSessionOwnerSlot
+    case clearOwnerSlotWithdrawalIntent
+    case clearAppLocalKeychain
+    case clearIdentityKeychain
+    case clearLegacySharedCredentials
+    case keychainItem(String)
+
+    var description: String {
+      switch self {
+      case .persistOwnerSlotWithdrawalIntent:
+        "persist owner-slot withdrawal intent"
+      case .preserveWatchClearWatermark:
+        "preserve Watch clear watermark"
+      case .deleteAtomicIdentity:
+        "delete atomic identity"
+      case .withdrawSharedSessionOwnerSlot:
+        "withdraw shared-session owner slot"
+      case .clearOwnerSlotWithdrawalIntent:
+        "clear owner-slot withdrawal intent"
+      case .clearAppLocalKeychain:
+        "clear app-local Keychain"
+      case .clearIdentityKeychain:
+        "clear identity Keychain"
+      case .clearLegacySharedCredentials:
+        "clear legacy shared credentials"
+      case .keychainItem(let key):
+        key
+      }
+    }
+  }
+
   private struct KeychainClearError: LocalizedError {
-    let failedOperations: [String]
-    let sharedTransportWithdrawn: Bool
+    let failedOperations: [KeychainClearOperation]
+    let canReleaseSharedClearBarrier: Bool
 
     init(
-      failedOperations: [String],
-      sharedTransportWithdrawn: Bool = false
+      failedOperations: [KeychainClearOperation],
+      canReleaseSharedClearBarrier: Bool = false
     ) {
       self.failedOperations = failedOperations
-      self.sharedTransportWithdrawn = sharedTransportWithdrawn
+      self.canReleaseSharedClearBarrier = canReleaseSharedClearBarrier
     }
 
     var errorDescription: String? {
-      "Unable to complete Clerk Keychain clear: \(failedOperations.joined(separator: ", "))."
+      let descriptions = failedOperations.map(\.description)
+      return "Unable to complete Clerk Keychain clear: \(descriptions.joined(separator: ", "))."
     }
   }
 
   private struct KeychainClearResult {
+    let canReleaseSharedClearBarrier: Bool
+  }
+
+  private struct OwnerSlotWithdrawalResult {
+    let failedOperations: [KeychainClearOperation]
     let sharedTransportWithdrawn: Bool
   }
 
@@ -38,11 +79,9 @@ extension Clerk {
     let loggingConfiguration: ClerkLogger.Configuration
   }
 
-  private static let atomicIdentityDeletionOperation = "delete atomic identity"
-
   private static func attemptKeychainClear(
-    _ operation: String,
-    recording failures: inout [String],
+    _ operation: KeychainClearOperation,
+    recording failures: inout [KeychainClearOperation],
     logMessage: String? = nil,
     configuration: ClerkLogger.Configuration,
     perform: () throws -> Void
@@ -85,8 +124,10 @@ extension Clerk {
   /// Clerk retains the non-secret shared-session adoption marker so disabling sync cannot
   /// resurrect legacy shared credentials. After atomic shared-session adoption, Clerk also
   /// retains Watch ordering metadata containing only transition state, versions, and
-  /// fingerprints so a stale Watch payload cannot restore cleared authentication. These
-  /// coordination records do not contain a reusable device token, Client, or Environment.
+  /// fingerprints so a stale Watch payload cannot restore cleared authentication. While an
+  /// owner slot is being withdrawn, Clerk retains a durable recovery intent so an interrupted
+  /// clear is completed before the next configuration hydrates identity. These coordination
+  /// records do not contain a reusable device token, Client, or Environment.
   ///
   /// This source-compatible method starts a best-effort asynchronous clear and returns after
   /// synchronously clearing the legacy keys it can safely reach. Use
@@ -131,7 +172,23 @@ extension Clerk {
       return keychainClearTask
     }
 
-    let pendingClear = beginKeychainClear(for: clerk)
+    let pendingClear: PendingKeychainClear
+    do {
+      pendingClear = try beginKeychainClear(for: clerk)
+    } catch {
+      let loggingConfiguration = ClerkLogger.Configuration(options: clerk.options)
+      let task = Task<Void, Error> { @MainActor in
+        ClerkLogger.logError(
+          error,
+          message: "Failed to clear all Clerk Keychain items",
+          configuration: loggingConfiguration
+        )
+        clerk.keychainClearTask = nil
+        throw error
+      }
+      clerk.keychainClearTask = task
+      return task
+    }
     let task = Task { @MainActor in
       let result: Result<Void, any Error>
       do {
@@ -153,17 +210,29 @@ extension Clerk {
   }
 
   @MainActor
-  private static func beginKeychainClear(for clerk: Clerk) -> PendingKeychainClear {
+  private static func beginKeychainClear(for clerk: Clerk) throws -> PendingKeychainClear {
     let dependencies = clerk.dependencies
     let loggingConfiguration = ClerkLogger.Configuration(options: clerk.options)
+    if clerk.sharedSessionSyncCoordinator != nil {
+      do {
+        guard let context = dependencies.sharedSessionOwnerSlotClearRecovery else {
+          throw SharedSessionOwnerSlotClearRecoveryError.missingCurrentTopology
+        }
+        try SharedSessionOwnerSlotClearRecovery.markPending(in: context)
+      } catch {
+        throw KeychainClearError(
+          failedOperations: [.persistOwnerSlotWithdrawalIntent]
+        )
+      }
+    }
     let cacheManager = clerk.cacheManager
     cacheManager?.freezePersistence()
     let identityClear = clerk.identityController.beginStorageClear()
     let usesAtomicLocalIdentity = identityClear.usesAtomicLocalPersistence
-    var initialFailedOperations: [String] = []
+    var initialFailedOperations: [KeychainClearOperation] = []
     if usesAtomicLocalIdentity {
       attemptKeychainClear(
-        "preserve Watch clear watermark",
+        .preserveWatchClearWatermark,
         recording: &initialFailedOperations,
         logMessage: "Failed to preserve the Watch clear watermark",
         configuration: loggingConfiguration
@@ -175,7 +244,7 @@ extension Clerk {
     clerk.identityController.applyStorageClearToMemory(identityClear)
     if let atomicIdentityStore = dependencies.atomicIdentityStore {
       attemptKeychainClear(
-        atomicIdentityDeletionOperation,
+        .deleteAtomicIdentity,
         recording: &initialFailedOperations,
         logMessage: "Failed to synchronously delete Clerk's atomic identity",
         configuration: loggingConfiguration
@@ -185,9 +254,10 @@ extension Clerk {
         )
       }
     }
-    let preservedKeys: Set<ClerkKeychainKey> = usesAtomicLocalIdentity
-      ? [.sharedSessionSyncAdopted, .watchSyncMetadata]
-      : [.sharedSessionSyncAdopted]
+    var preservedKeys: Set<ClerkKeychainKey> = [.sharedSessionSyncAdopted]
+    if usesAtomicLocalIdentity {
+      preservedKeys.insert(.watchSyncMetadata)
+    }
     clearAllKeychainItems(
       in: dependencies.appLocalKeychain,
       preserving: preservedKeys,
@@ -229,27 +299,23 @@ extension Clerk {
     identityClear: ClerkIdentityController.StorageClearContext,
     cacheManager: CacheManager?,
     preservedKeys: Set<ClerkKeychainKey>,
-    initialFailedOperations: [String],
+    initialFailedOperations: [KeychainClearOperation],
     loggingConfiguration: ClerkLogger.Configuration
   ) -> Task<KeychainClearResult, Error> {
     clerk.identityController.enqueueLocalOperation { operationRevision in
-      var failedOperations = initialFailedOperations
-      var sharedTransportWithdrawn = false
-      do {
-        sharedTransportWithdrawn = try await clerk.identityController
-          .deleteCapturedOwnerSlotAfterStorageClear(identityClear)
-      } catch {
-        ClerkLogger.logError(
-          error,
-          message: "Failed to withdraw Clerk's shared-session owner slot",
-          configuration: loggingConfiguration
-        )
-        failedOperations.append("withdraw shared-session owner slot")
-      }
+      let withdrawalResult = await withdrawOwnerSlotIfNeeded(
+        clerk: clerk,
+        identityClear: identityClear,
+        initialFailedOperations: initialFailedOperations,
+        loggingConfiguration: loggingConfiguration
+      )
+      var failedOperations = withdrawalResult.failedOperations
+      var atomicIdentityDeleted = !identityClear.usesAtomicLocalPersistence
+        || !failedOperations.contains(.deleteAtomicIdentity)
 
       await cacheManager?.drainFrozenPersistence()
       attemptKeychainClear(
-        "clear app-local Keychain",
+        .clearAppLocalKeychain,
         recording: &failedOperations,
         configuration: loggingConfiguration
       ) {
@@ -260,7 +326,7 @@ extension Clerk {
         )
       }
       attemptKeychainClear(
-        "clear identity Keychain",
+        .clearIdentityKeychain,
         recording: &failedOperations,
         configuration: loggingConfiguration
       ) {
@@ -271,7 +337,7 @@ extension Clerk {
         )
       }
       attemptKeychainClear(
-        "clear legacy shared credentials",
+        .clearLegacySharedCredentials,
         recording: &failedOperations,
         configuration: loggingConfiguration
       ) {
@@ -288,8 +354,9 @@ extension Clerk {
             operationRevision: operationRevision
           )
           if didDelete {
+            atomicIdentityDeleted = true
             failedOperations.removeAll {
-              $0 == atomicIdentityDeletionOperation
+              $0 == .deleteAtomicIdentity
             }
           }
         } catch {
@@ -298,42 +365,120 @@ extension Clerk {
             message: "Failed to delete Clerk's atomic identity",
             configuration: loggingConfiguration
           )
-          if !failedOperations.contains(atomicIdentityDeletionOperation) {
-            failedOperations.append(atomicIdentityDeletionOperation)
+          if !failedOperations.contains(.deleteAtomicIdentity) {
+            failedOperations.append(.deleteAtomicIdentity)
           }
         }
+      }
+
+      let canReleaseSharedClearBarrier: Bool
+      do {
+        canReleaseSharedClearBarrier = try clearOwnerSlotWithdrawalIntentIfSafe(
+          in: dependencies,
+          identityClear: identityClear,
+          sharedTransportWithdrawn: withdrawalResult.sharedTransportWithdrawn,
+          atomicIdentityDeleted: atomicIdentityDeleted
+        )
+      } catch {
+        ClerkLogger.logError(
+          error,
+          message: "Failed to clear Clerk's shared-session owner-slot withdrawal intent",
+          configuration: loggingConfiguration
+        )
+        failedOperations.append(.clearOwnerSlotWithdrawalIntent)
+        canReleaseSharedClearBarrier = false
       }
 
       guard failedOperations.isEmpty else {
         throw KeychainClearError(
           failedOperations: failedOperations,
-          sharedTransportWithdrawn: sharedTransportWithdrawn
+          canReleaseSharedClearBarrier: canReleaseSharedClearBarrier
         )
       }
       return KeychainClearResult(
-        sharedTransportWithdrawn: sharedTransportWithdrawn
+        canReleaseSharedClearBarrier: canReleaseSharedClearBarrier
       )
     }
   }
 
   @MainActor
+  private static func withdrawOwnerSlotIfNeeded(
+    clerk: Clerk,
+    identityClear: ClerkIdentityController.StorageClearContext,
+    initialFailedOperations: [KeychainClearOperation],
+    loggingConfiguration: ClerkLogger.Configuration
+  ) async -> OwnerSlotWithdrawalResult {
+    var failedOperations = initialFailedOperations
+    guard identityClear.requiresOwnerSlotWithdrawal else {
+      return OwnerSlotWithdrawalResult(
+        failedOperations: failedOperations,
+        sharedTransportWithdrawn: true
+      )
+    }
+
+    let sharedTransportWithdrawn: Bool
+    do {
+      sharedTransportWithdrawn = try await clerk.identityController
+        .deleteCapturedOwnerSlotAfterStorageClear(identityClear)
+    } catch {
+      ClerkLogger.logError(
+        error,
+        message: "Failed to withdraw Clerk's shared-session owner slot",
+        configuration: loggingConfiguration
+      )
+      failedOperations.append(.withdrawSharedSessionOwnerSlot)
+      return OwnerSlotWithdrawalResult(
+        failedOperations: failedOperations,
+        sharedTransportWithdrawn: false
+      )
+    }
+
+    return OwnerSlotWithdrawalResult(
+      failedOperations: failedOperations,
+      sharedTransportWithdrawn: sharedTransportWithdrawn
+    )
+  }
+
+  @MainActor
+  private static func clearOwnerSlotWithdrawalIntentIfSafe(
+    in dependencies: any Dependencies,
+    identityClear: ClerkIdentityController.StorageClearContext,
+    sharedTransportWithdrawn: Bool,
+    atomicIdentityDeleted: Bool
+  ) throws -> Bool {
+    guard identityClear.requiresOwnerSlotWithdrawal else { return true }
+    guard sharedTransportWithdrawn, atomicIdentityDeleted else { return false }
+
+    guard let context = dependencies.sharedSessionOwnerSlotClearRecovery,
+          let intent = context.currentIntent
+    else {
+      throw SharedSessionOwnerSlotClearRecoveryError.missingCurrentTopology
+    }
+    try SharedSessionOwnerSlotClearRecovery.clearPendingIntent(
+      matching: intent,
+      in: context
+    )
+    return true
+  }
+
+  @MainActor
   private static func finishKeychainClear(_ pendingClear: PendingKeychainClear) async throws {
     let result: Result<Void, any Error>
-    let sharedTransportWithdrawn: Bool
+    let canReleaseSharedClearBarrier: Bool
     do {
       let clearResult = try await pendingClear.clearOperation.value
       result = .success(())
-      sharedTransportWithdrawn = clearResult.sharedTransportWithdrawn
+      canReleaseSharedClearBarrier = clearResult.canReleaseSharedClearBarrier
     } catch let error as KeychainClearError {
       result = .failure(error)
-      sharedTransportWithdrawn = error.sharedTransportWithdrawn
+      canReleaseSharedClearBarrier = error.canReleaseSharedClearBarrier
     } catch {
       result = .failure(error)
-      sharedTransportWithdrawn = false
+      canReleaseSharedClearBarrier = false
     }
     pendingClear.clerk.identityController.finishStorageClear(
       pendingClear.identityClear,
-      sharedTransportWithdrawn: sharedTransportWithdrawn
+      canReleaseSharedClearBarrier: canReleaseSharedClearBarrier
     )
     if pendingClear.clerk.dependencies === pendingClear.dependencies,
        pendingClear.clerk.cacheManager === pendingClear.cacheManager
@@ -389,12 +534,12 @@ extension Clerk {
     in keychain: any KeychainStorage,
     configuration: ClerkLogger.Configuration? = nil
   ) throws {
-    var failures: [String] = []
+    var failures: [KeychainClearOperation] = []
     for key in keys {
       do {
         try keychain.deleteItem(forKey: key.rawValue)
       } catch {
-        failures.append(key.rawValue)
+        failures.append(.keychainItem(key.rawValue))
         ClerkLogger.logError(
           error,
           message: "Failed to delete legacy shared Keychain item '\(key.rawValue)'.",

--- a/Sources/ClerkKit/Storage/Keychain/Clerk+Keychain.swift
+++ b/Sources/ClerkKit/Storage/Keychain/Clerk+Keychain.swift
@@ -38,6 +38,8 @@ extension Clerk {
     let loggingConfiguration: ClerkLogger.Configuration
   }
 
+  private static let atomicIdentityDeletionOperation = "delete atomic identity"
+
   private static func attemptKeychainClear(
     _ operation: String,
     recording failures: inout [String],
@@ -173,7 +175,7 @@ extension Clerk {
     clerk.identityController.applyStorageClearToMemory(identityClear)
     if let atomicIdentityStore = dependencies.atomicIdentityStore {
       attemptKeychainClear(
-        "delete atomic identity",
+        atomicIdentityDeletionOperation,
         recording: &initialFailedOperations,
         logMessage: "Failed to synchronously delete Clerk's atomic identity",
         configuration: loggingConfiguration
@@ -282,14 +284,23 @@ extension Clerk {
 
       if let localIdentityIO = dependencies.atomicIdentityIO {
         do {
-          _ = try await localIdentityIO.delete(operationRevision: operationRevision)
+          let didDelete = try await localIdentityIO.delete(
+            operationRevision: operationRevision
+          )
+          if didDelete {
+            failedOperations.removeAll {
+              $0 == atomicIdentityDeletionOperation
+            }
+          }
         } catch {
           ClerkLogger.logError(
             error,
             message: "Failed to delete Clerk's atomic identity",
             configuration: loggingConfiguration
           )
-          failedOperations.append("delete atomic identity")
+          if !failedOperations.contains(atomicIdentityDeletionOperation) {
+            failedOperations.append(atomicIdentityDeletionOperation)
+          }
         }
       }
 

--- a/Sources/ClerkKit/Storage/Keychain/Clerk+Keychain.swift
+++ b/Sources/ClerkKit/Storage/Keychain/Clerk+Keychain.swift
@@ -171,6 +171,12 @@ extension Clerk {
     if let keychainClearTask = clerk.keychainClearTask {
       return keychainClearTask
     }
+    if runtimeReconfigurationIsInProgress {
+      return Task { @MainActor in
+        await waitForRuntimeReconfigurationIfNeeded()
+        try await startKeychainClearIfNeeded(for: clerk).value
+      }
+    }
 
     let pendingClear: PendingKeychainClear
     do {

--- a/Sources/ClerkKit/WatchSync/WatchConnectivityCoordinator+DeviceTokenUpdates.swift
+++ b/Sources/ClerkKit/WatchSync/WatchConnectivityCoordinator+DeviceTokenUpdates.swift
@@ -15,7 +15,8 @@ extension WatchConnectivityCoordinator {
     let resolvedVersion = try version ?? WatchSyncVersion(
       rawValue: record.effectiveDeviceTokenVersion
     ).next()
-    record.deviceTokenState = state
+    let deviceToken = deviceToken.nilIfEmpty
+    record.deviceTokenState = deviceToken == nil ? .cleared : state
     record.deviceTokenVersion = resolvedVersion.rawValue
     record.deviceTokenFingerprint = Self.deviceTokenFingerprint(deviceToken)
     record.deviceTokenSource = nil

--- a/Sources/ClerkKit/WatchSync/WatchConnectivityCoordinator+StatePersistence.swift
+++ b/Sources/ClerkKit/WatchSync/WatchConnectivityCoordinator+StatePersistence.swift
@@ -377,7 +377,8 @@ extension WatchConnectivityCoordinator {
     let store = WatchSyncMetadataStore(keychain: keychain)
     var record = try store.load()
     if let tokenVersion = intent.tokenVersion {
-      let fingerprint = Self.deviceTokenFingerprint(intent.deviceToken)
+      let deviceToken = intent.deviceToken.nilIfEmpty
+      let fingerprint = Self.deviceTokenFingerprint(deviceToken)
       resetAcceptedDeviceTokenWatermarkIfNeeded(
         in: &record,
         version: tokenVersion,
@@ -388,7 +389,7 @@ extension WatchConnectivityCoordinator {
       else {
         throw ClerkClientError(message: "Conflicting Watch token payload reused a pending version.")
       }
-      record.pendingDeviceTokenState = intent.deviceToken == nil ? .cleared : .set
+      record.pendingDeviceTokenState = deviceToken == nil ? .cleared : .set
       record.pendingDeviceTokenVersion = tokenVersion.rawValue
       record.pendingDeviceTokenFingerprint = fingerprint
       record.pendingDeviceTokenSource = intent.source
@@ -542,7 +543,8 @@ extension WatchConnectivityCoordinator {
   }
 
   static func deviceTokenFingerprint(_ deviceToken: String?) -> String {
-    fingerprint(Data((deviceToken.map { "set\u{0}\($0)" } ?? "cleared").utf8))
+    let deviceToken = deviceToken.nilIfEmpty
+    return fingerprint(Data((deviceToken.map { "set\u{0}\($0)" } ?? "cleared").utf8))
   }
 
   static func authFingerprint(client: Client?, serverDate: Date?) throws -> String {

--- a/Sources/ClerkKit/WatchSync/WatchConnectivityCoordinator.swift
+++ b/Sources/ClerkKit/WatchSync/WatchConnectivityCoordinator.swift
@@ -187,10 +187,9 @@ final class WatchConnectivityCoordinator: ClerkInternalStateChangeObserver {
     guard isAcceptingIdentityUpdates else { return }
 
     if let environment = payload.environment {
-      let wasApplyingRemotePayload = isApplyingRemotePayload
-      isApplyingRemotePayload = true
-      clerk.environment = environment
-      isApplyingRemotePayload = wasApplyingRemotePayload
+      withApplyingRemotePayload {
+        clerk.environment = environment
+      }
     }
 
     guard payload.deviceTokenUpdate != .notIncluded
@@ -226,13 +225,13 @@ extension WatchConnectivityCoordinator {
       return nil
     }
 
-    let currentToken = normalizedToken(clerk.deviceToken)
+    let currentToken = clerk.deviceToken.nilIfEmpty
     let deviceToken: String?
     switch payload.deviceTokenUpdate {
     case .notIncluded:
       deviceToken = clerk.deviceToken
     case .tokenSet(let token, _):
-      guard let token = normalizedToken(token) else { return nil }
+      guard let token = Optional(token).nilIfEmpty else { return nil }
       deviceToken = token
     case .tokenCleared:
       deviceToken = nil
@@ -263,7 +262,7 @@ extension WatchConnectivityCoordinator {
       }
     case .snapshot(let snapshot, let date, _):
       guard case .tokenSet(let pairedToken, _) = payload.deviceTokenUpdate,
-            normalizedToken(pairedToken) == deviceToken
+            Optional(pairedToken).nilIfEmpty == deviceToken
       else {
         scheduleRefresh(for: clerk)
         return nil
@@ -310,7 +309,7 @@ extension WatchConnectivityCoordinator {
   private func accepts(_ candidate: VersionAcceptance) -> Bool {
     guard candidate.updateIsIncluded else { return true }
     guard let version = candidate.version else {
-      return acceptsLegacyVersionlessUpdate(candidate)
+      return legacyVersionlessUpdateIsAccepted(candidate)
     }
     if let current = candidate.current {
       guard version >= current
@@ -332,13 +331,15 @@ extension WatchConnectivityCoordinator {
       return candidate.incomingFingerprint == candidate.durableFingerprint
     }
     if let current = candidate.current {
-      return candidate.source.incomingDeviceIsAuthoritative
-        || version > current
+      if version < current, candidate.allowsAuthoritativeVersionReset {
+        return true
+      }
+      return candidate.source.incomingDeviceIsAuthoritative || version > current
     }
     return true
   }
 
-  private func acceptsLegacyVersionlessUpdate(_ candidate: VersionAcceptance) -> Bool {
+  private func legacyVersionlessUpdateIsAccepted(_ candidate: VersionAcceptance) -> Bool {
     guard candidate.pendingVersion == nil else { return false }
     if candidate.acceptedVersion == nil, candidate.current == nil {
       return true
@@ -361,7 +362,7 @@ extension WatchConnectivityCoordinator {
     case .notIncluded:
       Self.deviceTokenFingerprint(clerk.deviceToken)
     case .tokenSet(let token, _):
-      Self.deviceTokenFingerprint(normalizedToken(token))
+      Self.deviceTokenFingerprint(Optional(token).nilIfEmpty)
     case .tokenCleared:
       Self.deviceTokenFingerprint(nil)
     }
@@ -409,7 +410,7 @@ extension WatchConnectivityCoordinator {
     case .notIncluded:
       Self.deviceTokenFingerprint(clerk.deviceToken)
     case .tokenSet(let token, _):
-      Self.deviceTokenFingerprint(normalizedToken(token))
+      Self.deviceTokenFingerprint(Optional(token).nilIfEmpty)
     case .tokenCleared:
       Self.deviceTokenFingerprint(nil)
     }
@@ -461,38 +462,34 @@ extension WatchConnectivityCoordinator {
         durableFingerprint: durableAuthFingerprint
       )
     )
-    guard accepts(
-      VersionAcceptance(
-        version: payload.deviceTokenUpdate.version,
-        updateIsIncluded: payload.deviceTokenUpdate != .notIncluded,
-        acceptedVersion: metadata.deviceTokenVersion.map(WatchSyncVersion.init(rawValue:)),
-        acceptedFingerprint: metadata.deviceTokenFingerprint,
-        pendingVersion: metadata.pendingDeviceTokenVersion.map(WatchSyncVersion.init(rawValue:)),
-        pendingFingerprint: metadata.pendingDeviceTokenFingerprint,
-        current: tokenCurrent,
-        allowsAuthoritativeVersionReset: allowsTokenAuthoritativeVersionReset,
-        incomingFingerprint: incomingTokenFingerprint,
-        durableFingerprint: durableTokenFingerprint,
-        source: source
-      )
-    ) else {
+    guard accepts(VersionAcceptance(
+      version: payload.deviceTokenUpdate.version,
+      updateIsIncluded: payload.deviceTokenUpdate != .notIncluded,
+      acceptedVersion: metadata.deviceTokenVersion.map(WatchSyncVersion.init(rawValue:)),
+      acceptedFingerprint: metadata.deviceTokenFingerprint,
+      pendingVersion: metadata.pendingDeviceTokenVersion.map(WatchSyncVersion.init(rawValue:)),
+      pendingFingerprint: metadata.pendingDeviceTokenFingerprint,
+      current: tokenCurrent,
+      allowsAuthoritativeVersionReset: allowsTokenAuthoritativeVersionReset,
+      incomingFingerprint: incomingTokenFingerprint,
+      durableFingerprint: durableTokenFingerprint,
+      source: source
+    )) else {
       return false
     }
-    guard accepts(
-      VersionAcceptance(
-        version: payload.clientUpdate.version,
-        updateIsIncluded: payload.clientUpdate != .notIncluded,
-        acceptedVersion: acceptedAuthVersion,
-        acceptedFingerprint: metadata.authFingerprint,
-        pendingVersion: metadata.pendingAuthVersion.map(WatchSyncVersion.init(rawValue:)),
-        pendingFingerprint: metadata.pendingAuthFingerprint,
-        current: authCurrent,
-        allowsAuthoritativeVersionReset: allowsAuthAuthoritativeVersionReset,
-        incomingFingerprint: incomingAuthFingerprint,
-        durableFingerprint: durableAuthFingerprint,
-        source: source
-      )
-    ) else {
+    guard accepts(VersionAcceptance(
+      version: payload.clientUpdate.version,
+      updateIsIncluded: payload.clientUpdate != .notIncluded,
+      acceptedVersion: acceptedAuthVersion,
+      acceptedFingerprint: metadata.authFingerprint,
+      pendingVersion: metadata.pendingAuthVersion.map(WatchSyncVersion.init(rawValue:)),
+      pendingFingerprint: metadata.pendingAuthFingerprint,
+      current: authCurrent,
+      allowsAuthoritativeVersionReset: allowsAuthAuthoritativeVersionReset,
+      incomingFingerprint: incomingAuthFingerprint,
+      durableFingerprint: durableAuthFingerprint,
+      source: source
+    )) else {
       scheduleRefreshForRejectedClientIfNeeded(
         payload.clientUpdate,
         source: source,
@@ -639,7 +636,7 @@ extension WatchConnectivityCoordinator {
     clientUpdate: WatchSyncClientUpdate,
     clerk: Clerk
   ) -> Bool {
-    let currentToken = normalizedToken(clerk.deviceToken)
+    let currentToken = clerk.deviceToken.nilIfEmpty
     guard currentToken != nil || clerk.client != nil else {
       return shouldApplyNonAuthoritativeClientUpdate(
         clientUpdate,
@@ -656,7 +653,7 @@ extension WatchConnectivityCoordinator {
       client: clerk.client,
       serverDate: clerk.lastClientServerFetchDate
     )
-    guard normalizedToken(deviceToken) == currentToken,
+    guard deviceToken.nilIfEmpty == currentToken,
           incomingAuthFingerprint == currentAuthFingerprint
     else {
       scheduleRefresh(for: clerk)
@@ -849,19 +846,17 @@ extension WatchConnectivityCoordinator {
     isApplyingRemotePayload = true
   }
 
+  private func withApplyingRemotePayload(_ operation: () -> Void) {
+    let previousApplyingState = isApplyingRemotePayload
+    isApplyingRemotePayload = true
+    defer { isApplyingRemotePayload = previousApplyingState }
+    operation()
+  }
+
   private func finishIdentityPublication(_ operationID: UUID) {
     identityPublicationTasks.removeValue(forKey: operationID)
     activeRemoteIdentityApplications.remove(operationID)
     isApplyingRemotePayload = !activeRemoteIdentityApplications.isEmpty
-  }
-
-  private func normalizedToken(_ token: String?) -> String? {
-    guard let token = token?.trimmingCharacters(in: .whitespacesAndNewlines),
-          !token.isEmpty
-    else {
-      return nil
-    }
-    return token
   }
 
   private func effectiveVersion(accepted: Int?, pending: Int?) -> WatchSyncVersion? {

--- a/Sources/ClerkKit/WatchSync/WatchConnectivityCoordinator.swift
+++ b/Sources/ClerkKit/WatchSync/WatchConnectivityCoordinator.swift
@@ -247,9 +247,9 @@ extension WatchConnectivityCoordinator {
         return nil
       case .tokenSet:
         if deviceToken == currentToken {
-          client = clerk.client
-          serverDate = clerk.lastClientServerFetchDate
-          requiresClientRefresh = false
+          client = clerk.authoritativeClient
+          serverDate = client == nil ? nil : clerk.lastClientServerFetchDate
+          requiresClientRefresh = client == nil
         } else {
           client = nil
           serverDate = nil

--- a/Sources/ClerkKit/WatchSync/WatchConnectivityCoordinator.swift
+++ b/Sources/ClerkKit/WatchSync/WatchConnectivityCoordinator.swift
@@ -229,7 +229,7 @@ extension WatchConnectivityCoordinator {
     let deviceToken: String?
     switch payload.deviceTokenUpdate {
     case .notIncluded:
-      deviceToken = clerk.deviceToken
+      deviceToken = currentToken
     case .tokenSet(let token, _):
       guard let token = Optional(token).nilIfEmpty else { return nil }
       deviceToken = token
@@ -679,9 +679,10 @@ extension WatchConnectivityCoordinator {
       ) ?? .initial
     ).next()
 
-    record.deviceTokenState = clerk.deviceToken == nil ? .cleared : .set
+    let deviceToken = clerk.deviceToken.nilIfEmpty
+    record.deviceTokenState = deviceToken == nil ? .cleared : .set
     record.deviceTokenVersion = deviceTokenVersion.rawValue
-    record.deviceTokenFingerprint = Self.deviceTokenFingerprint(clerk.deviceToken)
+    record.deviceTokenFingerprint = Self.deviceTokenFingerprint(deviceToken)
     record.deviceTokenSource = nil
     record.discardPendingDeviceToken()
     record.authState = clerk.client == nil ? .cleared : .set

--- a/Sources/ClerkKit/WatchSync/WatchSyncPayload.swift
+++ b/Sources/ClerkKit/WatchSync/WatchSyncPayload.swift
@@ -227,7 +227,7 @@ package struct WatchSyncPayload {
       metadata: metadata
     )
     let persistedAuthState = metadata.authState
-    if let client = clerk.client {
+    if let client = clerk.authoritativeClient {
       clientUpdate = .snapshot(client: client, serverFetchDate: clerk.lastClientServerFetchDate, version: authGeneration)
     } else if clerk.lastClientServerFetchDate != nil || persistedAuthState == .cleared {
       clientUpdate = .cleared(serverFetchDate: clerk.lastClientServerFetchDate, version: authGeneration)

--- a/Tests/Core/ClerkReconfigureTests.swift
+++ b/Tests/Core/ClerkReconfigureTests.swift
@@ -144,6 +144,43 @@ struct ClerkReconfigureTests {
   }
 
   @Test
+  func sharedSessionTopologyDistinguishesStoreFromOwnerSlot() throws {
+    let publishableKey = publishableKey(for: "topology.clerk.example.com")
+    let options = Clerk.Options(
+      keychainConfig: .init(
+        service: "com.example.clerk",
+        accessGroup: "TEAMID.com.example.shared"
+      ),
+      sharedSessionSync: .enabled
+    )
+    let first = try #require(SharedSessionSlotTopology(dependencies: makeDependencies(
+      publishableKey: publishableKey,
+      options: options,
+      owner: "com.example.first"
+    )))
+    let sameStore = try #require(SharedSessionSlotTopology(dependencies: makeDependencies(
+      publishableKey: publishableKey,
+      options: options,
+      owner: "com.example.second"
+    )))
+    let differentStore = try #require(SharedSessionSlotTopology(dependencies: makeDependencies(
+      publishableKey: publishableKey,
+      options: Clerk.Options(
+        keychainConfig: .init(
+          service: "com.example.changed",
+          accessGroup: "TEAMID.com.example.shared"
+        ),
+        sharedSessionSync: .enabled
+      ),
+      owner: "com.example.first"
+    )))
+
+    #expect(first.hasSameStore(as: sameStore))
+    #expect(!first.hasSameOwnerSlot(as: sameStore))
+    #expect(!first.hasSameStore(as: differentStore))
+  }
+
+  @Test
   func reconfigureUpdatesInstanceTypeForLiveKey() async throws {
     let publishableKey = publishableKey(for: "live.clerk.example.com", live: true)
 
@@ -275,7 +312,7 @@ struct ClerkReconfigureTests {
       keychain: throwingKeychain,
       telemetryCollector: Clerk.shared.dependencies.telemetryCollector
     )
-    original.performConfiguration(dependencies: previousDependencies)
+    try original.performConfiguration(dependencies: previousDependencies)
     original.client = .mock
     original.environment = .mock
     defer { original.cleanupManagers() }
@@ -319,7 +356,7 @@ struct ClerkReconfigureTests {
       atomicIdentityStore: localIdentityStore,
       telemetryCollector: original.dependencies.telemetryCollector
     )
-    original.performConfiguration(dependencies: previousDependencies)
+    try original.performConfiguration(dependencies: previousDependencies)
     let ownerSlotStore = RollbackOwnerSlotStore(
       slot: SharedSessionOwnerSlot(
         schemaVersion: SharedSessionOwnerSlot.schemaVersion,
@@ -367,7 +404,7 @@ struct ClerkReconfigureTests {
       keychain: oldKeychain,
       telemetryCollector: Clerk.shared.dependencies.telemetryCollector
     )
-    Clerk.shared.performConfiguration(dependencies: dependencies)
+    try Clerk.shared.performConfiguration(dependencies: dependencies)
     Clerk.shared.client = .mock
 
     let targetService = "com.clerk.tests.pending-cache-drain.\(UUID().uuidString)"
@@ -399,7 +436,7 @@ struct ClerkReconfigureTests {
       telemetryCollector: Clerk.shared.dependencies.telemetryCollector,
       sessionService: sessionService
     )
-    Clerk.shared.performConfiguration(dependencies: dependencies)
+    try Clerk.shared.performConfiguration(dependencies: dependencies)
     Clerk.shared.client = .mock
     await SessionTokensCache.shared.insertToken(
       .init(jwt: cachedJWT),
@@ -443,7 +480,7 @@ struct ClerkReconfigureTests {
       keychain: oldKeychain,
       telemetryCollector: Clerk.shared.dependencies.telemetryCollector
     )
-    Clerk.shared.performConfiguration(dependencies: dependencies)
+    try Clerk.shared.performConfiguration(dependencies: dependencies)
     Clerk.shared.client = .mock
     let staleSession = try #require(Clerk.shared.session)
     await SessionTokensCache.shared.insertToken(
@@ -537,7 +574,7 @@ struct ClerkReconfigureTests {
       keychain: slowKeychain,
       telemetryCollector: Clerk.shared.dependencies.telemetryCollector
     )
-    Clerk.shared.performConfiguration(dependencies: dependencies)
+    try Clerk.shared.performConfiguration(dependencies: dependencies)
     Clerk.shared.client = .mock
 
     let firstReconfigure = Task { @MainActor in

--- a/Tests/Core/ClerkReconfigureTests.swift
+++ b/Tests/Core/ClerkReconfigureTests.swift
@@ -346,6 +346,95 @@ struct ClerkReconfigureTests {
   }
 
   @Test
+  func failedRecoveryPreflightLeavesPreviousRuntimeInstalled() async throws {
+    let original = Clerk.shared
+    let previousEpoch = original.configurationEpoch
+    let journal = InMemoryKeychain()
+    let intent = SharedSessionOwnerSlotClearRecovery.Intent(
+      localIdentityService: "reconfigure.identity",
+      slotService: "reconfigure.slots",
+      slotAccessGroup: "reconfigure.group",
+      slotAccount: "reconfigure.owner",
+      instanceFingerprint: "reconfigure-instance",
+      ownerIdentifier: "reconfigure-app"
+    )
+    let recovery = SharedSessionOwnerSlotClearRecovery.Context(
+      journal: journal,
+      currentIntent: intent,
+      targetProvider: FailingReconfigurationRecoveryTargets()
+    )
+    let previousDependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(runtimeScope: original.runtimeScope),
+      sharedSessionOwnerSlotClearRecovery: recovery,
+      telemetryCollector: original.dependencies.telemetryCollector
+    )
+    try original.performConfiguration(dependencies: previousDependencies)
+    original.client = .mock
+    original.environment = .mock
+    try SharedSessionOwnerSlotClearRecovery.markPending(in: recovery)
+    defer {
+      try? journal.deleteItem(
+        forKey: SharedSessionOwnerSlotClearRecovery.storageKey
+      )
+      original.cleanupManagers()
+    }
+
+    do {
+      _ = try await Clerk.reconfigure(
+        publishableKey: publishableKey(for: "failed-recovery-preflight.clerk.example.com")
+      )
+      Issue.record("Expected recovery preflight to fail")
+    } catch FailingReconfigurationRecoveryTargets.Failure.unavailable {
+      // Expected.
+    } catch {
+      Issue.record("Expected recovery target failure, got \(error)")
+    }
+
+    #expect(Clerk.shared === original)
+    #expect(original.configurationEpoch == previousEpoch)
+    #expect(original.dependencies === previousDependencies)
+    #expect(original.client?.id == Client.mock.id)
+    #expect(original.environment == .mock)
+    #expect(try await original.refreshClient()?.id == Client.mock.id)
+  }
+
+  @Test
+  func keychainClearStartedDuringReconfigurationWaitsForInstalledRuntime() async throws {
+    let clerk = Clerk.shared
+    let keychain = InMemoryKeychain()
+    let dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(runtimeScope: clerk.runtimeScope),
+      keychain: keychain,
+      telemetryCollector: clerk.dependencies.telemetryCollector
+    )
+    try clerk.performConfiguration(dependencies: dependencies)
+    try keychain.set(
+      "device-token",
+      forKey: ClerkKeychainKey.clerkDeviceToken.rawValue
+    )
+    defer { clerk.cleanupManagers() }
+
+    try Clerk.beginRuntimeReconfiguration()
+    var endedReconfiguration = false
+    defer {
+      if !endedReconfiguration {
+        Clerk.endRuntimeReconfiguration()
+      }
+    }
+    let clearTask = Clerk.startKeychainClearIfNeeded(for: clerk)
+    await Task.yield()
+
+    #expect(try keychain.hasItem(forKey: ClerkKeychainKey.clerkDeviceToken.rawValue))
+    #expect(clerk.keychainClearTask == nil)
+
+    Clerk.endRuntimeReconfiguration()
+    endedReconfiguration = true
+    try await clearTask.value
+
+    #expect(try !keychain.hasItem(forKey: ClerkKeychainKey.clerkDeviceToken.rawValue))
+  }
+
+  @Test
   func failedReconfigurePreservesPreviousOwnerSlotForRollback() async throws {
     let original = Clerk.shared
     let throwingKeychain = ThrowingDeleteKeychain()
@@ -931,6 +1020,24 @@ private final class ThrowingDeleteKeychain: KeychainStorage, @unchecked Sendable
     lock.lock()
     defer { lock.unlock() }
     return storage[key] != nil
+  }
+}
+
+private struct FailingReconfigurationRecoveryTargets: SharedSessionClearRecoveryTargets {
+  enum Failure: Error {
+    case unavailable
+  }
+
+  func localIdentityStore(
+    for _: SharedSessionOwnerSlotClearRecovery.Intent
+  ) throws -> any SharedSessionLocalIdentityStoring {
+    throw Failure.unavailable
+  }
+
+  func slotStore(
+    for _: SharedSessionOwnerSlotClearRecovery.Intent
+  ) throws -> any SharedSessionSlotStoring {
+    throw Failure.unavailable
   }
 }
 

--- a/Tests/Core/ClerkResponseClientStateTests.swift
+++ b/Tests/Core/ClerkResponseClientStateTests.swift
@@ -57,6 +57,24 @@ struct ClerkResponseClientStateTests {
   }
 
   @Test
+  func applyResponseClientDoesNotRegressServerDateWatermark() {
+    let clerk = makeIsolatedClerk()
+    let first = client(id: "client-first", updatedAt: 1000)
+    let second = client(id: "client-second", updatedAt: 2000)
+    let stale = client(id: "client-stale", updatedAt: 3000)
+    let date200 = Date(timeIntervalSince1970: 200)
+    let date100 = Date(timeIntervalSince1970: 100)
+    let date150 = Date(timeIntervalSince1970: 150)
+
+    clerk.applyResponseClient(first, responseSequence: 10, serverDate: date200)
+    clerk.applyResponseClient(second, responseSequence: 11, serverDate: date100)
+    clerk.applyResponseClient(stale, responseSequence: 10, serverDate: date150)
+
+    #expect(clerk.client?.id == second.id)
+    #expect(clerk.lastClientServerFetchDate == date200)
+  }
+
+  @Test
   func applyResponseClientAcceptsOlderResponseSequenceWhenServerDateIsNewer() async throws {
     let clerk = makeIsolatedClerk()
     let refreshedBeforeCompletion = client(id: "client-current", signUpId: "sign-up-pending", updatedAt: 3000)

--- a/Tests/Core/ClerkTests.swift
+++ b/Tests/Core/ClerkTests.swift
@@ -416,6 +416,34 @@ struct ClerkTests {
   }
 
   @Test
+  func awaitedClearAcceptsSuccessfulAtomicIdentityDeletionRetry() async throws {
+    let clerk = Clerk()
+    let keychain = DeleteFailingKeychain(
+      failingKey: SharedSessionLocalIdentityStore.storageKey,
+      failuresRemaining: 1
+    )
+    let identityStore = SharedSessionLocalIdentityStore(keychain: keychain)
+    try identityStore.save(ClerkIdentitySnapshot(
+      state: .present,
+      deviceToken: "token",
+      client: .mock,
+      serverDate: nil
+    ))
+    clerk.dependencies = MockDependencyContainer(
+      apiClient: clerk.dependencies.apiClient,
+      keychain: keychain,
+      atomicIdentityStore: identityStore,
+      telemetryCollector: clerk.dependencies.telemetryCollector
+    )
+
+    try await clerk.clearAllKeychainItemsAndWait()
+
+    #expect(try identityStore.loadRecord() == nil)
+    #expect(keychain.failureCount == 1)
+    #expect(clerk.keychainClearTask == nil)
+  }
+
+  @Test
   func awaitedClearWithdrawsOwnerSlotBeforeReturning() async throws {
     let clerk = Clerk()
     let keychain = InMemoryKeychain()
@@ -1039,10 +1067,18 @@ private final class DeleteFailingKeychain: @unchecked Sendable, KeychainStorage 
   }
 
   private let backing = InMemoryKeychain()
+  private let lock = NSLock()
   private let failingKey: String
+  private var failuresRemaining: Int?
+  private var failures = 0
 
-  init(failingKey: String) {
+  init(failingKey: String, failuresRemaining: Int? = nil) {
     self.failingKey = failingKey
+    self.failuresRemaining = failuresRemaining
+  }
+
+  var failureCount: Int {
+    lock.withLock { failures }
   }
 
   func set(_ data: Data, forKey key: String) throws {
@@ -1054,7 +1090,16 @@ private final class DeleteFailingKeychain: @unchecked Sendable, KeychainStorage 
   }
 
   func deleteItem(forKey key: String) throws {
-    guard key != failingKey else { throw Failure.delete }
+    let shouldFail = lock.withLock {
+      guard key == failingKey else { return false }
+      if let failuresRemaining {
+        guard failuresRemaining > 0 else { return false }
+        self.failuresRemaining = failuresRemaining - 1
+      }
+      failures += 1
+      return true
+    }
+    guard !shouldFail else { throw Failure.delete }
     try backing.deleteItem(forKey: key)
   }
 

--- a/Tests/Core/ClerkTests.swift
+++ b/Tests/Core/ClerkTests.swift
@@ -136,7 +136,7 @@ struct ClerkTests {
       telemetryCollector: clerk.dependencies.telemetryCollector,
       clientService: MockClientService(get: { nil })
     )
-    clerk.performConfiguration(dependencies: dependencies)
+    try clerk.performConfiguration(dependencies: dependencies)
     defer { clerk.cleanupManagers() }
     clerk.client = Client.mock
     clerk.identityController.lastServerDate = Date(timeIntervalSince1970: 100)
@@ -210,12 +210,77 @@ struct ClerkTests {
       options: .init(sharedSessionSync: .enabled)
     )
 
-    clerk.performConfiguration(dependencies: dependencies)
+    try clerk.performConfiguration(dependencies: dependencies)
     defer { clerk.cleanupManagers() }
 
     #expect(clerk.client?.id == Client.mock.id)
-    #expect(clerk.lastClientServerFetchDate == serverDate)
+    #expect(clerk.authoritativeClient == nil)
+    #expect(clerk.lastClientServerFetchDate == nil)
     #expect(try localStore.load() == nil)
+  }
+
+  @Test
+  func provisionalLegacyClientIsExcludedFromRequestAndWatchIdentity() async throws {
+    let clerk = Clerk()
+    let keychain = InMemoryKeychain()
+    let localStore = SharedSessionLocalIdentityStore(keychain: keychain)
+    let dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      keychain: keychain,
+      atomicIdentityStore: localStore,
+      clientService: MockClientService(get: { nil })
+    )
+    clerk.dependencies = dependencies
+    clerk.identityController.localDeviceToken = "device-token"
+    clerk.identityController.hydrateProvisionalLegacyClientIfNeeded(.mock)
+
+    let requestIdentity = try await clerk.identityController.captureRequestIdentity()
+    let watchPayload = try WatchSyncPayload(
+      clerk: clerk,
+      metadata: .empty,
+      authGeneration: WatchSyncVersion(rawValue: 1)
+    )
+
+    #expect(clerk.client?.id == Client.mock.id)
+    #expect(clerk.authoritativeClient == nil)
+    #expect(requestIdentity.deviceToken == "device-token")
+    #expect(requestIdentity.clientID == nil)
+    #expect(watchPayload.clientUpdate == .notIncluded)
+
+    clerk.identityController.prepareForConfiguration()
+    #expect(clerk.authoritativeClient == nil)
+  }
+
+  @Test
+  func acceptedClientResponsePromotesProvisionalLegacyClient() async throws {
+    let clerk = Clerk()
+    let keychain = InMemoryKeychain()
+    let localStore = SharedSessionLocalIdentityStore(keychain: keychain)
+    clerk.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      keychain: keychain,
+      atomicIdentityStore: localStore,
+      clientService: MockClientService(get: { nil })
+    )
+    clerk.identityController.localDeviceToken = "device-token"
+    clerk.identityController.hydrateProvisionalLegacyClientIfNeeded(.mock)
+    let requestIdentity = try await clerk.identityController.captureRequestIdentity()
+
+    try await clerk.identityController.applyNetworkResponse(
+      ClientSyncResponseContext(
+        update: .client(.mock),
+        deviceTokenUpdate: .set("device-token"),
+        requestDeviceToken: "device-token",
+        baseGeneration: requestIdentity.baseGeneration,
+        serverDate: Date(timeIntervalSince1970: 200),
+        isCanonicalClientRequest: true,
+        clientResponseGeneration: requestIdentity.clientResponseGeneration,
+        responseSequence: 1
+      )
+    )
+
+    #expect(clerk.authoritativeClient?.id == Client.mock.id)
+    #expect(try localStore.load()?.client?.id == Client.mock.id)
   }
 
   @Test
@@ -243,7 +308,7 @@ struct ClerkTests {
       options: .init(sharedSessionSync: .enabled)
     )
 
-    clerk.performConfiguration(dependencies: dependencies)
+    try clerk.performConfiguration(dependencies: dependencies)
     defer { clerk.cleanupManagers() }
 
     #expect(clerk.client == nil)
@@ -448,14 +513,20 @@ struct ClerkTests {
     let clerk = Clerk()
     let keychain = InMemoryKeychain()
     let identityStore = SharedSessionLocalIdentityStore(keychain: keychain)
+    let slotStore = ClearTrackingSlotStore()
+    let recovery = makeClearRecoveryContext(
+      journal: keychain,
+      identityStore: identityStore,
+      slotStore: slotStore
+    )
     let dependencies = MockDependencyContainer(
       apiClient: clerk.dependencies.apiClient,
       keychain: keychain,
       atomicIdentityStore: identityStore,
+      sharedSessionOwnerSlotClearRecovery: recovery,
       telemetryCollector: clerk.dependencies.telemetryCollector
     )
     clerk.dependencies = dependencies
-    let slotStore = ClearTrackingSlotStore()
     let coordinator = SharedSessionSyncCoordinator(
       ownerIdentifier: "app.clear",
       instanceFingerprint: "instance",
@@ -498,6 +569,175 @@ struct ClerkTests {
     #expect(try slotStore.loadOwnSlot() == nil)
     #expect(try identityStore.loadRecord() == nil)
     #expect(clerk.client == nil)
+  }
+
+  @Test
+  func awaitedClearKeepsPublicationBlockedUntilRecoveryIntentIsRemoved() async throws {
+    let clerk = Clerk()
+    let keychain = DeleteFailingKeychain(
+      failingKey: SharedSessionOwnerSlotClearRecovery.storageKey,
+      failuresRemaining: 1
+    )
+    let identityStore = SharedSessionLocalIdentityStore(keychain: keychain)
+    let slotStore = ClearTrackingSlotStore()
+    let recovery = makeClearRecoveryContext(
+      journal: keychain,
+      identityStore: identityStore,
+      slotStore: slotStore
+    )
+    let dependencies = MockDependencyContainer(
+      apiClient: clerk.dependencies.apiClient,
+      keychain: keychain,
+      atomicIdentityStore: identityStore,
+      sharedSessionOwnerSlotClearRecovery: recovery,
+      telemetryCollector: clerk.dependencies.telemetryCollector
+    )
+    clerk.dependencies = dependencies
+    let coordinator = SharedSessionSyncCoordinator(
+      ownerIdentifier: "app.clear",
+      instanceFingerprint: "instance",
+      slotStore: slotStore,
+      localIdentityStore: identityStore,
+      localIdentityIO: dependencies.atomicIdentityIO,
+      notifier: SilentSharedSessionNotifier(),
+      configurationEpoch: clerk.configurationEpoch,
+      clerk: clerk
+    )
+    clerk.sharedSessionSyncCoordinator = coordinator
+    defer { clerk.sharedSessionSyncCoordinator = nil }
+    try slotStore.saveOwnSlot(
+      SharedSessionOwnerSlot(
+        schemaVersion: SharedSessionOwnerSlot.schemaVersion,
+        instanceFingerprint: "instance",
+        slotOwnerIdentifier: "app.clear",
+        event: SharedSessionIdentityEvent(
+          id: UUID(),
+          originOwnerIdentifier: "app.clear",
+          generation: 1,
+          state: .present,
+          deviceToken: "old-token",
+          client: .mock,
+          serverDate: nil
+        )
+      )
+    )
+
+    var clearFailed = false
+    do {
+      try await clerk.clearAllKeychainItemsAndWait()
+    } catch {
+      clearFailed = true
+    }
+
+    #expect(clearFailed)
+    #expect(try slotStore.loadOwnSlot() == nil)
+    #expect(try SharedSessionOwnerSlotClearRecovery.loadPendingIntent(in: keychain) != nil)
+    await #expect(throws: CancellationError.self) {
+      try await coordinator.publishLocalIdentity(
+        state: .present,
+        deviceToken: "new-token",
+        client: .mock,
+        serverDate: nil
+      )
+    }
+
+    try await clerk.clearAllKeychainItemsAndWait()
+
+    #expect(try SharedSessionOwnerSlotClearRecovery.loadPendingIntent(in: keychain) == nil)
+    #expect(
+      try await coordinator.publishLocalIdentity(
+        state: .present,
+        deviceToken: "new-token",
+        client: .mock,
+        serverDate: nil
+      )
+    )
+    #expect(try slotStore.loadOwnSlot()?.event.deviceToken == "new-token")
+  }
+
+  @Test
+  func awaitedClearKeepsRecoveryIntentWhenAtomicIdentityDeletionFailsTwice() async throws {
+    let clerk = Clerk()
+    let keychain = DeleteFailingKeychain(
+      failingKey: SharedSessionLocalIdentityStore.storageKey
+    )
+    let identityStore = SharedSessionLocalIdentityStore(keychain: keychain)
+    let slotStore = ClearTrackingSlotStore()
+    let recovery = makeClearRecoveryContext(
+      journal: keychain,
+      identityStore: identityStore,
+      slotStore: slotStore
+    )
+    let dependencies = MockDependencyContainer(
+      apiClient: clerk.dependencies.apiClient,
+      keychain: keychain,
+      atomicIdentityStore: identityStore,
+      sharedSessionOwnerSlotClearRecovery: recovery,
+      telemetryCollector: clerk.dependencies.telemetryCollector
+    )
+    clerk.dependencies = dependencies
+    let coordinator = SharedSessionSyncCoordinator(
+      ownerIdentifier: "app.clear",
+      instanceFingerprint: "instance",
+      slotStore: slotStore,
+      localIdentityStore: identityStore,
+      localIdentityIO: dependencies.atomicIdentityIO,
+      notifier: SilentSharedSessionNotifier(),
+      configurationEpoch: clerk.configurationEpoch,
+      clerk: clerk
+    )
+    clerk.sharedSessionSyncCoordinator = coordinator
+    defer { clerk.sharedSessionSyncCoordinator = nil }
+    let identity = SharedSessionLocalIdentity(
+      state: .present,
+      deviceToken: "old-token",
+      client: .mock,
+      serverDate: nil
+    )
+    try identityStore.save(identity)
+    clerk.hydrateIdentityIfNeeded(identity)
+    try slotStore.saveOwnSlot(
+      SharedSessionOwnerSlot(
+        schemaVersion: SharedSessionOwnerSlot.schemaVersion,
+        instanceFingerprint: "instance",
+        slotOwnerIdentifier: "app.clear",
+        event: SharedSessionIdentityEvent(
+          id: UUID(),
+          originOwnerIdentifier: "app.clear",
+          generation: 1,
+          state: .present,
+          deviceToken: identity.deviceToken,
+          client: identity.client,
+          serverDate: identity.serverDate
+        )
+      )
+    )
+
+    do {
+      try await clerk.clearAllKeychainItemsAndWait()
+      Issue.record("Expected both atomic identity deletion attempts to fail.")
+    } catch {
+      #expect(error.localizedDescription.contains("delete atomic identity"))
+    }
+
+    #expect(keychain.failureCount == 2)
+    let retainedIdentity = try #require(try identityStore.load())
+    #expect(retainedIdentity.state == .present)
+    #expect(retainedIdentity.deviceToken == "old-token")
+    #expect(retainedIdentity.client?.id == identity.client?.id)
+    #expect(try slotStore.loadOwnSlot() == nil)
+    #expect(
+      try SharedSessionOwnerSlotClearRecovery.loadPendingIntent(in: keychain)
+        == recovery.currentIntent
+    )
+    await #expect(throws: CancellationError.self) {
+      _ = try await coordinator.captureRequestIdentity()
+    }
+
+    keychain.allowDeletes()
+    #expect(try SharedSessionOwnerSlotClearRecovery.recoverIfNeeded(in: recovery))
+    #expect(try identityStore.loadRecord() == nil)
+    #expect(try SharedSessionOwnerSlotClearRecovery.loadPendingIntent(in: keychain) == nil)
   }
 
   @Test
@@ -565,7 +805,7 @@ struct ClerkTests {
       keychain: keychain,
       telemetryCollector: clerk.dependencies.telemetryCollector
     )
-    clerk.performConfiguration(dependencies: dependencies)
+    try clerk.performConfiguration(dependencies: dependencies)
     defer { clerk.cleanupManagers() }
     keychain.suspendNextSet(forKey: ClerkKeychainKey.cachedClient.rawValue)
     clerk.client = .mock
@@ -998,6 +1238,29 @@ struct ClerkTests {
     return environment
   }
 
+  private func makeClearRecoveryContext(
+    journal: any KeychainStorage,
+    identityStore: any SharedSessionLocalIdentityStoring,
+    slotStore: any SharedSessionSlotStoring
+  ) -> SharedSessionOwnerSlotClearRecovery.Context {
+    let intent = SharedSessionOwnerSlotClearRecovery.Intent(
+      localIdentityService: "app.identity",
+      slotService: "app.slots",
+      slotAccessGroup: "group.shared",
+      slotAccount: "owner.app.clear",
+      instanceFingerprint: "instance",
+      ownerIdentifier: "app.clear"
+    )
+    return SharedSessionOwnerSlotClearRecovery.Context(
+      journal: journal,
+      currentIntent: intent,
+      targetProvider: ClearRecoveryTargetProvider(
+        identityStore: identityStore,
+        slotStore: slotStore
+      )
+    )
+  }
+
   private func waitUntil(_ condition: () -> Bool) async throws {
     let deadline = ContinuousClock.now + .seconds(1)
     while ContinuousClock.now < deadline {
@@ -1005,6 +1268,25 @@ struct ClerkTests {
       await Task.yield()
     }
     throw ClerkClientError(message: "Timed out waiting for identity operation.")
+  }
+}
+
+private struct ClearRecoveryTargetProvider:
+  SharedSessionClearRecoveryTargets
+{
+  let identityStore: any SharedSessionLocalIdentityStoring
+  let slotStore: any SharedSessionSlotStoring
+
+  func localIdentityStore(
+    for _: SharedSessionOwnerSlotClearRecovery.Intent
+  ) throws -> any SharedSessionLocalIdentityStoring {
+    identityStore
+  }
+
+  func slotStore(
+    for _: SharedSessionOwnerSlotClearRecovery.Intent
+  ) throws -> any SharedSessionSlotStoring {
+    slotStore
   }
 }
 
@@ -1079,6 +1361,10 @@ private final class DeleteFailingKeychain: @unchecked Sendable, KeychainStorage 
 
   var failureCount: Int {
     lock.withLock { failures }
+  }
+
+  func allowDeletes() {
+    lock.withLock { failuresRemaining = 0 }
   }
 
   func set(_ data: Data, forKey key: String) throws {

--- a/Tests/Core/ClientResponseOrderingGateTests.swift
+++ b/Tests/Core/ClientResponseOrderingGateTests.swift
@@ -46,6 +46,24 @@ struct ClientResponseOrderingGateTests {
   }
 
   @Test
+  func recordDoesNotRegressServerDateWatermark() {
+    let newerDate = Date(timeIntervalSince1970: 200)
+    let olderDate = Date(timeIntervalSince1970: 100)
+    var gate = ClientResponseOrderingGate()
+
+    gate.record(sequence: 10, serverDate: newerDate)
+    gate.record(sequence: 11, serverDate: olderDate)
+
+    #expect(gate.lastAcceptedServerDate == newerDate)
+    #expect(!gate.accepts(
+      sequence: 10,
+      serverDate: Date(timeIntervalSince1970: 150),
+      incomingUpdatedAt: Date(timeIntervalSince1970: 300),
+      currentUpdatedAt: Date(timeIntervalSince1970: 100)
+    ))
+  }
+
+  @Test
   func resetClearsOrderingWatermarks() {
     let date = Date(timeIntervalSince1970: 100)
     var gate = ClientResponseOrderingGate()

--- a/Tests/Core/ClientResponseOrderingGateTests.swift
+++ b/Tests/Core/ClientResponseOrderingGateTests.swift
@@ -1,0 +1,71 @@
+@testable import ClerkKit
+import Foundation
+import Testing
+
+struct ClientResponseOrderingGateTests {
+  @Test
+  func rejectsOlderSequenceWithoutNewerServerState() {
+    let date = Date(timeIntervalSince1970: 100)
+    var gate = ClientResponseOrderingGate()
+    gate.record(sequence: 2, serverDate: date)
+
+    #expect(!gate.accepts(
+      sequence: 1,
+      serverDate: date,
+      incomingUpdatedAt: date,
+      currentUpdatedAt: date
+    ))
+  }
+
+  @Test
+  func acceptsOlderSequenceWithNewerServerDate() {
+    let date = Date(timeIntervalSince1970: 100)
+    var gate = ClientResponseOrderingGate()
+    gate.record(sequence: 2, serverDate: date)
+
+    #expect(gate.accepts(
+      sequence: 1,
+      serverDate: date.addingTimeInterval(1),
+      incomingUpdatedAt: date,
+      currentUpdatedAt: date
+    ))
+  }
+
+  @Test
+  func equalServerDateUsesClientUpdatedAt() {
+    let date = Date(timeIntervalSince1970: 100)
+    var gate = ClientResponseOrderingGate()
+    gate.record(sequence: 2, serverDate: date)
+
+    #expect(gate.accepts(
+      sequence: 1,
+      serverDate: date,
+      incomingUpdatedAt: date.addingTimeInterval(1),
+      currentUpdatedAt: date
+    ))
+  }
+
+  @Test
+  func resetClearsOrderingWatermarks() {
+    let date = Date(timeIntervalSince1970: 100)
+    var gate = ClientResponseOrderingGate()
+    gate.record(sequence: 2, serverDate: date)
+
+    gate.reset()
+
+    #expect(gate.lastAcceptedSequence == nil)
+    #expect(gate.lastAcceptedServerDate == nil)
+  }
+
+  @Test
+  func resetSequencePreservesServerWatermark() {
+    let date = Date(timeIntervalSince1970: 100)
+    var gate = ClientResponseOrderingGate()
+    gate.record(sequence: 2, serverDate: date)
+
+    gate.resetSequence()
+
+    #expect(gate.lastAcceptedSequence == nil)
+    #expect(gate.lastAcceptedServerDate == date)
+  }
+}

--- a/Tests/Core/SharedSessionOwnerSlotClearRecoveryTests.swift
+++ b/Tests/Core/SharedSessionOwnerSlotClearRecoveryTests.swift
@@ -1,0 +1,550 @@
+@testable import ClerkKit
+import Foundation
+import Testing
+
+@Suite(.serialized)
+struct SharedSessionOwnerSlotClearRecoveryTests {
+  @Test
+  @MainActor
+  func synchronousClearPersistsExactRecoveryIntentBeforeReturning() async throws {
+    let clerk = Clerk()
+    let keychain = InMemoryKeychain()
+    let journal = InMemoryKeychain()
+    let localStore = SharedSessionLocalIdentityStore(keychain: keychain)
+    let slotStore = try RecoveryOwnerSlotStore(slot: makeSlot())
+    let intent = makeIntent()
+    let recovery = makeContext(
+      journal: journal,
+      currentIntent: intent,
+      identityStore: localStore,
+      slotStore: slotStore
+    )
+    clerk.dependencies = MockDependencyContainer(
+      apiClient: clerk.dependencies.apiClient,
+      keychain: keychain,
+      identityKeychain: keychain,
+      atomicIdentityStore: localStore,
+      sharedSessionOwnerSlotClearRecovery: recovery,
+      clientService: MockClientService(get: { nil })
+    )
+    clerk.sharedSessionSyncCoordinator = SharedSessionSyncCoordinator(
+      ownerIdentifier: "app.owner",
+      instanceFingerprint: "instance",
+      slotStore: slotStore,
+      localIdentityStore: localStore,
+      notifier: RecoverySharedSessionNotifier(),
+      configurationEpoch: clerk.configurationEpoch,
+      clerk: clerk
+    )
+
+    let clearTask = Clerk.startKeychainClearIfNeeded(for: clerk)
+
+    #expect(
+      try SharedSessionOwnerSlotClearRecovery.loadPendingIntent(in: journal)
+        == intent
+    )
+
+    try await clearTask.value
+    #expect(try slotStore.loadOwnSlot() == nil)
+    #expect(try SharedSessionOwnerSlotClearRecovery.loadPendingIntent(in: journal) == nil)
+  }
+
+  @Test
+  @MainActor
+  func journalFailureLeavesIdentityAndOwnerSlotUntouched() async throws {
+    let clerk = Clerk()
+    let identityKeychain = InMemoryKeychain()
+    let journal = SetFailingKeychain()
+    let localStore = SharedSessionLocalIdentityStore(keychain: identityKeychain)
+    let slot = try makeSlot()
+    let slotStore = RecoveryOwnerSlotStore(slot: slot)
+    let recovery = makeContext(
+      journal: journal,
+      currentIntent: makeIntent(),
+      identityStore: localStore,
+      slotStore: slotStore
+    )
+    let dependencies = MockDependencyContainer(
+      apiClient: clerk.dependencies.apiClient,
+      keychain: identityKeychain,
+      identityKeychain: identityKeychain,
+      atomicIdentityStore: localStore,
+      sharedSessionOwnerSlotClearRecovery: recovery,
+      clientService: MockClientService(get: { nil })
+    )
+    clerk.dependencies = dependencies
+    let identity = makeIdentity(token: "accepted-token")
+    try localStore.save(identity)
+    let recordBeforeClear = try localStore.loadRecord()
+    clerk.hydrateIdentityIfNeeded(identity)
+    let coordinator = SharedSessionSyncCoordinator(
+      ownerIdentifier: "app.owner",
+      instanceFingerprint: "instance",
+      slotStore: slotStore,
+      localIdentityStore: localStore,
+      localIdentityIO: dependencies.atomicIdentityIO,
+      notifier: RecoverySharedSessionNotifier(),
+      configurationEpoch: clerk.configurationEpoch,
+      clerk: clerk
+    )
+    clerk.sharedSessionSyncCoordinator = coordinator
+
+    do {
+      try await clerk.clearAllKeychainItemsAndWait()
+      Issue.record("Expected recovery journal persistence to fail.")
+    } catch {
+      #expect(
+        error.localizedDescription.contains(
+          "persist owner-slot withdrawal intent"
+        )
+      )
+    }
+
+    #expect(clerk.client?.id == identity.client?.id)
+    #expect(clerk.identityController.currentDeviceToken == "accepted-token")
+    #expect(try localStore.loadRecord() == recordBeforeClear)
+    #expect(try slotStore.loadOwnSlot() == slot)
+    #expect(clerk.keychainClearTask == nil)
+    #expect(try await coordinator.captureRequestIdentity().deviceToken == "accepted-token")
+  }
+
+  @Test
+  @MainActor
+  func recoveryClearsAcceptedAndPendingIdentityBeforeCoordinatorStartup() async throws {
+    let journal = InMemoryKeychain()
+    let localStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    let slotStore = try RecoveryOwnerSlotStore(slot: makeSlot())
+    let intent = makeIntent()
+    let context = makeContext(
+      journal: journal,
+      currentIntent: intent,
+      identityStore: localStore,
+      slotStore: slotStore
+    )
+    try localStore.save(makeIdentity(token: "accepted-token"))
+    try localStore.stagePendingPublication(makeEvent(
+      token: "pending-token",
+      generation: 2
+    ))
+    try SharedSessionOwnerSlotClearRecovery.markPending(in: context)
+
+    #expect(try SharedSessionOwnerSlotClearRecovery.recoverIfNeeded(in: context))
+
+    #expect(try localStore.loadRecord() == nil)
+    #expect(try slotStore.loadOwnSlot() == nil)
+    #expect(try SharedSessionOwnerSlotClearRecovery.loadPendingIntent(in: journal) == nil)
+
+    let clerk = Clerk()
+    let dependencies = MockDependencyContainer(
+      apiClient: clerk.dependencies.apiClient,
+      atomicIdentityStore: localStore,
+      clientService: MockClientService(get: { nil })
+    )
+    clerk.dependencies = dependencies
+    let coordinator = SharedSessionSyncCoordinator(
+      ownerIdentifier: "app.owner",
+      instanceFingerprint: "instance",
+      slotStore: slotStore,
+      localIdentityStore: localStore,
+      localIdentityIO: dependencies.atomicIdentityIO,
+      notifier: RecoverySharedSessionNotifier(),
+      configurationEpoch: clerk.configurationEpoch,
+      clerk: clerk
+    )
+    clerk.sharedSessionSyncCoordinator = coordinator
+
+    _ = await coordinator.start().value
+
+    #expect(try slotStore.loadOwnSlot() == nil)
+    #expect(try localStore.loadRecord() == nil)
+  }
+
+  @Test
+  func recoveryUsesRecordedTopologyInsteadOfCurrentConfiguration() throws {
+    let journal = InMemoryKeychain()
+    let originalIdentityStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    let currentIdentityStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    let originalSlotStore = try RecoveryOwnerSlotStore(slot: makeSlot())
+    let currentSlotStore = try RecoveryOwnerSlotStore(slot: makeSlot(token: "current-token"))
+    let originalIntent = makeIntent(suffix: "original")
+    let currentIntent = makeIntent(suffix: "current")
+    try originalIdentityStore.save(makeIdentity(token: "original-token"))
+    try currentIdentityStore.save(makeIdentity(token: "current-token"))
+    let provider = RecoveryTargetProvider(
+      originalIntent: originalIntent,
+      originalIdentityStore: originalIdentityStore,
+      originalSlotStore: originalSlotStore,
+      otherIdentityStore: currentIdentityStore,
+      otherSlotStore: currentSlotStore
+    )
+    try SharedSessionOwnerSlotClearRecovery.markPending(in: .init(
+      journal: journal,
+      currentIntent: originalIntent,
+      targetProvider: provider
+    ))
+    let currentContext = SharedSessionOwnerSlotClearRecovery.Context(
+      journal: journal,
+      currentIntent: currentIntent,
+      targetProvider: provider
+    )
+
+    #expect(try SharedSessionOwnerSlotClearRecovery.recoverIfNeeded(in: currentContext))
+
+    #expect(try originalIdentityStore.loadRecord() == nil)
+    #expect(try originalSlotStore.loadOwnSlot() == nil)
+    #expect(try currentIdentityStore.load() != nil)
+    #expect(try currentSlotStore.loadOwnSlot() != nil)
+  }
+
+  @Test
+  @MainActor
+  func disabledSyncRecoversBeforeCacheHydration() throws {
+    let clerk = Clerk()
+    let journal = InMemoryKeychain()
+    let localStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    let slotStore = try RecoveryOwnerSlotStore(slot: makeSlot())
+    let intent = makeIntent()
+    let provider = RecoveryTargetProvider(
+      originalIntent: intent,
+      originalIdentityStore: localStore,
+      originalSlotStore: slotStore
+    )
+    try localStore.save(makeIdentity(token: "accepted-token"))
+    try SharedSessionOwnerSlotClearRecovery.markPending(in: .init(
+      journal: journal,
+      currentIntent: intent,
+      targetProvider: provider
+    ))
+    let disabledContext = SharedSessionOwnerSlotClearRecovery.Context(
+      journal: journal,
+      currentIntent: nil,
+      targetProvider: provider
+    )
+    let dependencies = MockDependencyContainer(
+      apiClient: clerk.dependencies.apiClient,
+      atomicIdentityStore: localStore,
+      sharedSessionOwnerSlotClearRecovery: disabledContext,
+      clientService: MockClientService(get: { nil })
+    )
+
+    try clerk.performConfiguration(dependencies: dependencies)
+    defer { clerk.cleanupManagers() }
+
+    #expect(clerk.identityController.currentDeviceToken == nil)
+    #expect(clerk.client == nil)
+    #expect(try localStore.loadRecord() == nil)
+    #expect(try slotStore.loadOwnSlot() == nil)
+    #expect(try SharedSessionOwnerSlotClearRecovery.loadPendingIntent(in: journal) == nil)
+  }
+
+  @Test
+  func failedLocalIdentityDeletionKeepsSlotAndIntent() throws {
+    let journal = InMemoryKeychain()
+    let localStore = DeleteFailingRecoveryIdentityStore()
+    let slotStore = try RecoveryOwnerSlotStore(slot: makeSlot())
+    let intent = makeIntent()
+    let context = makeContext(
+      journal: journal,
+      currentIntent: intent,
+      identityStore: localStore,
+      slotStore: slotStore
+    )
+    try SharedSessionOwnerSlotClearRecovery.markPending(in: context)
+
+    #expect(throws: DeleteFailingRecoveryIdentityStore.Failure.delete) {
+      try SharedSessionOwnerSlotClearRecovery.recoverIfNeeded(in: context)
+    }
+
+    #expect(try slotStore.loadOwnSlot() != nil)
+    #expect(try SharedSessionOwnerSlotClearRecovery.loadPendingIntent(in: journal) == intent)
+  }
+
+  @Test
+  @MainActor
+  func failedRecoveryPreventsCacheHydrationAndRuntimeInstallation() throws {
+    let clerk = Clerk()
+    let initialKeychain = InMemoryKeychain()
+    clerk.dependencies = MockDependencyContainer(
+      apiClient: clerk.dependencies.apiClient,
+      keychain: initialKeychain,
+      identityKeychain: initialKeychain,
+      clientService: MockClientService(get: { nil })
+    )
+    let journal = InMemoryKeychain()
+    let cachedIdentityStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    let failingRecoveryStore = DeleteFailingRecoveryIdentityStore()
+    let slotStore = try RecoveryOwnerSlotStore(slot: makeSlot())
+    let intent = makeIntent()
+    let context = makeContext(
+      journal: journal,
+      currentIntent: intent,
+      identityStore: failingRecoveryStore,
+      slotStore: slotStore
+    )
+    try cachedIdentityStore.save(makeIdentity(token: "must-not-hydrate"))
+    try SharedSessionOwnerSlotClearRecovery.markPending(in: context)
+    let dependencies = MockDependencyContainer(
+      apiClient: clerk.dependencies.apiClient,
+      atomicIdentityStore: cachedIdentityStore,
+      sharedSessionOwnerSlotClearRecovery: context,
+      clientService: MockClientService(get: { nil })
+    )
+
+    #expect(throws: DeleteFailingRecoveryIdentityStore.Failure.delete) {
+      try clerk.performConfiguration(dependencies: dependencies)
+    }
+
+    #expect(clerk.client == nil)
+    #expect(clerk.identityController.currentDeviceToken == nil)
+    #expect(clerk.dependencies !== dependencies)
+    #expect(try cachedIdentityStore.load() != nil)
+    #expect(try SharedSessionOwnerSlotClearRecovery.loadPendingIntent(in: journal) == intent)
+  }
+
+  @Test
+  func failedSlotWithdrawalLeavesClearedIdentityAndIntentForRetry() throws {
+    let journal = InMemoryKeychain()
+    let localStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    let slotStore = try RecoveryOwnerSlotStore(slot: makeSlot(), deleteFails: true)
+    let intent = makeIntent()
+    let context = makeContext(
+      journal: journal,
+      currentIntent: intent,
+      identityStore: localStore,
+      slotStore: slotStore
+    )
+    try localStore.save(makeIdentity(token: "accepted-token"))
+    try SharedSessionOwnerSlotClearRecovery.markPending(in: context)
+
+    #expect(throws: RecoveryOwnerSlotStore.Failure.delete) {
+      try SharedSessionOwnerSlotClearRecovery.recoverIfNeeded(in: context)
+    }
+
+    #expect(try localStore.loadRecord() == nil)
+    #expect(try slotStore.loadOwnSlot() != nil)
+    #expect(try SharedSessionOwnerSlotClearRecovery.loadPendingIntent(in: journal) == intent)
+  }
+
+  @Test
+  func futureSchemaSlotKeepsRecoveryIntentPending() throws {
+    let journal = InMemoryKeychain()
+    let localStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    let slotStore = try RecoveryOwnerSlotStore(
+      slot: makeSlot(),
+      futureSchemaVersion: 3
+    )
+    let intent = makeIntent()
+    let context = makeContext(
+      journal: journal,
+      currentIntent: intent,
+      identityStore: localStore,
+      slotStore: slotStore
+    )
+    try localStore.save(makeIdentity(token: "accepted-token"))
+    try SharedSessionOwnerSlotClearRecovery.markPending(in: context)
+
+    #expect(throws: SharedSessionOwnerSlotStoreError.futureSchemaVersion(3)) {
+      try SharedSessionOwnerSlotClearRecovery.recoverIfNeeded(in: context)
+    }
+
+    #expect(try localStore.loadRecord() == nil)
+    #expect(try slotStore.loadOwnSlot() != nil)
+    #expect(try SharedSessionOwnerSlotClearRecovery.loadPendingIntent(in: journal) == intent)
+  }
+
+  private func makeContext(
+    journal: any KeychainStorage,
+    currentIntent: SharedSessionOwnerSlotClearRecovery.Intent?,
+    identityStore: any SharedSessionLocalIdentityStoring,
+    slotStore: any SharedSessionSlotStoring
+  ) -> SharedSessionOwnerSlotClearRecovery.Context {
+    let intent = currentIntent ?? makeIntent()
+    return SharedSessionOwnerSlotClearRecovery.Context(
+      journal: journal,
+      currentIntent: currentIntent,
+      targetProvider: RecoveryTargetProvider(
+        originalIntent: intent,
+        originalIdentityStore: identityStore,
+        originalSlotStore: slotStore
+      )
+    )
+  }
+
+  private func makeIntent(
+    suffix: String = "original"
+  ) -> SharedSessionOwnerSlotClearRecovery.Intent {
+    SharedSessionOwnerSlotClearRecovery.Intent(
+      localIdentityService: "app.identity.\(suffix)",
+      slotService: "app.slots.\(suffix)",
+      slotAccessGroup: "group.\(suffix)",
+      slotAccount: "owner.\(suffix)",
+      instanceFingerprint: "instance-\(suffix)",
+      ownerIdentifier: "app.owner"
+    )
+  }
+
+  private func makeIdentity(token: String) -> ClerkIdentitySnapshot {
+    ClerkIdentitySnapshot(
+      state: .present,
+      deviceToken: token,
+      client: .mock,
+      serverDate: Date(timeIntervalSince1970: 100)
+    )
+  }
+
+  private func makeEvent(
+    token: String,
+    generation: UInt64
+  ) throws -> SharedSessionIdentityEvent {
+    try SharedSessionIdentityEvent(
+      id: UUID(),
+      originOwnerIdentifier: "app.owner",
+      generation: generation,
+      state: .present,
+      deviceToken: token,
+      client: .mock,
+      serverDate: Date(timeIntervalSince1970: 100)
+    ).validated()
+  }
+
+  private func makeSlot(token: String = "token") throws -> SharedSessionOwnerSlot {
+    try SharedSessionOwnerSlot(
+      schemaVersion: SharedSessionOwnerSlot.schemaVersion,
+      instanceFingerprint: "instance",
+      slotOwnerIdentifier: "app.owner",
+      event: makeEvent(token: token, generation: 1)
+    )
+  }
+}
+
+@MainActor
+private final class RecoverySharedSessionNotifier: SharedSessionSyncNotifying {
+  func setHandler(_: @escaping @MainActor () -> Void) {}
+  func post() {}
+}
+
+private final class RecoveryTargetProvider:
+  SharedSessionClearRecoveryTargets,
+  @unchecked Sendable
+{
+  enum Failure: Error {
+    case unexpectedIntent
+  }
+
+  private let originalIntent: SharedSessionOwnerSlotClearRecovery.Intent
+  private let originalIdentityStore: any SharedSessionLocalIdentityStoring
+  private let originalSlotStore: any SharedSessionSlotStoring
+  private let otherIdentityStore: (any SharedSessionLocalIdentityStoring)?
+  private let otherSlotStore: (any SharedSessionSlotStoring)?
+
+  init(
+    originalIntent: SharedSessionOwnerSlotClearRecovery.Intent,
+    originalIdentityStore: any SharedSessionLocalIdentityStoring,
+    originalSlotStore: any SharedSessionSlotStoring,
+    otherIdentityStore: (any SharedSessionLocalIdentityStoring)? = nil,
+    otherSlotStore: (any SharedSessionSlotStoring)? = nil
+  ) {
+    self.originalIntent = originalIntent
+    self.originalIdentityStore = originalIdentityStore
+    self.originalSlotStore = originalSlotStore
+    self.otherIdentityStore = otherIdentityStore
+    self.otherSlotStore = otherSlotStore
+  }
+
+  func localIdentityStore(
+    for intent: SharedSessionOwnerSlotClearRecovery.Intent
+  ) throws -> any SharedSessionLocalIdentityStoring {
+    if intent == originalIntent { return originalIdentityStore }
+    guard let otherIdentityStore else { throw Failure.unexpectedIntent }
+    return otherIdentityStore
+  }
+
+  func slotStore(
+    for intent: SharedSessionOwnerSlotClearRecovery.Intent
+  ) throws -> any SharedSessionSlotStoring {
+    if intent == originalIntent { return originalSlotStore }
+    guard let otherSlotStore else { throw Failure.unexpectedIntent }
+    return otherSlotStore
+  }
+}
+
+private final class RecoveryOwnerSlotStore: SharedSessionSlotStoring, @unchecked Sendable {
+  enum Failure: Error {
+    case delete
+  }
+
+  private let lock = NSLock()
+  private var slot: SharedSessionOwnerSlot?
+  private let deleteFails: Bool
+  private let futureSchemaVersion: Int?
+
+  init(
+    slot: SharedSessionOwnerSlot?,
+    deleteFails: Bool = false,
+    futureSchemaVersion: Int? = nil
+  ) {
+    self.slot = slot
+    self.deleteFails = deleteFails
+    self.futureSchemaVersion = futureSchemaVersion
+  }
+
+  func loadOwnSlot() throws -> SharedSessionOwnerSlot? {
+    lock.withLock { slot }
+  }
+
+  func loadAllSlots() throws -> [SharedSessionOwnerSlot] {
+    lock.withLock { slot.map { [$0] } ?? [] }
+  }
+
+  func saveOwnSlot(_ slot: SharedSessionOwnerSlot) throws {
+    lock.withLock { self.slot = slot }
+  }
+
+  func deleteOwnSlot() throws {
+    try lock.withLock {
+      if let futureSchemaVersion {
+        throw SharedSessionOwnerSlotStoreError.futureSchemaVersion(
+          futureSchemaVersion
+        )
+      }
+      if deleteFails { throw Failure.delete }
+      slot = nil
+    }
+  }
+}
+
+private final class DeleteFailingRecoveryIdentityStore:
+  SharedSessionLocalIdentityStoring,
+  @unchecked Sendable
+{
+  enum Failure: Error {
+    case delete
+  }
+
+  func loadRecord() throws -> SharedSessionLocalIdentityRecord? {
+    nil
+  }
+
+  func updateRecord(
+    _ update: (SharedSessionLocalIdentityRecord?) throws -> SharedSessionLocalIdentityRecord?
+  ) throws {
+    guard try update(nil) != nil else { throw Failure.delete }
+  }
+
+  func invalidateOperations(through _: UInt64) throws {}
+
+  func save(
+    _: SharedSessionLocalIdentity,
+    operationRevision _: UInt64
+  ) throws -> Bool {
+    true
+  }
+
+  func delete(operationRevision _: UInt64) throws -> Bool {
+    throw Failure.delete
+  }
+
+  func deleteInvalidatingOperations(through _: UInt64) throws {
+    throw Failure.delete
+  }
+}

--- a/Tests/Core/SharedSessionSyncAdoptionTests.swift
+++ b/Tests/Core/SharedSessionSyncAdoptionTests.swift
@@ -52,10 +52,12 @@ struct SharedSessionSyncAdoptionTests {
       legacyShared: legacyShared
     ).migrateIfNeeded()
 
-    let identity = try #require(try SharedSessionLocalIdentityStore(keychain: destination).load())
+    let store = SharedSessionLocalIdentityStore(keychain: destination)
+    let identity = try #require(try store.load())
     #expect(identity.state == .cleared)
     #expect(identity.deviceToken == "configured-token")
     #expect(identity.client == nil)
+    #expect(try store.loadRecord()?.requiresLegacyAdoptionPublication == true)
     #expect(try privateKeychain.data(forKey: ClerkKeychainKey.cachedEnvironment.rawValue) == environmentData)
   }
 
@@ -131,10 +133,12 @@ struct SharedSessionSyncAdoptionTests {
       legacyShared: legacyShared
     ).migrateIfNeeded()
 
-    let identity = try #require(try SharedSessionLocalIdentityStore(keychain: destination).load())
+    let store = SharedSessionLocalIdentityStore(keychain: destination)
+    let identity = try #require(try store.load())
     #expect(identity.state == .cleared)
     #expect(identity.deviceToken == "bundle-token")
     #expect(identity.client == nil)
+    #expect(try store.loadRecord()?.requiresLegacyAdoptionPublication == true)
   }
 
   @Test
@@ -392,10 +396,12 @@ struct SharedSessionSyncAdoptionTests {
       legacyShared: legacyShared
     ).migrateIfNeeded()
 
-    let identity = try #require(try SharedSessionLocalIdentityStore(keychain: destination).load())
+    let store = SharedSessionLocalIdentityStore(keychain: destination)
+    let identity = try #require(try store.load())
     #expect(identity.state == .cleared)
     #expect(identity.deviceToken == "token")
     #expect(identity.client == nil)
+    #expect(try store.loadRecord()?.requiresLegacyAdoptionPublication == false)
   }
 
   @Test

--- a/Tests/Core/SharedSessionSyncTests.swift
+++ b/Tests/Core/SharedSessionSyncTests.swift
@@ -175,6 +175,129 @@ struct SharedSessionSyncTests {
     #expect(node.coordinator.currentDeviceToken == "legacy-signed-in-token")
   }
 
+  @Test(arguments: [false, true])
+  func legacyAdoptionPublicationPreservesProvisionalClientUntilCanonicalResponse(
+    recoveringPendingPublication: Bool
+  ) async throws {
+    let backend = TestSlotBackend()
+    let peerEvent = try makeEvent(
+      owner: "app.custom-flows",
+      generation: 1,
+      clientID: "peer"
+    )
+    try backend.save(
+      SharedSessionOwnerSlot(
+        schemaVersion: SharedSessionOwnerSlot.schemaVersion,
+        instanceFingerprint: "instance",
+        slotOwnerIdentifier: "app.custom-flows",
+        event: peerEvent
+      ),
+      owner: "app.custom-flows"
+    )
+
+    let localStore = TestLocalIdentityStore()
+    try localStore.saveLegacyAdoption(SharedSessionLocalIdentity(
+      state: .cleared,
+      deviceToken: "legacy-token",
+      client: nil,
+      serverDate: nil
+    ))
+    let node = try makeNode(
+      owner: "app.quickstart",
+      backend: backend,
+      hydrateInitialIdentity: false,
+      localStore: localStore
+    )
+    var provisionalClient = Client.mock
+    provisionalClient.id = "provisional-client"
+    node.clerk.identityController.hydrateProvisionalLegacyClientIfNeeded(
+      provisionalClient
+    )
+
+    #expect(!node.coordinator.hydrateInitialSharedState())
+    #expect(node.clerk.client?.id == "provisional-client")
+    #expect(node.clerk.authoritativeClient == nil)
+
+    if recoveringPendingPublication {
+      localStore.failCommits = true
+      let initialReconciliationChanged = await node.coordinator.start().value
+      #expect(!initialReconciliationChanged)
+      #expect(try localStore.loadPendingPublication() != nil)
+      localStore.failCommits = false
+      #expect(await node.coordinator.reloadFromSharedStorage())
+    } else {
+      #expect(await node.coordinator.start().value)
+    }
+
+    #expect(node.clerk.client?.id == "provisional-client")
+    #expect(node.clerk.authoritativeClient == nil)
+    let adoptedIdentity = try #require(try localStore.load())
+    #expect(adoptedIdentity.state == .cleared)
+    #expect(adoptedIdentity.deviceToken == "legacy-token")
+    #expect(adoptedIdentity.client == nil)
+
+    var canonicalClient = Client.mock
+    canonicalClient.id = "canonical-client"
+    try await node.coordinator.handleNetworkResponse(ClientSyncResponseContext(
+      update: .client(canonicalClient),
+      deviceTokenUpdate: .set("legacy-token"),
+      requestDeviceToken: "legacy-token",
+      baseGeneration: 2,
+      serverDate: Date(timeIntervalSince1970: 1),
+      isCanonicalClientRequest: true,
+      clientResponseGeneration: nil,
+      responseSequence: 1
+    ))
+
+    #expect(node.clerk.client?.id == "canonical-client")
+    #expect(node.clerk.authoritativeClient?.id == "canonical-client")
+  }
+
+  @Test
+  func ordinarySharedClearReplacesMatchingProvisionalClient() async throws {
+    let backend = TestSlotBackend()
+    let initialIdentity = SharedSessionLocalIdentity(
+      state: .cleared,
+      deviceToken: "shared-token",
+      client: nil,
+      serverDate: nil
+    )
+    let node = try makeNode(
+      owner: "app.quickstart",
+      backend: backend,
+      initialIdentity: initialIdentity,
+      hydrateInitialIdentity: false
+    )
+    var provisionalClient = Client.mock
+    provisionalClient.id = "provisional-client"
+    node.clerk.identityController.hydrateProvisionalLegacyClientIfNeeded(
+      provisionalClient
+    )
+    let peerClear = try SharedSessionIdentityEvent(
+      id: UUID(),
+      originOwnerIdentifier: "app.custom-flows",
+      generation: 1,
+      state: .cleared,
+      deviceToken: "shared-token",
+      client: nil,
+      serverDate: Date(timeIntervalSince1970: 1)
+    ).validated()
+    try backend.save(
+      SharedSessionOwnerSlot(
+        schemaVersion: SharedSessionOwnerSlot.schemaVersion,
+        instanceFingerprint: "instance",
+        slotOwnerIdentifier: "app.custom-flows",
+        event: peerClear
+      ),
+      owner: "app.custom-flows"
+    )
+
+    #expect(await node.coordinator.start().value)
+
+    #expect(node.clerk.client == nil)
+    #expect(node.clerk.authoritativeClient == nil)
+  }
+
   @Test
   func competingWritesRemainDiscoverableUntilConvergence() async throws {
     let backend = TestSlotBackend()
@@ -1954,6 +2077,54 @@ struct SharedSessionSyncTests {
       backend.allSlots()
         .first { $0.slotOwnerIdentifier == "app.a" }?.event == pending
     )
+  }
+
+  @Test
+  func topologyChangeSettlementUsesRevisionAfterLegacyAdoptionPublication() async throws {
+    let backend = TestSlotBackend()
+    let peerEvent = try makeEvent(
+      owner: "app.b",
+      generation: 1,
+      clientID: "peer"
+    )
+    try backend.save(
+      SharedSessionOwnerSlot(
+        schemaVersion: SharedSessionOwnerSlot.schemaVersion,
+        instanceFingerprint: "instance",
+        slotOwnerIdentifier: "app.b",
+        event: peerEvent
+      ),
+      owner: "app.b"
+    )
+
+    let localStore = TestLocalIdentityStore()
+    try localStore.saveLegacyAdoption(SharedSessionLocalIdentity(
+      state: .cleared,
+      deviceToken: "legacy-token",
+      client: nil,
+      serverDate: nil
+    ))
+    let node = try makeNode(
+      owner: "app.a",
+      backend: backend,
+      hydrateInitialIdentity: false,
+      localStore: localStore
+    )
+
+    #expect(!node.coordinator.hydrateInitialSharedState())
+
+    try await node.coordinator.settlePendingPublicationForTopologyChange()
+
+    let record = try #require(try localStore.loadRecord())
+    #expect(!record.requiresLegacyAdoptionPublication)
+    #expect(record.pendingPublication == nil)
+    let adoptedEvent = try #require(
+      backend.allSlots()
+        .first { $0.slotOwnerIdentifier == "app.a" }?.event
+    )
+    #expect(adoptedEvent.generation == 2)
+    #expect(adoptedEvent.deviceToken == "legacy-token")
+    #expect(adoptedEvent.client == nil)
   }
 
   @Test

--- a/Tests/Core/SharedSessionSyncTests.swift
+++ b/Tests/Core/SharedSessionSyncTests.swift
@@ -1,4 +1,5 @@
 @_spi(FrameworkIntegration) @testable import ClerkKit
+import ConcurrencyExtras
 import Foundation
 import Testing
 
@@ -1175,6 +1176,68 @@ struct SharedSessionSyncTests {
     #expect(request.value(forHTTPHeaderField: "Authorization") == "peer-token")
     #expect(request.value(forHTTPHeaderField: "x-clerk-client-id") == "peer-client")
     #expect(request.clerkSharedSessionBaseGeneration == 1)
+  }
+
+  @Test
+  func concurrentSharedTokenlessRequestsShareStartupTakeoverGeneration() async throws {
+    let startupGate = SharedRequestPreparationGate()
+    let node = try makeNode(
+      owner: "app.receiver",
+      backend: TestSlotBackend(),
+      clientService: MockClientService(get: {
+        await startupGate.suspend()
+        return nil
+      })
+    )
+    defer {
+      startupGate.resume()
+      node.clerk.cleanupManagers()
+    }
+    _ = await node.coordinator.start().value
+    node.clerk.startStartupClientRefreshIfNeeded()
+    try await waitUntil { startupGate.isSuspended }
+    let startupGeneration = node.clerk.clientResponseGeneration
+
+    let identityGate = SharedRequestPreparationGate()
+    let blocker = node.coordinator.enqueueSerializedLocalIdentityOperation {
+      await identityGate.suspend()
+    }
+    try await waitUntil { identityGate.isSuspended }
+    let middleware = ClerkHeaderRequestMiddleware(runtimeScope: node.clerk.runtimeScope)
+    let url = try #require(URL(string: "https://example.com/v1/client/sign_ups"))
+
+    func prepareTokenlessRequest() async throws -> URLRequest {
+      var request = URLRequest(url: url)
+      request.setClerkStartupClientRefreshTakeoverID(UUID())
+      try await middleware.prepare(&request)
+      return request
+    }
+
+    var firstResult: URLRequest?
+    var secondResult: URLRequest?
+    try await withMainSerialExecutor {
+      let firstTask = Task { @MainActor in
+        try await prepareTokenlessRequest()
+      }
+      await Task.yield()
+      let secondTask = Task { @MainActor in
+        try await prepareTokenlessRequest()
+      }
+      await Task.yield()
+      identityGate.resume()
+      _ = try await blocker.value
+      firstResult = try await firstTask.value
+      secondResult = try await secondTask.value
+    }
+
+    let first = try #require(firstResult)
+    let second = try #require(secondResult)
+
+    #expect(node.clerk.clientResponseGeneration != startupGeneration)
+    #expect(first.clerkRequestDeviceToken == nil)
+    #expect(second.clerkRequestDeviceToken == nil)
+    #expect(first.clerkClientResponseGeneration == second.clerkClientResponseGeneration)
+    #expect(first.clerkClientResponseGeneration == node.clerk.clientResponseGeneration)
   }
 
   @Test

--- a/Tests/Core/SharedSessionSyncTests.swift
+++ b/Tests/Core/SharedSessionSyncTests.swift
@@ -1857,6 +1857,39 @@ struct SharedSessionSyncTests {
   }
 
   @Test
+  func topologyChangeSettlesPendingPublicationIntoCanonicalIdentity() async throws {
+    let backend = TestSlotBackend()
+    let previous = SharedSessionLocalIdentity(
+      state: .present,
+      deviceToken: "previous-token",
+      client: makeClient(id: "previous"),
+      serverDate: Date(timeIntervalSince1970: 100)
+    )
+    let node = try makeNode(
+      owner: "app.a",
+      backend: backend,
+      initialIdentity: previous
+    )
+    let pending = try makeEvent(
+      owner: "app.a",
+      generation: 4,
+      clientID: "pending"
+    )
+    try node.localStore.stagePendingPublication(pending)
+
+    try await node.coordinator.settlePendingPublicationForTopologyChange()
+
+    let record = try #require(try node.localStore.loadRecord())
+    #expect(record.pendingPublication == nil)
+    #expect(record.acceptedIdentity?.client?.id == "pending")
+    #expect(node.clerk.client?.id == "pending")
+    #expect(
+      backend.allSlots()
+        .first { $0.slotOwnerIdentifier == "app.a" }?.event == pending
+    )
+  }
+
+  @Test
   func updateDeviceTokenPublishesClearedIdentityBeforeRefreshFailure() async throws {
     let backend = TestSlotBackend()
     let previous = SharedSessionLocalIdentity(

--- a/Tests/Core/SharedSessionSyncTests.swift
+++ b/Tests/Core/SharedSessionSyncTests.swift
@@ -109,6 +109,73 @@ struct SharedSessionSyncTests {
   }
 
   @Test
+  func newlyAdoptedLegacyTokenPublishesAheadOfExistingSignedOutPeer() async throws {
+    let backend = TestSlotBackend()
+    let signedOutPeer = try makeEvent(
+      owner: "app.custom-flows",
+      generation: 1,
+      clientID: "signed-out-peer"
+    )
+    try backend.save(
+      SharedSessionOwnerSlot(
+        schemaVersion: SharedSessionOwnerSlot.schemaVersion,
+        instanceFingerprint: "instance",
+        slotOwnerIdentifier: "app.custom-flows",
+        event: signedOutPeer
+      ),
+      owner: "app.custom-flows"
+    )
+
+    let localStore = TestLocalIdentityStore()
+    try localStore.saveLegacyAdoption(SharedSessionLocalIdentity(
+      state: .cleared,
+      deviceToken: "legacy-signed-in-token",
+      client: nil,
+      serverDate: nil
+    ))
+    let node = try makeNode(
+      owner: "app.quickstart",
+      backend: backend,
+      hydrateInitialIdentity: false,
+      localStore: localStore
+    )
+
+    #expect(!node.coordinator.hydrateInitialSharedState())
+    #expect(node.coordinator.currentDeviceToken == "legacy-signed-in-token")
+
+    #expect(await node.coordinator.start().value)
+
+    let adoptedSlot = try #require(
+      backend.allSlots().first {
+        $0.slotOwnerIdentifier == "app.quickstart"
+      }
+    )
+    #expect(adoptedSlot.event.generation == 2)
+    #expect(adoptedSlot.event.deviceToken == "legacy-signed-in-token")
+    #expect(adoptedSlot.event.client == nil)
+    let adoptedRecord = try #require(try localStore.loadRecord())
+    #expect(!adoptedRecord.requiresLegacyAdoptionPublication)
+    #expect(adoptedRecord.pendingPublication == nil)
+
+    var signedInClient = Client.mock
+    signedInClient.id = "signed-in-client"
+    try await node.coordinator.handleNetworkResponse(ClientSyncResponseContext(
+      update: .client(signedInClient),
+      deviceTokenUpdate: .set("legacy-signed-in-token"),
+      requestDeviceToken: "legacy-signed-in-token",
+      baseGeneration: 2,
+      serverDate: Date(timeIntervalSince1970: 1),
+      isCanonicalClientRequest: true,
+      clientResponseGeneration: nil,
+      responseSequence: 1
+    ))
+
+    #expect(node.clerk.client?.id == "signed-in-client")
+    #expect(node.clerk.user != nil)
+    #expect(node.coordinator.currentDeviceToken == "legacy-signed-in-token")
+  }
+
+  @Test
   func competingWritesRemainDiscoverableUntilConvergence() async throws {
     let backend = TestSlotBackend()
     let first = try makeNode(owner: "app.a", backend: backend)

--- a/Tests/Core/SharedSessionSyncTests.swift
+++ b/Tests/Core/SharedSessionSyncTests.swift
@@ -2255,12 +2255,29 @@ struct SharedSessionSyncTests {
     let apiClient = createMockAPIClient(
       runtimeScope: .init(epoch: clerk.configurationEpoch, clerkProvider: { clerk })
     )
+    let slotStore = TestOwnerSlotStore(owner: owner, backend: backend)
+    let recoveryIntent = SharedSessionOwnerSlotClearRecovery.Intent(
+      localIdentityService: "identity.\(owner)",
+      slotService: "slots.instance",
+      slotAccessGroup: "group.shared",
+      slotAccount: "owner.\(owner)",
+      instanceFingerprint: "instance",
+      ownerIdentifier: owner
+    )
     let dependencies = MockDependencyContainer(
       apiClient: apiClient,
       keychain: keychain,
       appLocalKeychain: keychain,
       identityKeychain: keychain,
       atomicIdentityStore: localStore,
+      sharedSessionOwnerSlotClearRecovery: .init(
+        journal: InMemoryKeychain(),
+        currentIntent: recoveryIntent,
+        targetProvider: TestClearRecoveryTargets(
+          identityStore: localStore,
+          slotStore: slotStore
+        )
+      ),
       clientService: clientService ?? MockClientService(get: { nil })
     )
     try dependencies.configurationManager.configure(
@@ -2276,7 +2293,7 @@ struct SharedSessionSyncTests {
     let coordinator = SharedSessionSyncCoordinator(
       ownerIdentifier: owner,
       instanceFingerprint: "instance",
-      slotStore: TestOwnerSlotStore(owner: owner, backend: backend),
+      slotStore: slotStore,
       localIdentityStore: localStore,
       notifier: notifier,
       configurationEpoch: clerk.configurationEpoch,
@@ -2561,6 +2578,23 @@ private struct TestOwnerSlotStore: SharedSessionSlotStoring {
 
   func deleteOwnSlot() throws {
     try backend.delete(owner: owner)
+  }
+}
+
+private struct TestClearRecoveryTargets: SharedSessionClearRecoveryTargets {
+  let identityStore: any SharedSessionLocalIdentityStoring
+  let slotStore: any SharedSessionSlotStoring
+
+  func localIdentityStore(
+    for _: SharedSessionOwnerSlotClearRecovery.Intent
+  ) throws -> any SharedSessionLocalIdentityStoring {
+    identityStore
+  }
+
+  func slotStore(
+    for _: SharedSessionOwnerSlotClearRecovery.Intent
+  ) throws -> any SharedSessionSlotStoring {
+    slotStore
   }
 }
 

--- a/Tests/Core/SharedSessionTopologyMigrationTests.swift
+++ b/Tests/Core/SharedSessionTopologyMigrationTests.swift
@@ -1,0 +1,249 @@
+@testable import ClerkKit
+import Foundation
+import Testing
+
+@Suite(.serialized)
+struct SharedSessionTopologyMigrationTests {
+  @Test
+  func emptyDestinationPublishesCompleteAcceptedIdentity() throws {
+    let identity = makeIdentity(clientID: "accepted")
+    let localStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    let slotStore = TopologyOwnerSlotStore(ownerIdentifier: "app.new")
+
+    let rollback = try SharedSessionTopologyMigration.prepare(
+      identity: identity,
+      destinationIdentityStore: localStore,
+      destinationSlotStore: slotStore,
+      destinationInstanceFingerprint: "destination",
+      destinationOwnerIdentifier: "app.new"
+    )
+
+    #expect(try localStore.load() == identity)
+    let slot = try #require(try slotStore.loadOwnSlot())
+    #expect(slot.instanceFingerprint == "destination")
+    #expect(slot.event.originOwnerIdentifier == "app.new")
+    #expect(slot.event.generation == 1)
+    #expect(slot.event.deviceToken == identity.deviceToken)
+    #expect(slot.event.client == identity.client)
+    #expect(slot.event.serverDate == identity.serverDate)
+
+    try rollback.restore()
+    #expect(try localStore.loadRecord() == nil)
+    #expect(try slotStore.loadOwnSlot() == nil)
+  }
+
+  @Test
+  func sourceSlotReplacementAdvancesDestinationGeneration() throws {
+    let sourceSlot = try makeSlot(
+      owner: "app.old",
+      generation: 7,
+      identity: makeIdentity(clientID: "old")
+    )
+    let slotStore = TopologyOwnerSlotStore(
+      ownerIdentifier: "app.new",
+      slots: [sourceSlot]
+    )
+    let localStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+
+    _ = try SharedSessionTopologyMigration.prepare(
+      identity: makeIdentity(clientID: "accepted"),
+      destinationIdentityStore: localStore,
+      destinationSlotStore: slotStore,
+      destinationInstanceFingerprint: "instance",
+      destinationOwnerIdentifier: "app.new",
+      excludingSourceOwnerIdentifier: "app.old"
+    )
+
+    let destinationSlot = try #require(try slotStore.loadOwnSlot())
+    #expect(destinationSlot.event.generation == 8)
+    #expect(destinationSlot.event.client?.id == "accepted")
+  }
+
+  @Test
+  func staleDestinationOwnedSlotIsReplacedWhenNoPeerExists() throws {
+    let staleIdentity = makeIdentity(clientID: "stale")
+    let staleSlot = try makeSlot(
+      owner: "app.new",
+      generation: 7,
+      identity: staleIdentity
+    )
+    let slotStore = TopologyOwnerSlotStore(
+      ownerIdentifier: "app.new",
+      slots: [staleSlot]
+    )
+    let localStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+
+    let rollback = try SharedSessionTopologyMigration.prepare(
+      identity: makeIdentity(clientID: "accepted"),
+      destinationIdentityStore: localStore,
+      destinationSlotStore: slotStore,
+      destinationInstanceFingerprint: "instance",
+      destinationOwnerIdentifier: "app.new"
+    )
+
+    let destinationSlot = try #require(try slotStore.loadOwnSlot())
+    #expect(destinationSlot.event.generation == 8)
+    #expect(destinationSlot.event.client?.id == "accepted")
+    #expect(try localStore.load()?.client?.id == "accepted")
+
+    try rollback.restore()
+    #expect(try slotStore.loadOwnSlot() == staleSlot)
+    #expect(try localStore.loadRecord() == nil)
+  }
+
+  @Test
+  func existingPendingPublicationIsSupersededTransactionally() throws {
+    let previousIdentity = makeIdentity(clientID: "previous")
+    let pendingPublication = try makeEvent(
+      owner: "app.old",
+      generation: 9,
+      identity: makeIdentity(clientID: "pending")
+    )
+    let localStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    try localStore.save(previousIdentity)
+    try localStore.stagePendingPublication(pendingPublication)
+    let previousRecord = try localStore.loadRecord()
+    let slotStore = TopologyOwnerSlotStore(ownerIdentifier: "app.new")
+
+    let rollback = try SharedSessionTopologyMigration.prepare(
+      identity: makeIdentity(clientID: "accepted"),
+      destinationIdentityStore: localStore,
+      destinationSlotStore: slotStore,
+      destinationInstanceFingerprint: "destination",
+      destinationOwnerIdentifier: "app.new"
+    )
+
+    let slot = try #require(try slotStore.loadOwnSlot())
+    #expect(slot.event.generation == 10)
+    #expect(slot.event.client?.id == "accepted")
+    #expect(try localStore.load()?.client?.id == "accepted")
+    #expect(try localStore.loadPendingPublication() == nil)
+
+    try rollback.restore()
+    #expect(try localStore.loadRecord() == previousRecord)
+    #expect(try slotStore.loadOwnSlot() == nil)
+  }
+
+  @Test
+  func destinationPublicationFailureRestoresPreviousLocalIdentity() throws {
+    let previousIdentity = makeIdentity(clientID: "previous")
+    let localStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    try localStore.save(previousIdentity)
+    try localStore.stagePendingPublication(makeEvent(
+      owner: "app.old",
+      generation: 4,
+      identity: makeIdentity(clientID: "pending")
+    ))
+    let previousRecord = try localStore.loadRecord()
+    let slotStore = TopologyOwnerSlotStore(
+      ownerIdentifier: "app.new",
+      saveFails: true
+    )
+
+    #expect(throws: TopologyOwnerSlotStore.Failure.save) {
+      _ = try SharedSessionTopologyMigration.prepare(
+        identity: makeIdentity(clientID: "accepted"),
+        destinationIdentityStore: localStore,
+        destinationSlotStore: slotStore,
+        destinationInstanceFingerprint: "destination",
+        destinationOwnerIdentifier: "app.new"
+      )
+    }
+
+    #expect(try localStore.loadRecord() == previousRecord)
+    #expect(try slotStore.loadOwnSlot() == nil)
+  }
+
+  private func makeIdentity(clientID: String) -> ClerkIdentitySnapshot {
+    var client = Client.mockSignedOut
+    client.id = clientID
+    return ClerkIdentitySnapshot(
+      state: .present,
+      deviceToken: "token-\(clientID)",
+      client: client,
+      serverDate: Date(timeIntervalSince1970: 100)
+    )
+  }
+
+  private func makeSlot(
+    owner: String,
+    generation: UInt64,
+    identity: ClerkIdentitySnapshot
+  ) throws -> SharedSessionOwnerSlot {
+    try SharedSessionOwnerSlot(
+      schemaVersion: SharedSessionOwnerSlot.schemaVersion,
+      instanceFingerprint: "instance",
+      slotOwnerIdentifier: owner,
+      event: SharedSessionIdentityEvent(
+        id: UUID(),
+        originOwnerIdentifier: owner,
+        generation: generation,
+        state: identity.state,
+        deviceToken: identity.deviceToken,
+        client: identity.client,
+        serverDate: identity.serverDate
+      ).validated()
+    )
+  }
+
+  private func makeEvent(
+    owner: String,
+    generation: UInt64,
+    identity: ClerkIdentitySnapshot
+  ) throws -> SharedSessionIdentityEvent {
+    try SharedSessionIdentityEvent(
+      id: UUID(),
+      originOwnerIdentifier: owner,
+      generation: generation,
+      state: identity.state,
+      deviceToken: identity.deviceToken,
+      client: identity.client,
+      serverDate: identity.serverDate
+    ).validated()
+  }
+}
+
+private final class TopologyOwnerSlotStore: SharedSessionSlotStoring, @unchecked Sendable {
+  enum Failure: Error {
+    case save
+  }
+
+  private let lock = NSLock()
+  private let ownerIdentifier: String
+  private var slots: [SharedSessionOwnerSlot]
+  private let saveFails: Bool
+
+  init(
+    ownerIdentifier: String,
+    slots: [SharedSessionOwnerSlot] = [],
+    saveFails: Bool = false
+  ) {
+    self.ownerIdentifier = ownerIdentifier
+    self.slots = slots
+    self.saveFails = saveFails
+  }
+
+  func loadOwnSlot() throws -> SharedSessionOwnerSlot? {
+    lock.withLock {
+      slots.first { $0.slotOwnerIdentifier == ownerIdentifier }
+    }
+  }
+
+  func loadAllSlots() throws -> [SharedSessionOwnerSlot] {
+    lock.withLock { slots }
+  }
+
+  func saveOwnSlot(_ slot: SharedSessionOwnerSlot) throws {
+    try lock.withLock {
+      if saveFails { throw Failure.save }
+      slots.removeAll { $0.slotOwnerIdentifier == ownerIdentifier }
+      slots.append(slot)
+    }
+  }
+
+  func deleteOwnSlot() throws {
+    lock.withLock {
+      slots.removeAll { $0.slotOwnerIdentifier == ownerIdentifier }
+    }
+  }
+}

--- a/Tests/Core/SharedSessionTopologyMigrationTests.swift
+++ b/Tests/Core/SharedSessionTopologyMigrationTests.swift
@@ -155,6 +155,38 @@ struct SharedSessionTopologyMigrationTests {
   }
 
   @Test
+  func finalIdentityCommitFailureRollsBackPublishedSlotAndRecord() throws {
+    let previousIdentity = makeIdentity(clientID: "previous")
+    let previousRecord = SharedSessionLocalIdentityRecord(
+      acceptedIdentity: previousIdentity,
+      pendingPublication: nil
+    )
+    let localStore = CommitFailingTopologyIdentityStore(record: previousRecord)
+    let previousSlot = try makeSlot(
+      owner: "app.new",
+      generation: 3,
+      identity: previousIdentity
+    )
+    let slotStore = TopologyOwnerSlotStore(
+      ownerIdentifier: "app.new",
+      slots: [previousSlot]
+    )
+
+    #expect(throws: CommitFailingTopologyIdentityStore.Failure.commit) {
+      _ = try SharedSessionTopologyMigration.prepare(
+        identity: makeIdentity(clientID: "accepted"),
+        destinationIdentityStore: localStore,
+        destinationSlotStore: slotStore,
+        destinationInstanceFingerprint: "destination",
+        destinationOwnerIdentifier: "app.new"
+      )
+    }
+
+    #expect(try localStore.loadRecord() == previousRecord)
+    #expect(try slotStore.loadOwnSlot() == previousSlot)
+  }
+
+  @Test
   func rollbackPreservesNewerDestinationPublicationAndIdentity() throws {
     let localStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
     let slotStore = TopologyOwnerSlotStore(ownerIdentifier: "app.new")
@@ -275,6 +307,39 @@ struct SharedSessionTopologyMigrationTests {
       client: identity.client,
       serverDate: identity.serverDate
     ).validated()
+  }
+}
+
+private final class CommitFailingTopologyIdentityStore: SharedSessionLocalIdentityStoring, @unchecked Sendable {
+  enum Failure: Error {
+    case commit
+  }
+
+  private let lock = NSLock()
+  private var record: SharedSessionLocalIdentityRecord?
+  private var shouldFailNextCommit = true
+
+  init(record: SharedSessionLocalIdentityRecord?) {
+    self.record = record
+  }
+
+  func loadRecord() throws -> SharedSessionLocalIdentityRecord? {
+    lock.withLock { record }
+  }
+
+  func updateRecord(
+    _ update: (SharedSessionLocalIdentityRecord?) throws -> SharedSessionLocalIdentityRecord?
+  ) throws {
+    try lock.withLock {
+      let updatedRecord = try update(record)
+      let isCommit = record?.pendingPublication != nil
+        && updatedRecord?.pendingPublication == nil
+      if isCommit, shouldFailNextCommit {
+        shouldFailNextCommit = false
+        throw Failure.commit
+      }
+      record = updatedRecord
+    }
   }
 }
 

--- a/Tests/Core/SharedSessionTopologyMigrationTests.swift
+++ b/Tests/Core/SharedSessionTopologyMigrationTests.swift
@@ -154,6 +154,81 @@ struct SharedSessionTopologyMigrationTests {
     #expect(try slotStore.loadOwnSlot() == nil)
   }
 
+  @Test
+  func rollbackPreservesNewerDestinationPublicationAndIdentity() throws {
+    let localStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    let slotStore = TopologyOwnerSlotStore(ownerIdentifier: "app.new")
+    let rollback = try SharedSessionTopologyMigration.prepare(
+      identity: makeIdentity(clientID: "migrated"),
+      destinationIdentityStore: localStore,
+      destinationSlotStore: slotStore,
+      destinationInstanceFingerprint: "instance",
+      destinationOwnerIdentifier: "app.new"
+    )
+    let newerIdentity = makeIdentity(clientID: "newer")
+    let newerSlot = try makeSlot(
+      owner: "app.new",
+      generation: 99,
+      identity: newerIdentity
+    )
+    try slotStore.saveOwnSlot(newerSlot)
+    try localStore.save(newerIdentity)
+
+    #expect(throws: SharedSessionTopologyMigrationError.destinationSlotChanged) {
+      try rollback.restore()
+    }
+
+    #expect(try slotStore.loadOwnSlot() == newerSlot)
+    #expect(try localStore.load() == newerIdentity)
+  }
+
+  @Test
+  func rollbackKeepsMigratedIdentityWhenDestinationSlotWasSuperseded() throws {
+    let localStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    let slotStore = TopologyOwnerSlotStore(ownerIdentifier: "app.new")
+    let migratedIdentity = makeIdentity(clientID: "migrated")
+    let rollback = try SharedSessionTopologyMigration.prepare(
+      identity: migratedIdentity,
+      destinationIdentityStore: localStore,
+      destinationSlotStore: slotStore,
+      destinationInstanceFingerprint: "instance",
+      destinationOwnerIdentifier: "app.new"
+    )
+    let newerSlot = try makeSlot(
+      owner: "app.new",
+      generation: 99,
+      identity: migratedIdentity
+    )
+    try slotStore.saveOwnSlot(newerSlot)
+
+    #expect(throws: SharedSessionTopologyMigrationError.destinationSlotChanged) {
+      try rollback.restore()
+    }
+
+    #expect(try slotStore.loadOwnSlot() == newerSlot)
+    #expect(try localStore.load() == migratedIdentity)
+  }
+
+  @Test
+  func rollbackPreservesNewerDestinationIdentityWithoutSlotPublication() throws {
+    let localStore = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    let rollback = try SharedSessionTopologyMigration.prepare(
+      identity: makeIdentity(clientID: "migrated"),
+      destinationIdentityStore: localStore,
+      destinationSlotStore: nil,
+      destinationInstanceFingerprint: nil,
+      destinationOwnerIdentifier: nil
+    )
+    let newerIdentity = makeIdentity(clientID: "newer")
+    try localStore.save(newerIdentity)
+
+    #expect(throws: SharedSessionTopologyMigrationError.destinationIdentityChanged) {
+      try rollback.restore()
+    }
+
+    #expect(try localStore.load() == newerIdentity)
+  }
+
   private func makeIdentity(clientID: String) -> ClerkIdentitySnapshot {
     var client = Client.mockSignedOut
     client.id = clientID

--- a/Tests/Core/WatchSyncPayloadTests.swift
+++ b/Tests/Core/WatchSyncPayloadTests.swift
@@ -258,6 +258,43 @@ struct WatchSyncPayloadTests {
   }
 
   @Test
+  func whitespaceDeviceTokenPersistsAsClearedMetadata() throws {
+    let keychain = InMemoryKeychain()
+    let coordinator = WatchConnectivityCoordinator()
+
+    let metadata = try coordinator.persistDeviceTokenState(
+      .set,
+      deviceToken: " \n\t ",
+      version: WatchSyncVersion(rawValue: 1),
+      keychain: keychain
+    )
+
+    #expect(metadata.deviceTokenState == .cleared)
+    #expect(metadata.deviceTokenVersion == 1)
+    #expect(metadata.deviceTokenFingerprint == WatchConnectivityCoordinator.deviceTokenFingerprint(nil))
+  }
+
+  @Test
+  func identityChangeNormalizesWhitespaceDeviceTokenBeforePublishingMetadata() throws {
+    configureClerkForTesting()
+    let clerk = Clerk()
+    let keychain = InMemoryKeychain()
+    try keychain.set(" \n\t ", forKey: ClerkKeychainKey.clerkDeviceToken.rawValue)
+    clerk.dependencies = MockDependencyContainer(
+      apiClient: clerk.dependencies.apiClient,
+      keychain: keychain,
+      telemetryCollector: clerk.dependencies.telemetryCollector
+    )
+    let coordinator = WatchConnectivityCoordinator()
+
+    try coordinator.handle(.identityDidChange, from: clerk)
+
+    let metadata = try WatchSyncMetadataStore(keychain: keychain).load()
+    #expect(metadata.deviceTokenState == .cleared)
+    #expect(metadata.deviceTokenFingerprint == WatchConnectivityCoordinator.deviceTokenFingerprint(nil))
+  }
+
+  @Test
   func watchTokenClearCannotSignOutAnActivePhone() async throws {
     configureClerkForTesting()
     let clerk = Clerk()

--- a/Tests/Core/WatchSyncPayloadTests.swift
+++ b/Tests/Core/WatchSyncPayloadTests.swift
@@ -150,7 +150,7 @@ struct WatchSyncPayloadTests {
       options: .init(watchConnectivityEnabled: true)
     )
 
-    clerk.performConfiguration(dependencies: dependencies)
+    try clerk.performConfiguration(dependencies: dependencies)
     defer { clerk.cleanupManagers() }
 
     #expect(clerk.client?.id == cachedClient.id)
@@ -744,6 +744,45 @@ struct WatchSyncPayloadTests {
     #expect(try keychain.string(forKey: ClerkKeychainKey.clerkDeviceToken.rawValue) == "new-token")
     #expect(clerk.client == nil)
     #expect(clerk.lastClientServerFetchDate == nil)
+  }
+
+  @Test
+  func tokenOnlyUpdateDoesNotPromoteProvisionalLegacyClient() async throws {
+    configureClerkForTesting()
+    let clerk = Clerk()
+    let keychain = InMemoryKeychain()
+    let identityStore = SharedSessionLocalIdentityStore(keychain: keychain)
+    clerk.dependencies = MockDependencyContainer(
+      apiClient: clerk.dependencies.apiClient,
+      keychain: keychain,
+      atomicIdentityStore: identityStore,
+      telemetryCollector: clerk.dependencies.telemetryCollector,
+      clientService: MockClientService(get: { throw CancellationError() })
+    )
+    clerk.identityController.localDeviceToken = "device-token"
+    clerk.identityController.hydrateProvisionalLegacyClientIfNeeded(
+      client(id: "provisional-client", updatedAt: 100)
+    )
+    let payload = WatchSyncPayload(
+      deviceTokenUpdate: .tokenSet(
+        token: "device-token",
+        version: WatchSyncVersion(rawValue: 1)
+      ),
+      clientUpdate: .notIncluded,
+      environment: nil
+    )
+    let coordinator = WatchConnectivityCoordinator()
+
+    coordinator.apply(payload, from: .phone, to: clerk)
+    await coordinator.waitForIdentityPublications()
+
+    let persistedIdentity = try #require(try identityStore.load())
+    #expect(clerk.client == nil)
+    #expect(clerk.authoritativeClient == nil)
+    #expect(persistedIdentity.state == .cleared)
+    #expect(persistedIdentity.deviceToken == "device-token")
+    #expect(persistedIdentity.client == nil)
+    #expect(persistedIdentity.serverDate == nil)
   }
 
   @Test

--- a/Tests/Core/WatchSyncPayloadTests.swift
+++ b/Tests/Core/WatchSyncPayloadTests.swift
@@ -275,7 +275,7 @@ struct WatchSyncPayloadTests {
   }
 
   @Test
-  func identityChangeNormalizesWhitespaceDeviceTokenBeforePublishingMetadata() throws {
+  func identityChangeNormalizesWhitespaceDeviceTokenBeforePublishingMetadataAndPayload() throws {
     configureClerkForTesting()
     let clerk = Clerk()
     let keychain = InMemoryKeychain()
@@ -292,6 +292,12 @@ struct WatchSyncPayloadTests {
     let metadata = try WatchSyncMetadataStore(keychain: keychain).load()
     #expect(metadata.deviceTokenState == .cleared)
     #expect(metadata.deviceTokenFingerprint == WatchConnectivityCoordinator.deviceTokenFingerprint(nil))
+    let payload = try WatchSyncPayload(
+      clerk: clerk,
+      metadata: metadata,
+      authGeneration: .initial
+    )
+    #expect(payload.deviceTokenUpdate == .tokenCleared(version: WatchSyncVersion(rawValue: 1)))
   }
 
   @Test

--- a/Tests/Dependencies/DependencyContainerKeychainTests.swift
+++ b/Tests/Dependencies/DependencyContainerKeychainTests.swift
@@ -64,6 +64,37 @@ struct DependencyContainerKeychainTests {
     #expect(container.sharedSessionOwnerSlotClearRecovery == nil)
   }
 
+  @Test
+  @MainActor
+  func constructionCompletesClearRecoveryBeforeReturning() throws {
+    let owner = "com.clerk.tests.deferred-recovery.\(UUID().uuidString)"
+    let recovery = try #require(
+      SharedSessionOwnerSlotClearRecovery.liveContext(
+        ownerIdentifier: owner,
+        currentIntent: nil
+      )
+    )
+    defer {
+      try? recovery.journal.deleteItem(
+        forKey: SharedSessionOwnerSlotClearRecovery.storageKey
+      )
+    }
+    try recovery.journal.set(
+      Data("invalid recovery journal".utf8),
+      forKey: SharedSessionOwnerSlotClearRecovery.storageKey
+    )
+
+    #expect(throws: DecodingError.self) {
+      try DependencyContainer(
+        publishableKey: testPublishableKey,
+        options: .init(),
+        runtimeScope: ClerkRuntimeScope(epoch: .initial),
+        persistentAdoptionEnabledOverride: true,
+        ownerIdentifierProvider: { owner }
+      )
+    }
+  }
+
   #if os(macOS)
   @Test
   @MainActor

--- a/Tests/Dependencies/DependencyContainerKeychainTests.swift
+++ b/Tests/Dependencies/DependencyContainerKeychainTests.swift
@@ -132,7 +132,7 @@ struct DependencyContainerKeychainTests {
     )
 
     #expect(try container.atomicIdentityStore?.loadPendingPublication() != nil)
-    try container.prepareForInstallationAfterIdentityProducersDrain()
+    try container.discardPendingPublicationWhenSharedSyncDisabled()
     #expect(try container.atomicIdentityStore?.loadPendingPublication() == nil)
     #expect(try container.atomicIdentityStore?.load() == accepted)
   }

--- a/Tests/Dependencies/DependencyContainerKeychainTests.swift
+++ b/Tests/Dependencies/DependencyContainerKeychainTests.swift
@@ -71,6 +71,112 @@ struct DependencyContainerKeychainTests {
 
   @Test
   @MainActor
+  func disabledConfigurationWithoutAdoptionMarkerKeepsLegacyPersistenceBoundary() throws {
+    let configuredService = "com.clerk.tests.legacy.\(UUID().uuidString)"
+    let owner = "com.clerk.tests.app.\(UUID().uuidString)"
+    let options = Clerk.Options(
+      keychainConfig: .init(service: configuredService)
+    )
+    let legacyKeychain = SystemKeychain(service: configuredService)
+    let configuration = ConfigurationManager()
+    try configuration.configure(publishableKey: testPublishableKey, options: options)
+    let namespace = SharedSessionNamespace(
+      frontendApiUrl: configuration.frontendApiUrl,
+      publishableKey: configuration.publishableKey
+    )
+    let stableIdentityKeychain = SystemKeychain(
+      service: DependencyContainer.stableIdentityService(
+        configuredService: configuredService,
+        instanceFingerprint: namespace.fingerprint,
+        ownerIdentifier: owner
+      )
+    )
+    defer {
+      for key in [
+        ClerkKeychainKey.clerkDeviceToken.rawValue,
+        ClerkKeychainKey.cachedClient.rawValue,
+        ClerkKeychainKey.cachedClientServerDate.rawValue,
+        ClerkKeychainKey.cachedEnvironment.rawValue,
+      ] {
+        try? legacyKeychain.deleteItem(forKey: key)
+      }
+      try? stableIdentityKeychain.deleteItem(
+        forKey: SharedSessionLocalIdentityStore.storageKey
+      )
+      try? stableIdentityKeychain.deleteItem(
+        forKey: ClerkKeychainKey.sharedSessionSyncAdopted.rawValue
+      )
+    }
+
+    var legacyClient = Client.mock
+    legacyClient.id = "legacy-client"
+    let environmentData = try JSONEncoder.clerkEncoder.encode(Clerk.Environment.mock)
+    try legacyKeychain.set(
+      "legacy-token",
+      forKey: ClerkKeychainKey.clerkDeviceToken.rawValue
+    )
+    try legacyKeychain.set(
+      JSONEncoder.clerkEncoder.encode(legacyClient),
+      forKey: ClerkKeychainKey.cachedClient.rawValue
+    )
+    try legacyKeychain.set(
+      "100",
+      forKey: ClerkKeychainKey.cachedClientServerDate.rawValue
+    )
+    try legacyKeychain.set(
+      environmentData,
+      forKey: ClerkKeychainKey.cachedEnvironment.rawValue
+    )
+
+    let container = try DependencyContainer(
+      publishableKey: testPublishableKey,
+      options: options,
+      runtimeScope: ClerkRuntimeScope(epoch: .initial),
+      persistentAdoptionEnabledOverride: true,
+      ownerIdentifierProvider: { owner }
+    )
+    try container.discardPendingPublicationWhenSharedSyncDisabled()
+
+    #expect(container.atomicIdentityStore == nil)
+    #expect(!container.shouldHydrateProvisionalLegacyClient)
+    #expect(
+      try container.identityKeychain.string(
+        forKey: ClerkKeychainKey.clerkDeviceToken.rawValue
+      ) == "legacy-token"
+    )
+    let cachedClientData = try #require(
+      try container.identityKeychain.data(
+        forKey: ClerkKeychainKey.cachedClient.rawValue
+      )
+    )
+    #expect(
+      try JSONDecoder.clerkDecoder.decode(Client.self, from: cachedClientData).id
+        == "legacy-client"
+    )
+    #expect(
+      try container.identityKeychain.string(
+        forKey: ClerkKeychainKey.cachedClientServerDate.rawValue
+      ) == "100"
+    )
+    #expect(
+      try container.appLocalKeychain.data(
+        forKey: ClerkKeychainKey.cachedEnvironment.rawValue
+      ) == environmentData
+    )
+    #expect(
+      try stableIdentityKeychain.data(
+        forKey: SharedSessionLocalIdentityStore.storageKey
+      ) == nil
+    )
+    #expect(
+      try stableIdentityKeychain.string(
+        forKey: ClerkKeychainKey.sharedSessionSyncAdopted.rawValue
+      ) == nil
+    )
+  }
+
+  @Test
+  @MainActor
   func sharedConfigurationRecordsExactRecoveryTopology() throws {
     let owner = "com.clerk.tests.recovery.\(UUID().uuidString)"
     let options = Clerk.Options(

--- a/Tests/Dependencies/DependencyContainerKeychainTests.swift
+++ b/Tests/Dependencies/DependencyContainerKeychainTests.swift
@@ -71,6 +71,49 @@ struct DependencyContainerKeychainTests {
 
   @Test
   @MainActor
+  func sharedConfigurationRecordsExactRecoveryTopology() throws {
+    let owner = "com.clerk.tests.recovery.\(UUID().uuidString)"
+    let options = Clerk.Options(
+      keychainConfig: .init(
+        service: "com.clerk.tests.service",
+        accessGroup: "  TEAMID.com.clerk.tests.shared\n"
+      ),
+      sharedSessionSync: .enabled
+    )
+    let container = try DependencyContainer(
+      publishableKey: testPublishableKey,
+      options: options,
+      runtimeScope: ClerkRuntimeScope(epoch: .initial),
+      ownerIdentifierProvider: { owner }
+    )
+    let namespace = SharedSessionNamespace(
+      frontendApiUrl: container.configurationManager.frontendApiUrl,
+      publishableKey: container.configurationManager.publishableKey
+    )
+    let intent = try #require(
+      container.sharedSessionOwnerSlotClearRecovery?.currentIntent
+    )
+
+    #expect(intent.localIdentityService == DependencyContainer.stableIdentityService(
+      configuredService: options.keychainConfig.service,
+      instanceFingerprint: namespace.fingerprint,
+      ownerIdentifier: owner
+    ))
+    #expect(intent.slotService == SharedSessionOwnerSlotStore.service(
+      configuredService: options.keychainConfig.service,
+      instanceFingerprint: namespace.fingerprint
+    ))
+    #expect(intent.slotAccessGroup == "TEAMID.com.clerk.tests.shared")
+    #expect(intent.slotAccount == SharedSessionOwnerSlotStore.account(
+      instanceFingerprint: namespace.fingerprint,
+      ownerIdentifier: owner
+    ))
+    #expect(intent.instanceFingerprint == namespace.fingerprint)
+    #expect(intent.ownerIdentifier == owner)
+  }
+
+  @Test
+  @MainActor
   func constructingDisabledTransportDoesNotClearPendingPublication() throws {
     let configuredService = "com.clerk.tests.pending.\(UUID().uuidString)"
     let owner = "com.clerk.tests.app"

--- a/Tests/Dependencies/DependencyContainerKeychainTests.swift
+++ b/Tests/Dependencies/DependencyContainerKeychainTests.swift
@@ -50,6 +50,20 @@ struct DependencyContainerKeychainTests {
     #expect(container.keychain is SystemKeychain)
   }
 
+  @Test
+  @MainActor
+  func disabledPersistentAdoptionDoesNotInstallLiveClearRecovery() throws {
+    let container = try DependencyContainer(
+      publishableKey: testPublishableKey,
+      options: .init(),
+      runtimeScope: ClerkRuntimeScope(epoch: .initial),
+      persistentAdoptionEnabledOverride: false,
+      ownerIdentifierProvider: { "com.clerk.tests.app" }
+    )
+
+    #expect(container.sharedSessionOwnerSlotClearRecovery == nil)
+  }
+
   #if os(macOS)
   @Test
   @MainActor
@@ -177,7 +191,7 @@ struct DependencyContainerKeychainTests {
 
   @Test
   @MainActor
-  func sharedConfigurationRecordsExactRecoveryTopology() throws {
+  func sharedConfigurationBuildsExactRecoveryTopology() throws {
     let owner = "com.clerk.tests.recovery.\(UUID().uuidString)"
     let options = Clerk.Options(
       keychainConfig: .init(
@@ -186,18 +200,17 @@ struct DependencyContainerKeychainTests {
       ),
       sharedSessionSync: .enabled
     )
-    let container = try DependencyContainer(
-      publishableKey: testPublishableKey,
-      options: options,
-      runtimeScope: ClerkRuntimeScope(epoch: .initial),
-      ownerIdentifierProvider: { owner }
-    )
+    let configuration = ConfigurationManager()
+    try configuration.configure(publishableKey: testPublishableKey, options: options)
     let namespace = SharedSessionNamespace(
-      frontendApiUrl: container.configurationManager.frontendApiUrl,
-      publishableKey: container.configurationManager.publishableKey
+      frontendApiUrl: configuration.frontendApiUrl,
+      publishableKey: configuration.publishableKey
     )
     let intent = try #require(
-      container.sharedSessionOwnerSlotClearRecovery?.currentIntent
+      DependencyContainer.makeOwnerSlotClearRecovery(
+        configuration: configuration,
+        ownerIdentifier: owner
+      )?.currentIntent
     )
 
     #expect(intent.localIdentityService == DependencyContainer.stableIdentityService(

--- a/Tests/Domains/Auth/MagicLinkServiceTests.swift
+++ b/Tests/Domains/Auth/MagicLinkServiceTests.swift
@@ -31,7 +31,7 @@ struct MagicLinkServiceTests {
     )
     mock.onRequestHandler = OnRequestHandler { @Sendable request in
       #expect(request.httpMethod == "POST")
-      #expect(request.clerkCanEstablishClientWhenTokenless)
+      #expect(request.clerkStartupClientRefreshTakeoverID != nil)
       requestHandled.setValue(true)
     }
     mock.register()

--- a/Tests/Domains/Auth/MagicLinkServiceTests.swift
+++ b/Tests/Domains/Auth/MagicLinkServiceTests.swift
@@ -1,0 +1,49 @@
+@testable import ClerkKit
+import ConcurrencyExtras
+import Foundation
+import Mocker
+import Testing
+
+@MainActor
+@Suite(.serialized)
+struct MagicLinkServiceTests {
+  init() {
+    configureClerkForTesting()
+  }
+
+  @Test
+  func completeCanEstablishClientWhenTokenless() async throws {
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/magic_links/complete")!
+    let response = MagicLinkCompleteResult.ticket(
+      MagicLinkCompleteResponse(flowId: "flow_123", ticket: "ticket_123")
+    )
+    var mock = try Mock(
+      url: originalURL,
+      ignoreQuery: true,
+      contentType: .json,
+      statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(
+          ClientResponse<MagicLinkCompleteResult>(response: response, client: .mock)
+        ),
+      ]
+    )
+    mock.onRequestHandler = OnRequestHandler { @Sendable request in
+      #expect(request.httpMethod == "POST")
+      #expect(request.clerkCanEstablishClientWhenTokenless)
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    _ = try await Clerk.shared.dependencies.magicLinkService.complete(
+      params: MagicLinkCompleteParams(
+        flowId: "flow_123",
+        approvalToken: "approval_123",
+        codeVerifier: "verifier_123"
+      )
+    )
+
+    #expect(requestHandled.value)
+  }
+}

--- a/Tests/Domains/Auth/SignIn/SignInServiceTests.swift
+++ b/Tests/Domains/Auth/SignIn/SignInServiceTests.swift
@@ -25,7 +25,7 @@ struct SignInServiceTests {
 
     mock.onRequestHandler = OnRequestHandler { @Sendable request in
       #expect(request.httpMethod == "POST")
-      #expect(request.clerkCanEstablishClientWhenTokenless)
+      #expect(request.clerkStartupClientRefreshTakeoverID != nil)
       #expect(request.urlEncodedFormBody!["identifier"] == "test@example.com")
       #expect(request.urlEncodedFormBody!["locale"] != nil)
       requestHandled.setValue(true)

--- a/Tests/Domains/Auth/SignIn/SignInServiceTests.swift
+++ b/Tests/Domains/Auth/SignIn/SignInServiceTests.swift
@@ -25,7 +25,7 @@ struct SignInServiceTests {
 
     mock.onRequestHandler = OnRequestHandler { @Sendable request in
       #expect(request.httpMethod == "POST")
-      #expect(request.clerkCreatesClientWhenTokenless)
+      #expect(request.clerkCanEstablishClientWhenTokenless)
       #expect(request.urlEncodedFormBody!["identifier"] == "test@example.com")
       #expect(request.urlEncodedFormBody!["locale"] != nil)
       requestHandled.setValue(true)

--- a/Tests/Domains/Auth/SignIn/SignInServiceTests.swift
+++ b/Tests/Domains/Auth/SignIn/SignInServiceTests.swift
@@ -25,6 +25,7 @@ struct SignInServiceTests {
 
     mock.onRequestHandler = OnRequestHandler { @Sendable request in
       #expect(request.httpMethod == "POST")
+      #expect(request.clerkCreatesClientWhenTokenless)
       #expect(request.urlEncodedFormBody!["identifier"] == "test@example.com")
       #expect(request.urlEncodedFormBody!["locale"] != nil)
       requestHandled.setValue(true)

--- a/Tests/Domains/Auth/SignUp/SignUpServiceTests.swift
+++ b/Tests/Domains/Auth/SignUp/SignUpServiceTests.swift
@@ -25,7 +25,7 @@ struct SignUpServiceTests {
 
     mock.onRequestHandler = OnRequestHandler { @Sendable request in
       #expect(request.httpMethod == "POST")
-      #expect(request.clerkCanEstablishClientWhenTokenless)
+      #expect(request.clerkStartupClientRefreshTakeoverID != nil)
       #expect(request.urlEncodedFormBody!["email_address"] == "test@example.com")
       #expect(request.urlEncodedFormBody!["password"] == "password123")
       #expect(request.urlEncodedFormBody!["locale"] != nil)

--- a/Tests/Domains/Auth/SignUp/SignUpServiceTests.swift
+++ b/Tests/Domains/Auth/SignUp/SignUpServiceTests.swift
@@ -25,7 +25,7 @@ struct SignUpServiceTests {
 
     mock.onRequestHandler = OnRequestHandler { @Sendable request in
       #expect(request.httpMethod == "POST")
-      #expect(request.clerkCreatesClientWhenTokenless)
+      #expect(request.clerkCanEstablishClientWhenTokenless)
       #expect(request.urlEncodedFormBody!["email_address"] == "test@example.com")
       #expect(request.urlEncodedFormBody!["password"] == "password123")
       #expect(request.urlEncodedFormBody!["locale"] != nil)

--- a/Tests/Domains/Auth/SignUp/SignUpServiceTests.swift
+++ b/Tests/Domains/Auth/SignUp/SignUpServiceTests.swift
@@ -25,6 +25,7 @@ struct SignUpServiceTests {
 
     mock.onRequestHandler = OnRequestHandler { @Sendable request in
       #expect(request.httpMethod == "POST")
+      #expect(request.clerkCreatesClientWhenTokenless)
       #expect(request.urlEncodedFormBody!["email_address"] == "test@example.com")
       #expect(request.urlEncodedFormBody!["password"] == "password123")
       #expect(request.urlEncodedFormBody!["locale"] != nil)

--- a/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
@@ -185,11 +185,13 @@ struct ClerkHeaderRequestMiddlewareTests {
   func tokenlessClientCreationFencesSuspendedStartupRefresh() async throws {
     let clerk = Clerk()
     let gate = RequestIdentityOperationGate()
+    var startupClient = Client.mock
+    startupClient.id = "startup-refresh-client"
     let dependencies = MockDependencyContainer(
       apiClient: createMockAPIClient(runtimeScope: clerk.runtimeScope),
       clientService: MockClientService(get: {
         await gate.suspend()
-        return .mock
+        return startupClient
       })
     )
     clerk.performConfiguration(dependencies: dependencies)
@@ -199,14 +201,43 @@ struct ClerkHeaderRequestMiddlewareTests {
     }
     try await gate.waitUntilSuspended()
     let startupGeneration = clerk.clientResponseGeneration
+    let middleware = ClerkHeaderRequestMiddleware(runtimeScope: clerk.runtimeScope)
+    let signUpURL = try #require(URL(string: "https://example.com/v1/client/sign_ups"))
 
-    var request = try URLRequest(url: #require(URL(string: "https://example.com/v1/client/sign_ups")))
-    request.setClerkCanEstablishClientWhenTokenless(true)
-    try await ClerkHeaderRequestMiddleware(runtimeScope: clerk.runtimeScope).prepare(&request)
+    func prepareTokenlessRequest() async throws -> URLRequest {
+      var request = URLRequest(url: signUpURL)
+      request.setClerkCanEstablishClientWhenTokenless(true)
+      try await middleware.prepare(&request)
+      return request
+    }
 
-    #expect(request.clerkRequestDeviceToken == nil)
+    async let firstRequest = prepareTokenlessRequest()
+    async let secondRequest = prepareTokenlessRequest()
+    let (first, second) = try await (firstRequest, secondRequest)
+
+    #expect(first.clerkRequestDeviceToken == nil)
+    #expect(second.clerkRequestDeviceToken == nil)
     #expect(clerk.clientResponseGeneration != startupGeneration)
-    #expect(request.clerkClientResponseGeneration == clerk.clientResponseGeneration)
+    #expect(first.clerkClientResponseGeneration == second.clerkClientResponseGeneration)
+    #expect(first.clerkClientResponseGeneration == clerk.clientResponseGeneration)
+    #expect(second.clerkClientResponseGeneration == clerk.clientResponseGeneration)
+
+    var staleClient = Client.mock
+    staleClient.id = "stale-startup-client"
+    clerk.applyResponseClient(staleClient, clientResponseGeneration: startupGeneration)
+    #expect(clerk.client == nil)
+
+    var acceptedClient = Client.mock
+    acceptedClient.id = "accepted-tokenless-client"
+    clerk.applyResponseClient(
+      acceptedClient,
+      clientResponseGeneration: second.clerkClientResponseGeneration
+    )
+    #expect(clerk.client?.id == acceptedClient.id)
+
+    gate.resume()
+    await Task.yield()
+    #expect(clerk.client?.id == acceptedClient.id)
   }
 
   @Test

--- a/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
@@ -205,7 +205,7 @@ struct ClerkHeaderRequestMiddlewareTests {
         return startupClient
       })
     )
-    clerk.performConfiguration(dependencies: dependencies)
+    try clerk.performConfiguration(dependencies: dependencies)
     defer {
       startupGate.resume()
       clerk.cleanupManagers()

--- a/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
@@ -182,37 +182,59 @@ struct ClerkHeaderRequestMiddlewareTests {
   }
 
   @Test
-  func tokenlessClientCreationFencesSuspendedStartupRefresh() async throws {
+  func concurrentAtomicTokenlessRequestsShareStartupTakeoverGeneration() async throws {
     let clerk = Clerk()
-    let gate = RequestIdentityOperationGate()
+    let startupGate = RequestIdentityOperationGate()
+    let startupCancellationObserved = RequestStartSignal()
+    let identityStore = ReadCountingIdentityStore(identity: SharedSessionLocalIdentity(
+      state: .cleared,
+      deviceToken: nil,
+      client: nil,
+      serverDate: nil
+    ))
     var startupClient = Client.mock
     startupClient.id = "startup-refresh-client"
     let dependencies = MockDependencyContainer(
       apiClient: createMockAPIClient(runtimeScope: clerk.runtimeScope),
+      atomicIdentityStore: identityStore,
       clientService: MockClientService(get: {
-        await gate.suspend()
+        await startupGate.suspend()
+        #expect(Task.isCancelled)
+        await startupCancellationObserved.signal()
+        try Task.checkCancellation()
         return startupClient
       })
     )
     clerk.performConfiguration(dependencies: dependencies)
     defer {
-      gate.resume()
+      startupGate.resume()
       clerk.cleanupManagers()
     }
-    try await gate.waitUntilSuspended()
+    try await startupGate.waitUntilSuspended()
     let startupGeneration = clerk.clientResponseGeneration
     let middleware = ClerkHeaderRequestMiddleware(runtimeScope: clerk.runtimeScope)
     let signUpURL = try #require(URL(string: "https://example.com/v1/client/sign_ups"))
+    let identityGate = RequestIdentityOperationGate()
+    let blocker = clerk.identityController.enqueueLocalOperation { _ in
+      await identityGate.suspend()
+    }
+    try await identityGate.waitUntilSuspended()
+    let revisionBeforeRequests = clerk.identityController.localOperationRevision
 
     func prepareTokenlessRequest() async throws -> URLRequest {
       var request = URLRequest(url: signUpURL)
-      request.setClerkCanEstablishClientWhenTokenless(true)
+      request.setClerkStartupClientRefreshTakeoverID(UUID())
       try await middleware.prepare(&request)
       return request
     }
 
     async let firstRequest = prepareTokenlessRequest()
     async let secondRequest = prepareTokenlessRequest()
+    try await waitUntil {
+      clerk.identityController.localOperationRevision >= revisionBeforeRequests + 2
+    }
+    identityGate.resume()
+    _ = try await blocker.value
     let (first, second) = try await (firstRequest, secondRequest)
 
     #expect(first.clerkRequestDeviceToken == nil)
@@ -222,22 +244,26 @@ struct ClerkHeaderRequestMiddlewareTests {
     #expect(first.clerkClientResponseGeneration == clerk.clientResponseGeneration)
     #expect(second.clerkClientResponseGeneration == clerk.clientResponseGeneration)
 
-    var staleClient = Client.mock
-    staleClient.id = "stale-startup-client"
-    clerk.applyResponseClient(staleClient, clientResponseGeneration: startupGeneration)
+    try await clerk.identityController.applyNetworkResponse(
+      responseContext(
+        clientID: "stale-startup-client",
+        generation: startupGeneration
+      )
+    )
     #expect(clerk.client == nil)
 
-    var acceptedClient = Client.mock
-    acceptedClient.id = "accepted-tokenless-client"
-    clerk.applyResponseClient(
-      acceptedClient,
-      clientResponseGeneration: second.clerkClientResponseGeneration
+    let acceptedGeneration = try #require(second.clerkClientResponseGeneration)
+    try await clerk.identityController.applyNetworkResponse(
+      responseContext(
+        clientID: "accepted-tokenless-client",
+        generation: acceptedGeneration
+      )
     )
-    #expect(clerk.client?.id == acceptedClient.id)
+    #expect(clerk.client?.id == "accepted-tokenless-client")
 
-    gate.resume()
-    await Task.yield()
-    #expect(clerk.client?.id == acceptedClient.id)
+    startupGate.resume()
+    await startupCancellationObserved.wait()
+    #expect(clerk.client?.id == "accepted-tokenless-client")
   }
 
   @Test
@@ -309,6 +335,33 @@ struct ClerkHeaderRequestMiddlewareTests {
     #expect(request.value(forHTTPHeaderField: "x-bundle-id") != nil, "Should include bundle ID header")
     #expect(request.value(forHTTPHeaderField: "x-is-sandbox") != nil, "Should include sandbox header")
     #expect(["true", "false"].contains(request.value(forHTTPHeaderField: "x-is-sandbox") ?? ""), "Sandbox should be true or false")
+  }
+
+  private func responseContext(
+    clientID: String,
+    generation: ClientResponseGeneration
+  ) -> ClientSyncResponseContext {
+    var client = Client.mockSignedOut
+    client.id = clientID
+    return ClientSyncResponseContext(
+      update: .client(client),
+      deviceTokenUpdate: .set("response-token"),
+      requestDeviceToken: nil,
+      baseGeneration: 0,
+      serverDate: nil,
+      isCanonicalClientRequest: true,
+      clientResponseGeneration: generation,
+      responseSequence: nil
+    )
+  }
+
+  private func waitUntil(_ condition: () -> Bool) async throws {
+    let deadline = ContinuousClock.now + .seconds(1)
+    while ContinuousClock.now < deadline {
+      if condition() { return }
+      await Task.yield()
+    }
+    throw ClerkClientError(message: "Timed out waiting for request identity capture.")
   }
 }
 

--- a/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
@@ -212,6 +212,7 @@ struct ClerkHeaderRequestMiddlewareTests {
     }
     try await startupGate.waitUntilSuspended()
     let startupGeneration = clerk.clientResponseGeneration
+    clerk.identityController.localDeviceToken = " \n\t "
     let middleware = ClerkHeaderRequestMiddleware(runtimeScope: clerk.runtimeScope)
     let signUpURL = try #require(URL(string: "https://example.com/v1/client/sign_ups"))
     let identityGate = RequestIdentityOperationGate()
@@ -239,6 +240,8 @@ struct ClerkHeaderRequestMiddlewareTests {
 
     #expect(first.clerkRequestDeviceToken == nil)
     #expect(second.clerkRequestDeviceToken == nil)
+    #expect(first.value(forHTTPHeaderField: "Authorization") == nil)
+    #expect(second.value(forHTTPHeaderField: "Authorization") == nil)
     #expect(clerk.clientResponseGeneration != startupGeneration)
     #expect(first.clerkClientResponseGeneration == second.clerkClientResponseGeneration)
     #expect(first.clerkClientResponseGeneration == clerk.clientResponseGeneration)

--- a/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
@@ -201,7 +201,7 @@ struct ClerkHeaderRequestMiddlewareTests {
     let startupGeneration = clerk.clientResponseGeneration
 
     var request = try URLRequest(url: #require(URL(string: "https://example.com/v1/client/sign_ups")))
-    request.setClerkCreatesClientWhenTokenless(true)
+    request.setClerkCanEstablishClientWhenTokenless(true)
     try await ClerkHeaderRequestMiddleware(runtimeScope: clerk.runtimeScope).prepare(&request)
 
     #expect(request.clerkRequestDeviceToken == nil)

--- a/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
+++ b/Tests/Middleware/ClerkHeaderRequestMiddlewareTests.swift
@@ -182,6 +182,34 @@ struct ClerkHeaderRequestMiddlewareTests {
   }
 
   @Test
+  func tokenlessClientCreationFencesSuspendedStartupRefresh() async throws {
+    let clerk = Clerk()
+    let gate = RequestIdentityOperationGate()
+    let dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(runtimeScope: clerk.runtimeScope),
+      clientService: MockClientService(get: {
+        await gate.suspend()
+        return .mock
+      })
+    )
+    clerk.performConfiguration(dependencies: dependencies)
+    defer {
+      gate.resume()
+      clerk.cleanupManagers()
+    }
+    try await gate.waitUntilSuspended()
+    let startupGeneration = clerk.clientResponseGeneration
+
+    var request = try URLRequest(url: #require(URL(string: "https://example.com/v1/client/sign_ups")))
+    request.setClerkCreatesClientWhenTokenless(true)
+    try await ClerkHeaderRequestMiddleware(runtimeScope: clerk.runtimeScope).prepare(&request)
+
+    #expect(request.clerkRequestDeviceToken == nil)
+    #expect(clerk.clientResponseGeneration != startupGeneration)
+    #expect(request.clerkClientResponseGeneration == clerk.clientResponseGeneration)
+  }
+
+  @Test
   func omitsClientIdHeaderWhenSkipClientIdHeaderIsPresent() async throws {
     Clerk.shared.client = .mock
 

--- a/Tests/Networking/ClerkAPIClientTests.swift
+++ b/Tests/Networking/ClerkAPIClientTests.swift
@@ -351,7 +351,7 @@ struct ClerkAPIClientTests {
         return recoveredClient
       })
     )
-    clerk.performConfiguration(dependencies: dependencies)
+    try clerk.performConfiguration(dependencies: dependencies)
     defer {
       startupGate.resume()
       clerk.cleanupManagers()
@@ -409,7 +409,7 @@ struct ClerkAPIClientTests {
         return startupClient
       })
     )
-    clerk.performConfiguration(dependencies: dependencies)
+    try clerk.performConfiguration(dependencies: dependencies)
     defer {
       startupGate.resume()
       clerk.cleanupManagers()

--- a/Tests/Networking/ClerkAPIClientTests.swift
+++ b/Tests/Networking/ClerkAPIClientTests.swift
@@ -321,6 +321,117 @@ struct ClerkAPIClientTests {
   }
 
   @Test
+  func failedTokenlessRequestRestartsStartupClientRefresh() async throws {
+    let clerk = Clerk()
+    let startupGate = APIClientStartupGate()
+    let refreshCount = LockIsolated(0)
+    var startupClient = Client.mockSignedOut
+    startupClient.id = "cancelled-startup-client"
+    var recoveredClient = Client.mockSignedOut
+    recoveredClient.id = "recovered-startup-client"
+    let runtimeScope = clerk.runtimeScope
+    let apiClient = APIClient(
+      baseURL: mockBaseUrl,
+      runtimeScope: runtimeScope
+    ) { configuration in
+      configuration.pipeline = .clerkDefault(runtimeScope: runtimeScope)
+        .appendingRequestMiddleware([FailingTokenlessRequestMiddleware()])
+    }
+    let dependencies = MockDependencyContainer(
+      apiClient: apiClient,
+      clientService: MockClientService(get: {
+        let call = refreshCount.withValue {
+          $0 += 1
+          return $0
+        }
+        if call == 1 {
+          await startupGate.suspend()
+          return startupClient
+        }
+        return recoveredClient
+      })
+    )
+    clerk.performConfiguration(dependencies: dependencies)
+    defer {
+      startupGate.resume()
+      clerk.cleanupManagers()
+    }
+    try await waitUntil { startupGate.isSuspended }
+
+    await #expect(throws: FailingTokenlessRequestMiddleware.Failure.self) {
+      _ = try await apiClient.send(Request<EmptyResponse>(
+        path: "/v1/client/sign_ups",
+        method: .post,
+        canEstablishClientWhenTokenless: true
+      ))
+    }
+    try await waitUntil { clerk.client?.id == recoveredClient.id }
+
+    #expect(refreshCount.value == 2)
+    #expect(clerk.client?.id == recoveredClient.id)
+  }
+
+  @Test
+  func successfulTokenlessRequestDoesNotRestartStartupClientRefresh() async throws {
+    let clerk = Clerk()
+    let startupGate = APIClientStartupGate()
+    let refreshCount = LockIsolated(0)
+    var startupClient = Client.mockSignedOut
+    startupClient.id = "cancelled-startup-client"
+    var establishedClient = Client.mockSignedOut
+    establishedClient.id = "established-tokenless-client"
+    let url = URL(string: mockBaseUrl.absoluteString + "/v1/client/sign_ups")!
+    let mock = try Mock(
+      url: url,
+      ignoreQuery: true,
+      contentType: .json,
+      statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(ClientResponse(
+          response: EmptyResponse(),
+          client: establishedClient
+        )),
+      ],
+      additionalHeaders: ["Authorization": "established-token"]
+    )
+    mock.register()
+    let apiClient = createMockAPIClient(runtimeScope: clerk.runtimeScope)
+    let dependencies = MockDependencyContainer(
+      apiClient: apiClient,
+      clientService: MockClientService(get: {
+        let call = refreshCount.withValue {
+          $0 += 1
+          return $0
+        }
+        if call == 1 {
+          await startupGate.suspend()
+        }
+        return startupClient
+      })
+    )
+    clerk.performConfiguration(dependencies: dependencies)
+    defer {
+      startupGate.resume()
+      clerk.cleanupManagers()
+    }
+    try await waitUntil { startupGate.isSuspended }
+
+    _ = try await apiClient.send(Request<EmptyResponse>(
+      path: "/v1/client/sign_ups",
+      method: .post,
+      canEstablishClientWhenTokenless: true
+    ))
+
+    #expect(refreshCount.value == 1)
+    #expect(!clerk.isStartupClientRefreshInProgress)
+    #expect(clerk.client?.id == establishedClient.id)
+
+    startupGate.resume()
+    try await waitUntil { !startupGate.isSuspended }
+    #expect(clerk.client?.id == establishedClient.id)
+  }
+
+  @Test
   func retryPreservesFirstPreparedSharedIdentityContext() async throws {
     let prepareCount = LockIsolated(0)
     let observedContexts = LockIsolated<[(UInt64?, String?, String?, Bool, String?)]>([])
@@ -466,6 +577,42 @@ struct ClerkAPIClientTests {
     }
     #expect(prepareCount.value == 2)
     #expect(observedContexts.value.count == 1)
+  }
+
+  private func waitUntil(_ condition: () -> Bool) async throws {
+    let deadline = ContinuousClock.now + .seconds(1)
+    while ContinuousClock.now < deadline {
+      if condition() { return }
+      await Task.yield()
+    }
+    throw ClerkClientError(message: "Timed out waiting for API client state.")
+  }
+}
+
+private struct FailingTokenlessRequestMiddleware: ClerkRequestMiddleware {
+  enum Failure: Error {
+    case expected
+  }
+
+  func prepare(_: inout URLRequest) async throws {
+    throw Failure.expected
+  }
+}
+
+@MainActor
+private final class APIClientStartupGate {
+  private(set) var isSuspended = false
+  private var continuation: CheckedContinuation<Void, Never>?
+
+  func suspend() async {
+    isSuspended = true
+    await withCheckedContinuation { continuation = $0 }
+    isSuspended = false
+  }
+
+  func resume() {
+    continuation?.resume()
+    continuation = nil
   }
 }
 

--- a/Tests/Storage/CacheManagerTests.swift
+++ b/Tests/Storage/CacheManagerTests.swift
@@ -17,6 +17,7 @@ final class MockCacheCoordinator: CacheCoordinator {
   var serverFetchDateSet = LockIsolated(false)
   var environmentSet = LockIsolated(false)
   var identityHydrated = LockIsolated(false)
+  var provisionalClientSet = LockIsolated(false)
   private var client: Client?
   private var serverFetchDate: Date?
   private var environment: Clerk.Environment?
@@ -43,6 +44,12 @@ final class MockCacheCoordinator: CacheCoordinator {
     if client != nil {
       clientSet.setValue(true)
     }
+  }
+
+  func setProvisionalClientIfNeeded(_ client: Client?) {
+    guard self.client == nil, let client else { return }
+    self.client = client
+    provisionalClientSet.setValue(true)
   }
 
   func setServerFetchDateIfNeeded(_ date: Date) {
@@ -211,9 +218,9 @@ struct CacheManagerTests {
 
     cacheManager.loadProvisionalLegacyClientForPresentation()
 
-    #expect(coordinator.clientSet.value == true)
+    #expect(coordinator.provisionalClientSet.value == true)
     #expect(coordinator.clientID == Client.mock.id)
-    #expect(coordinator.currentServerFetchDate == serverDate)
+    #expect(coordinator.currentServerFetchDate == nil)
   }
 
   @Test

--- a/Tests/Storage/SharedSessionLocalIdentityStoreTests.swift
+++ b/Tests/Storage/SharedSessionLocalIdentityStoreTests.swift
@@ -18,6 +18,49 @@ struct SharedSessionLocalIdentityStoreTests {
 
     #expect(record.acceptedIdentity == identity)
     #expect(record.pendingPublication == nil)
+    #expect(!record.requiresLegacyAdoptionPublication)
+  }
+
+  @Test
+  func recordWrittenBeforeAdoptionProvenanceDefaultsToSettled() throws {
+    struct PreviousRecord: Encodable {
+      let schemaVersion = SharedSessionLocalIdentityRecord.schemaVersion
+      let acceptedIdentity: SharedSessionLocalIdentity
+      let pendingPublication: SharedSessionIdentityEvent? = nil
+    }
+
+    let keychain = InMemoryKeychain()
+    let identity = makeIdentity(clientID: "previous-record")
+    try keychain.set(
+      JSONEncoder.clerkEncoder.encode(PreviousRecord(acceptedIdentity: identity)),
+      forKey: SharedSessionLocalIdentityStore.storageKey
+    )
+
+    let record = try #require(
+      try SharedSessionLocalIdentityStore(keychain: keychain).loadRecord()
+    )
+
+    #expect(record.acceptedIdentity == identity)
+    #expect(!record.requiresLegacyAdoptionPublication)
+  }
+
+  @Test
+  func legacyAdoptionProvenanceSurvivesStagingAndClearsOnCommit() throws {
+    let store = SharedSessionLocalIdentityStore(keychain: InMemoryKeychain())
+    let adopted = makeIdentity(clientID: "adopted")
+    let pending = try makeEvent(clientID: "pending")
+    try store.saveLegacyAdoption(adopted)
+
+    try store.stagePendingPublication(pending)
+
+    #expect(try store.loadRecord()?.requiresLegacyAdoptionPublication == true)
+
+    try store.commitAcceptedIdentity(
+      adopted,
+      clearingPendingPublicationID: pending.id
+    )
+
+    #expect(try store.loadRecord()?.requiresLegacyAdoptionPublication == false)
   }
 
   @Test

--- a/Tests/Storage/SharedSessionOwnerSlotStoreTests.swift
+++ b/Tests/Storage/SharedSessionOwnerSlotStoreTests.swift
@@ -234,7 +234,36 @@ struct SharedSessionOwnerSlotStoreTests {
   }
 
   @Test
-  func futureOwnSlotIsPreserved() throws {
+  func recoveryIntentDeleteUsesRecordedServiceAccessGroupAndAccount() throws {
+    let spy = SharedSessionSecItemSpy()
+    spy.copyMatchingResults = [.status(errSecItemNotFound)]
+    let intent = SharedSessionOwnerSlotClearRecovery.Intent(
+      localIdentityService: "recorded.identity",
+      slotService: "recorded.slot-service",
+      slotAccessGroup: "recorded.access-group",
+      slotAccount: "recorded.account",
+      instanceFingerprint: "recorded-instance",
+      ownerIdentifier: "recorded.owner"
+    )
+    let store = try SharedSessionOwnerSlotStore(
+      clearRecoveryIntent: intent,
+      secItemClient: spy.client,
+      diagnostics: { _ in }
+    )
+
+    try store.deleteOwnSlot()
+
+    let readQuery = try #require(spy.copyMatchingQueries.first)
+    let deleteQuery = try #require(spy.deleteQueries.first)
+    for query in [readQuery, deleteQuery] {
+      #expect(query[kSecAttrService as String] as? String == intent.slotService)
+      #expect(query[kSecAttrAccessGroup as String] as? String == intent.slotAccessGroup)
+      #expect(query[kSecAttrAccount as String] as? String == intent.slotAccount)
+    }
+  }
+
+  @Test
+  func futureOwnSlotDeletionReportsPreservation() throws {
     let spy = SharedSessionSecItemSpy()
     let futureData = try JSONSerialization.data(withJSONObject: [
       "schemaVersion": 3,
@@ -247,7 +276,9 @@ struct SharedSessionOwnerSlotStoreTests {
     #expect(throws: SharedSessionOwnerSlotStoreError.futureSchemaVersion(3)) {
       try store.saveOwnSlot(makeSlot(owner: "app.a", generation: 1))
     }
-    try store.deleteOwnSlot()
+    #expect(throws: SharedSessionOwnerSlotStoreError.futureSchemaVersion(3)) {
+      try store.deleteOwnSlot()
+    }
 
     #expect(spy.addQueries.isEmpty)
     #expect(spy.updateQueries.isEmpty)
@@ -255,7 +286,7 @@ struct SharedSessionOwnerSlotStoreTests {
   }
 
   @Test
-  func futureOwnSlotIsPreservedWhenCurrentHeaderFieldsAreAbsent() throws {
+  func futureOwnSlotDeletionReportsPreservationWhenCurrentHeaderFieldsAreAbsent() throws {
     let spy = SharedSessionSecItemSpy()
     let futureData = try JSONSerialization.data(withJSONObject: [
       "schemaVersion": 3,
@@ -267,7 +298,9 @@ struct SharedSessionOwnerSlotStoreTests {
     #expect(throws: SharedSessionOwnerSlotStoreError.futureSchemaVersion(3)) {
       try store.saveOwnSlot(makeSlot(owner: "app.a", generation: 1))
     }
-    try store.deleteOwnSlot()
+    #expect(throws: SharedSessionOwnerSlotStoreError.futureSchemaVersion(3)) {
+      try store.deleteOwnSlot()
+    }
 
     #expect(spy.addQueries.isEmpty)
     #expect(spy.updateQueries.isEmpty)

--- a/Tests/Storage/SharedSessionOwnerSlotStoreTests.swift
+++ b/Tests/Storage/SharedSessionOwnerSlotStoreTests.swift
@@ -234,6 +234,46 @@ struct SharedSessionOwnerSlotStoreTests {
   }
 
   @Test
+  func conditionalRestorePreservesAReplacementSlot() throws {
+    let spy = SharedSessionSecItemSpy()
+    let published = makeSlot(owner: "app.a", generation: 2)
+    let replacement = makeSlot(owner: "app.a", generation: 3)
+    spy.copyMatchingResults = try [
+      .success(JSONEncoder.clerkEncoder.encode(replacement)),
+    ]
+    let store = try makeStore(owner: "app.a", spy: spy)
+
+    #expect(try !store.restoreOwnSlot(
+      makeSlot(owner: "app.a", generation: 1),
+      ifCurrentMatchesPublication: published
+    ))
+
+    #expect(spy.updateQueries.isEmpty)
+    #expect(spy.deleteQueries.isEmpty)
+  }
+
+  @Test
+  func conditionalRestoreReplacesTheMigrationOwnedSlot() throws {
+    let spy = SharedSessionSecItemSpy()
+    let previous = makeSlot(owner: "app.a", generation: 1)
+    let published = makeSlot(owner: "app.a", generation: 2)
+    let publishedData = try JSONEncoder.clerkEncoder.encode(published)
+    spy.copyMatchingResults = [
+      .success(publishedData),
+      .success(publishedData),
+    ]
+    let store = try makeStore(owner: "app.a", spy: spy)
+
+    #expect(try store.restoreOwnSlot(
+      previous,
+      ifCurrentMatchesPublication: published
+    ))
+
+    #expect(spy.updateQueries.count == 1)
+    #expect(spy.deleteQueries.isEmpty)
+  }
+
+  @Test
   func recoveryIntentDeleteUsesRecordedServiceAccessGroupAndAccount() throws {
     let spy = SharedSessionSecItemSpy()
     spy.copyMatchingResults = [.status(errSecItemNotFound)]


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix startup/signup race by coordinating tokenless client refresh takeover
- Introduces a `StartupClientRefreshTakeover` mechanism so that sign-in, sign-up, and magic-link requests that can establish a client without a device token preempt the background startup client refresh, preventing races between the two flows.
- Adds `SharedSessionOwnerSlotClearRecovery` to persist a durable withdrawal intent before clearing identity, allowing interrupted clears to be recovered on next startup via `recoverIfNeeded`.
- Introduces `SharedSessionTopologyMigration` with transactional rollback support for migrating identity and owner-slot state when reconfiguring between different shared-session topologies.
- Adds `ClientResponseOrderingGate` to centralize stale-response rejection using sequence numbers and server-date watermarks across `ClerkIdentityController` and `SharedSessionSyncCoordinator`.
- Adds provisional client support so a cached client can be presented during startup legacy-adoption flows without being treated as authoritative for request identity or Watch sync.
- Risk: `performConfiguration` now throws if owner-slot clear recovery fails, and keychain clear is deferred when runtime reconfiguration is in progress — both are behavioral changes to previously silent or racy paths.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7610381.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->