### PR TITLE
Add isolated Clerk test configuration

### DIFF
--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -533,6 +533,38 @@ extension Clerk {
     return clerk
   }
 
+  /// Configures the shared instance with isolated persistence for SDK tests.
+  @MainActor
+  @discardableResult
+  static func configureForTesting(
+    publishableKey: String,
+    options: Clerk.Options = .init(),
+    keychainStorage: any KeychainStorage
+  ) throws -> Clerk {
+    guard EnvironmentDetection.isRunningInTests else {
+      throw ClerkClientError(
+        message: "Isolated Clerk configuration is only available while running tests."
+      )
+    }
+
+    if let existing = _shared {
+      existing.cleanupManagers()
+      _shared = nil
+    }
+
+    let clerk = Clerk()
+    let dependencies = try DependencyContainer(
+      publishableKey: publishableKey,
+      options: options,
+      runtimeScope: clerk.runtimeScope,
+      persistentAdoptionEnabledOverride: false,
+      keychainStorageOverride: keychainStorage
+    )
+    try clerk.performConfiguration(dependencies: dependencies)
+    _shared = clerk
+    return clerk
+  }
+
   /// Reconfigures the shared Clerk instance with a new publishable key and options.
   ///
   /// This method validates and installs the new configuration. Changing the publishable

--- a/Sources/ClerkKit/Dependencies/DependencyContainer.swift
+++ b/Sources/ClerkKit/Dependencies/DependencyContainer.swift
@@ -75,6 +75,7 @@ final class DependencyContainer: Dependencies {
     runtimeScope: ClerkRuntimeScope,
     deferSharedSessionAdoption: Bool = false,
     persistentAdoptionEnabledOverride: Bool? = nil,
+    keychainStorageOverride: (any KeychainStorage)? = nil,
     ownerIdentifierProvider: () -> String? = { Bundle.main.bundleIdentifier }
   ) throws {
     // Phase 1: Core infrastructure (no dependencies)
@@ -126,7 +127,8 @@ final class DependencyContainer: Dependencies {
       publishableKey: configurationManager.publishableKey,
       ownerIdentifier: sharedSessionOwnerIdentifier,
       usePersistentAdoptionState: persistentAdoptionEnabled,
-      performPersistentAdoption: !deferSharedSessionAdoption
+      performPersistentAdoption: !deferSharedSessionAdoption,
+      keychainStorageOverride: keychainStorageOverride
     )
     keychain = keychainStorages.shared
     appLocalKeychain = keychainStorages.appLocal
@@ -185,8 +187,28 @@ final class DependencyContainer: Dependencies {
     publishableKey: String,
     ownerIdentifier: String?,
     usePersistentAdoptionState: Bool,
-    performPersistentAdoption: Bool
+    performPersistentAdoption: Bool,
+    keychainStorageOverride: (any KeychainStorage)?
   ) throws -> KeychainStorages {
+    if let keychainStorageOverride {
+      guard options.sharedSessionSync == nil,
+            !usePersistentAdoptionState
+      else {
+        throw ClerkClientError(
+          message: "Injected Keychain storage cannot be used with persistent shared-session adoption."
+        )
+      }
+
+      return KeychainStorages(
+        shared: keychainStorageOverride,
+        appLocal: keychainStorageOverride,
+        identity: keychainStorageOverride,
+        legacyAppLocal: nil,
+        localIdentityStore: nil,
+        shouldHydrateProvisionalLegacyClient: false
+      )
+    }
+
     let config = options.keychainConfig
     let shared = makeKeychainStorage(config: config)
     let syncEnabled = options.sharedSessionSync != nil

--- a/Tests/Core/ClerkTests.swift
+++ b/Tests/Core/ClerkTests.swift
@@ -70,6 +70,27 @@ struct ClerkTests {
   }
 
   @Test
+  func isolatedConfigurationInstallsPersistenceBeforeStartup() throws {
+    let keychain = InMemoryKeychain()
+    try keychain.set(
+      "isolated-device-token",
+      forKey: ClerkKeychainKey.clerkDeviceToken.rawValue
+    )
+
+    let clerk = try Clerk.configureForTesting(
+      publishableKey: testPublishableKey,
+      keychainStorage: keychain
+    )
+    defer { clerk.cleanupManagers() }
+
+    #expect(clerk.publishableKey == testPublishableKey)
+    #expect(clerk.identityController.currentDeviceToken == "isolated-device-token")
+    #expect((clerk.dependencies.keychain as? InMemoryKeychain) === keychain)
+    #expect((clerk.dependencies.appLocalKeychain as? InMemoryKeychain) === keychain)
+    #expect((clerk.dependencies.identityKeychain as? InMemoryKeychain) === keychain)
+  }
+
+  @Test
   func clearAllKeychainItemsDeletesStoredDataAndPreservesAdoptionMarker() async throws {
     // Set up with InMemoryKeychain for testing
     let keychain = InMemoryKeychain()

--- a/Tests/Integration/IntegrationTestHelpers.swift
+++ b/Tests/Integration/IntegrationTestHelpers.swift
@@ -78,28 +78,9 @@ func configureClerkForIntegrationTesting(keyName: String) throws -> Bool {
     return false
   }
 
-  Clerk.configure(publishableKey: publishableKey)
-
-  // Replace the dependencies with a container that uses an in-memory keychain
-  // but keeps the real API client and services for making actual API calls
-  let apiClient = Clerk.shared.dependencies.apiClient
-
-  Clerk.shared.dependencies = MockDependencyContainer(
-    apiClient: apiClient,
-    keychain: InMemoryKeychain(),
-    telemetryCollector: Clerk.shared.dependencies.telemetryCollector,
-    clientService: ClientService(apiClient: apiClient),
-    userService: UserService(apiClient: apiClient),
-    signInService: SignInService(apiClient: apiClient),
-    signUpService: SignUpService(apiClient: apiClient),
-    sessionService: SessionService(apiClient: apiClient),
-    magicLinkService: MagicLinkService(apiClient: apiClient),
-    passkeyService: PasskeyService(apiClient: apiClient),
-    organizationService: OrganizationService(apiClient: apiClient),
-    environmentService: EnvironmentService(apiClient: apiClient),
-    emailAddressService: EmailAddressService(apiClient: apiClient),
-    phoneNumberService: PhoneNumberService(apiClient: apiClient),
-    externalAccountService: ExternalAccountService(apiClient: apiClient)
+  try Clerk.configureForTesting(
+    publishableKey: publishableKey,
+    keychainStorage: InMemoryKeychain()
   )
 
   return true


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `Clerk.configureForTesting` for isolated SDK test configuration
- Adds a `@MainActor` static method `Clerk.configureForTesting` in [Clerk.swift](https://github.com/clerk/clerk-ios/pull/529/files#diff-639f19e3d28f9402ce7a5b6a768e19a84c2cec81797989e059d4b74dac60d71b) that tears down any existing shared instance and installs a fresh one configured with an injected `KeychainStorage` and persistent adoption disabled. Throws if called outside a test process.
- Extends `DependencyContainer.init` in [DependencyContainer.swift](https://github.com/clerk/clerk-ios/pull/529/files#diff-65d6d015620f334edb07e025d391f5aafe5234151811b3d3a01c3dc243dc7e44) to accept an optional `keychainStorageOverride`, routing it through `makeKeychainStorages` to replace all keychain roles (shared, appLocal, identity) with the override.
- When an override is supplied, `makeKeychainStorages` validates that shared-session sync and persistent adoption are not in use, then bypasses the normal keychain selection logic.
- Reworks [IntegrationTestHelpers.swift](https://github.com/clerk/clerk-ios/pull/529/files#diff-052a2cb845ec5f75ddabfa3aeeb9d68e5cedd132f5d4a937cabbe9ea17cbe8c2) to use the new API with an `InMemoryKeychain` instead of manually reassigning dependencies post-configuration.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81d6e7e.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->