### PR TITLE
Suppress automatic passkey authorization errors

### DIFF
--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -488,23 +488,22 @@ extension AuthStartView {
     }
   }
 
-  /// Presents a failure from the automatic passkey sign-in.
+  /// Presents an actionable failure from the automatic passkey sign-in.
   ///
   /// The automatic modal and the AutoFill fallback both start without user intent, so
-  /// release builds suppress failures the user never participated in: everything from
-  /// stages that run before the credential picker (`isPreSelection`), and any
-  /// `ASAuthorizationError` — most commonly an app that has not declared a
-  /// `webcredentials:` associated domain for its Frontend API, which is actionable only
-  /// by the developer. Debug builds present everything so misconfiguration is visible
-  /// while integrating; every build logs. Other errors, such as the server rejecting a
-  /// credential the user selected, present in every build.
+  /// failures from stages before credential selection and authorization ceremony failures
+  /// are logged instead of presented. Other errors, such as the server rejecting a
+  /// credential the user selected, remain actionable and are presented.
   private func presentAutomaticPasskeyError(_ error: any Error, isPreSelection: Bool = false) {
-    #if DEBUG
+    guard Self.shouldPresentAutomaticPasskeyError(error, isPreSelection: isPreSelection) else { return }
     generalError = error
-    #else
-    guard !isPreSelection, !(error is ASAuthorizationError) else { return }
-    generalError = error
-    #endif
+  }
+
+  static func shouldPresentAutomaticPasskeyError(
+    _ error: any Error,
+    isPreSelection: Bool = false
+  ) -> Bool {
+    !isPreSelection && !(error is ASAuthorizationError)
   }
 
   @discardableResult

--- a/Tests/UI/AutomaticPasskeyErrorPresentationTests.swift
+++ b/Tests/UI/AutomaticPasskeyErrorPresentationTests.swift
@@ -1,0 +1,43 @@
+import AuthenticationServices
+@testable import ClerkKitUI
+import Foundation
+import Testing
+
+@MainActor
+struct AutomaticPasskeyErrorPresentationTests {
+  private enum TestError: Error {
+    case failed
+  }
+
+  @Test
+  func noCredentialAuthorizationErrorIsNotPresented() {
+    let error = ASAuthorizationError(
+      .canceled,
+      userInfo: [
+        NSLocalizedFailureReasonErrorKey: "No credentials available for login.",
+      ]
+    )
+
+    #expect(!AuthStartView.shouldPresentAutomaticPasskeyError(error))
+  }
+
+  @Test
+  func authorizationErrorWithoutFailureReasonIsNotPresented() {
+    let error = ASAuthorizationError(.failed)
+
+    #expect(!AuthStartView.shouldPresentAutomaticPasskeyError(error))
+  }
+
+  @Test
+  func preSelectionErrorIsNotPresented() {
+    #expect(!AuthStartView.shouldPresentAutomaticPasskeyError(
+      TestError.failed,
+      isPreSelection: true
+    ))
+  }
+
+  @Test
+  func postSelectionNonAuthorizationErrorIsPresented() {
+    #expect(AuthStartView.shouldPresentAutomaticPasskeyError(TestError.failed))
+  }
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Suppress automatic passkey authorization errors in all build configurations
Previously, `ASAuthorizationError` and pre-selection errors were suppressed only in non-debug builds. This PR unifies the behavior across all configurations by extracting the suppression logic into a new static helper `shouldPresentAutomaticPasskeyError`. Suppressed errors are logged rather than shown to the user. Four new tests in [AutomaticPasskeyErrorPresentationTests.swift](https://github.com/clerk/clerk-ios/pull/530/files#diff-edbb498df5399d0d92b0725a58ef731ce865865666ace2519b71eeacaf5d3a6b) cover the presentation policy.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized b55cff7.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->