### PR TITLE
Stop showing automatic passkey sign-in errors to end users

### DIFF
--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -482,7 +482,7 @@ extension AuthStartView {
       if Task.isCancelled || error.isCancellationError { return nil }
       guard navigation.path.isEmpty else { return nil }
 
-      presentAutomaticPasskeyError(error)
+      presentAutomaticPasskeyError(error, isPreSelection: true)
       ClerkLogger.error("Failed to create passkey sign-in", error: error)
       return nil
     }
@@ -490,17 +490,19 @@ extension AuthStartView {
 
   /// Presents a failure from the automatic passkey sign-in.
   ///
-  /// Release builds suppress `ASAuthorizationError`: the automatic modal and the AutoFill
-  /// fallback both start without user intent, and an authorization ceremony failure —
-  /// most commonly an app that has not declared a `webcredentials:` associated domain for
-  /// its Frontend API — is actionable only by the developer. Debug builds present it so
-  /// the misconfiguration is visible while integrating; every build logs it. Other errors,
-  /// such as the server rejecting a credential the user selected, present in every build.
-  private func presentAutomaticPasskeyError(_ error: any Error) {
+  /// The automatic modal and the AutoFill fallback both start without user intent, so
+  /// release builds suppress failures the user never participated in: everything from
+  /// stages that run before the credential picker (`isPreSelection`), and any
+  /// `ASAuthorizationError` — most commonly an app that has not declared a
+  /// `webcredentials:` associated domain for its Frontend API, which is actionable only
+  /// by the developer. Debug builds present everything so misconfiguration is visible
+  /// while integrating; every build logs. Other errors, such as the server rejecting a
+  /// credential the user selected, present in every build.
+  private func presentAutomaticPasskeyError(_ error: any Error, isPreSelection: Bool = false) {
     #if DEBUG
     generalError = error
     #else
-    guard !(error is ASAuthorizationError) else { return }
+    guard !isPreSelection, !(error is ASAuthorizationError) else { return }
     generalError = error
     #endif
   }

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -90,7 +90,7 @@ struct AuthStartView: View {
   func passkeySignInIsAvailable(environment: Clerk.Environment?) -> Bool {
     switch authState.mode {
     case .signIn, .signInOrUp:
-      environment?.passkeyIsEnabled == true &&
+      environment?.passkeyFirstFactorIsEnabled == true &&
         !lockedInitialIdentifierIsActive
     case .signUp:
       false

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -481,10 +481,24 @@ extension AuthStartView {
       if Task.isCancelled || error.isCancellationError { return nil }
       guard navigation.path.isEmpty else { return nil }
 
-      generalError = error
+      presentAutomaticPasskeyError(error)
       ClerkLogger.error("Failed to create passkey sign-in", error: error)
       return nil
     }
+  }
+
+  /// Presents a failure from the automatic passkey sign-in, in debug builds only.
+  ///
+  /// The automatic modal and the AutoFill fallback both start without user intent, so a
+  /// failure leaves nothing for the person signing in to act on. The most common cause is
+  /// an app that has not declared a `webcredentials:` associated domain for its Frontend
+  /// API, which fails every attempt with an error only the developer can fix. Debug builds
+  /// still present it so that misconfiguration is visible while integrating; every build
+  /// logs it.
+  private func presentAutomaticPasskeyError(_ error: any Error) {
+    #if DEBUG
+    generalError = error
+    #endif
   }
 
   @discardableResult
@@ -509,7 +523,7 @@ extension AuthStartView {
       if error.isUserCancelledError { return .continueWithAutofill }
       guard navigation.path.isEmpty else { return .stopped }
 
-      generalError = error
+      presentAutomaticPasskeyError(error)
       if autofill {
         ClerkLogger.error("Failed to authenticate with passkey autofill", error: error)
       } else {

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -7,6 +7,7 @@
 
 #if os(iOS) || os(macOS)
 
+import AuthenticationServices
 import ClerkKit
 import SwiftUI
 
@@ -487,16 +488,19 @@ extension AuthStartView {
     }
   }
 
-  /// Presents a failure from the automatic passkey sign-in, in debug builds only.
+  /// Presents a failure from the automatic passkey sign-in.
   ///
-  /// The automatic modal and the AutoFill fallback both start without user intent, so a
-  /// failure leaves nothing for the person signing in to act on. The most common cause is
-  /// an app that has not declared a `webcredentials:` associated domain for its Frontend
-  /// API, which fails every attempt with an error only the developer can fix. Debug builds
-  /// still present it so that misconfiguration is visible while integrating; every build
-  /// logs it.
+  /// Release builds suppress `ASAuthorizationError`: the automatic modal and the AutoFill
+  /// fallback both start without user intent, and an authorization ceremony failure —
+  /// most commonly an app that has not declared a `webcredentials:` associated domain for
+  /// its Frontend API — is actionable only by the developer. Debug builds present it so
+  /// the misconfiguration is visible while integrating; every build logs it. Other errors,
+  /// such as the server rejecting a credential the user selected, present in every build.
   private func presentAutomaticPasskeyError(_ error: any Error) {
     #if DEBUG
+    generalError = error
+    #else
+    guard !(error is ASAuthorizationError) else { return }
     generalError = error
     #endif
   }

--- a/Sources/ClerkKitUI/Extensions/Environment+Ext.swift
+++ b/Sources/ClerkKitUI/Extensions/Environment+Ext.swift
@@ -68,9 +68,20 @@ extension Clerk.Environment {
     }
   }
 
+  /// Whether the instance lets users register and manage passkeys.
   var passkeyIsEnabled: Bool {
     userSettings.attributes.contains { key, value in
       key == "passkey" && value.enabled
+    }
+  }
+
+  /// Whether the instance accepts a passkey as a first factor when signing in.
+  ///
+  /// An instance can enable passkeys for registration and verification while leaving them
+  /// out of the sign-in factors, so this is narrower than ``passkeyIsEnabled``.
+  var passkeyFirstFactorIsEnabled: Bool {
+    userSettings.attributes.contains { key, value in
+      key == "passkey" && value.enabled && value.usedForFirstFactor
     }
   }
 

--- a/Tests/UI/PasskeyFirstFactorAvailabilityTests.swift
+++ b/Tests/UI/PasskeyFirstFactorAvailabilityTests.swift
@@ -1,0 +1,53 @@
+@testable import ClerkKit
+@testable import ClerkKitUI
+import Testing
+
+@MainActor
+struct PasskeyFirstFactorAvailabilityTests {
+  private func environment(
+    passkeyEnabled: Bool,
+    usedForFirstFactor: Bool
+  ) -> Clerk.Environment {
+    var environment = Clerk.Environment.mock
+    environment.userSettings.attributes["passkey"] = .init(
+      enabled: passkeyEnabled,
+      required: false,
+      usedForFirstFactor: usedForFirstFactor,
+      firstFactors: usedForFirstFactor ? ["passkey"] : [],
+      usedForSecondFactor: false,
+      secondFactors: [],
+      verifications: ["passkey"],
+      verifyAtSignUp: false
+    )
+    return environment
+  }
+
+  @Test
+  func passkeyFirstFactorIsEnabledWhenPasskeyIsAFirstFactor() {
+    let environment = environment(passkeyEnabled: true, usedForFirstFactor: true)
+
+    #expect(environment.passkeyIsEnabled)
+    #expect(environment.passkeyFirstFactorIsEnabled)
+  }
+
+  @Test
+  func passkeyFirstFactorIsDisabledWhenPasskeyIsRegistrationOnly() {
+    let environment = environment(passkeyEnabled: true, usedForFirstFactor: false)
+
+    #expect(environment.passkeyIsEnabled)
+    #expect(!environment.passkeyFirstFactorIsEnabled)
+  }
+
+  @Test
+  func passkeyFirstFactorIsDisabledWhenPasskeyIsDisabled() {
+    let environment = environment(passkeyEnabled: false, usedForFirstFactor: true)
+
+    #expect(!environment.passkeyIsEnabled)
+    #expect(!environment.passkeyFirstFactorIsEnabled)
+  }
+
+  @Test
+  func passkeyFirstFactorIsDisabledWhenPasskeyAttributeIsAbsent() {
+    #expect(!Clerk.Environment.mock.passkeyFirstFactorIsEnabled)
+  }
+}

--- a/Tests/UI/PasskeyFirstFactorAvailabilityTests.swift
+++ b/Tests/UI/PasskeyFirstFactorAvailabilityTests.swift
@@ -47,6 +47,14 @@ struct PasskeyFirstFactorAvailabilityTests {
   }
 
   @Test
+  func passkeyFirstFactorIsDisabledWhenPasskeyIsDisabledAndNotAFirstFactor() {
+    let environment = environment(passkeyEnabled: false, usedForFirstFactor: false)
+
+    #expect(!environment.passkeyIsEnabled)
+    #expect(!environment.passkeyFirstFactorIsEnabled)
+  }
+
+  @Test
   func passkeyFirstFactorIsDisabledWhenPasskeyAttributeIsAbsent() {
     #expect(!Clerk.Environment.mock.passkeyFirstFactorIsEnabled)
   }


### PR DESCRIPTION
Two fixes to the automatic passkey sign-in that `AuthStartView` kicks off when the sign-in form appears.

## 1. Automatic passkey failures no longer reach end users in release builds

The automatic modal and the AutoFill fallback both start without the user doing anything, so when they fail there's nothing for the person signing in to act on. The error was still being pushed into `generalError` and presented as a "Whoops, something is wrong" sheet on top of the sign-in form.

The common trigger is an app that hasn't declared a `webcredentials:` associated domain for its Frontend API. Every attempt fails with `Application with identifier <team>.<bundle-id> is not associated with domain <fapi-host>`, and only the developer can fix it.

These errors are now presented in debug builds only, so the misconfiguration stays obvious while integrating. Every build still logs through `ClerkLogger`.

Suppression is limited to `ASAuthorizationError`, i.e. authorization ceremony failures. Once the user picks a passkey from the AutoFill suggestions or the automatic modal, a server rejection of that credential surfaces as a `ClerkAPIError` and still presents in every build.

Explicit passkey sign-in (the button in `SignInFactorOnePasskeyView`) is unchanged and still surfaces errors, since the user initiated it.

## 2. Automatic passkey sign-in only starts when passkey is a first factor

An instance can enable passkeys for registration and verification while leaving them out of the sign-in factors:

```json
"passkey": {
  "enabled": true,
  "used_for_first_factor": false,
  "first_factors": [],
  "verifications": ["passkey"]
}
```

`passkeySignInIsAvailable` checked only `enabled`, so `AuthStartView` fired `POST /v1/client/sign_ins` and `prepare_first_factor` on every appearance, against an instance that would never accept the assertion. Added `passkeyFirstFactorIsEnabled`, which mirrors how every other attribute is checked for sign-in, and gated the automatic flow on it.

`UserProfileSecurityView` keeps using `passkeyIsEnabled`. Managing passkeys in the profile is separate from whether they're a sign-in factor.

## Testing

- `swift build`, `swift test --skip Integration`: 1018 tests pass
- `make format-check`, `make lint`: clean on the changed files
- New `Tests/UI/PasskeyFirstFactorAvailabilityTests.swift` covers the four combinations of `enabled` / `used_for_first_factor`

The two commits are independent if you'd rather land them separately.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop showing automatic passkey sign-in errors to end users in release builds
> - In release builds, passkey authentication failures that occur before user selection (pre-selection) and `ASAuthorizationError` failures no longer set `generalError` in `AuthStartView`, so users don't see confusing automatic passkey prompts fail silently with an error. Debug builds still surface all errors.
> - Adds a `passkeyFirstFactorIsEnabled` property to `Clerk.Environment` that returns true only when the passkey attribute is both enabled and marked `usedForFirstFactor`. The availability check in `AuthStartView` now uses this instead of the broader `passkeyIsEnabled`.
> - The new `presentAutomaticPasskeyError(_:isPreSelection:)` helper in [`AuthStartView.swift`](https://github.com/clerk/clerk-ios/pull/528/files#diff-79b95372da33986fe80f19e2de0dccfcff7540e47c3efd8e5421c99b8354f895) centralizes the conditional error-presentation logic for both autofill and immediate-credential passkey flows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7506f95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->