### PR TITLE
Present only actionable passkey errors

### DIFF
--- a/Sources/ClerkKit/Domains/Auth/SignIn/PasskeyAuthenticationFailure.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignIn/PasskeyAuthenticationFailure.swift
@@ -1,0 +1,15 @@
+//
+//  PasskeyAuthenticationFailure.swift
+//  Clerk
+//
+
+package struct PasskeyAuthenticationFailure: Error {
+  package enum Stage {
+    case preparingFirstFactor
+    case requestingAuthorization
+    case attemptingFirstFactor
+  }
+
+  package let stage: Stage
+  package let underlyingError: any Error
+}

--- a/Sources/ClerkKit/Domains/Auth/SignIn/SignIn.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignIn/SignIn.swift
@@ -507,20 +507,69 @@ extension SignIn {
   @discardableResult
   @MainActor
   public func authenticateWithPasskey(autofill: Bool = false, preferImmediatelyAvailableCredentials: Bool = true) async throws -> SignIn {
-    let signIn = try await signInService.prepareFirstFactor(
-      signInId: id,
-      params: .init(strategy: .passkey, redirectUrl: Clerk.shared.options.redirectConfig.redirectUrl)
-    )
+    do {
+      return try await authenticateWithPasskeyWithFailureContext(
+        autofill: autofill,
+        preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
+      )
+    } catch {
+      throw error.underlyingError
+    }
+  }
 
-    let credential = try await signIn.getCredentialForPasskey(
-      autofill: autofill,
-      preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
-    )
+  @discardableResult
+  @MainActor
+  package func authenticateWithPasskeyWithFailureContext(
+    autofill: Bool = false,
+    preferImmediatelyAvailableCredentials: Bool = true
+  ) async throws(PasskeyAuthenticationFailure) -> SignIn {
+    try await authenticateWithPasskeyWithFailureContext { signIn in
+      try await signIn.getCredentialForPasskey(
+        autofill: autofill,
+        preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
+      )
+    }
+  }
 
-    return try await signInService.attemptFirstFactor(
-      signInId: signIn.id,
-      params: .init(strategy: .passkey, publicKeyCredential: credential)
-    )
+  @discardableResult
+  @MainActor
+  func authenticateWithPasskeyWithFailureContext(
+    credentialProvider: @MainActor (SignIn) async throws -> String
+  ) async throws(PasskeyAuthenticationFailure) -> SignIn {
+    let signIn: SignIn
+    do {
+      signIn = try await signInService.prepareFirstFactor(
+        signInId: id,
+        params: .init(strategy: .passkey, redirectUrl: Clerk.shared.options.redirectConfig.redirectUrl)
+      )
+    } catch {
+      throw PasskeyAuthenticationFailure(
+        stage: .preparingFirstFactor,
+        underlyingError: error
+      )
+    }
+
+    let credential: String
+    do {
+      credential = try await credentialProvider(signIn)
+    } catch {
+      throw PasskeyAuthenticationFailure(
+        stage: .requestingAuthorization,
+        underlyingError: error
+      )
+    }
+
+    do {
+      return try await signInService.attemptFirstFactor(
+        signInId: signIn.id,
+        params: .init(strategy: .passkey, publicKeyCredential: credential)
+      )
+    } catch {
+      throw PasskeyAuthenticationFailure(
+        stage: .attemptingFirstFactor,
+        underlyingError: error
+      )
+    }
   }
   #endif
 }

--- a/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthStartView.swift
@@ -7,7 +7,6 @@
 
 #if os(iOS) || os(macOS)
 
-import AuthenticationServices
 import ClerkKit
 import SwiftUI
 
@@ -482,7 +481,6 @@ extension AuthStartView {
       if Task.isCancelled || error.isCancellationError { return nil }
       guard navigation.path.isEmpty else { return nil }
 
-      presentAutomaticPasskeyError(error, isPreSelection: true)
       ClerkLogger.error("Failed to create passkey sign-in", error: error)
       return nil
     }
@@ -494,16 +492,15 @@ extension AuthStartView {
   /// failures from stages before credential selection and authorization ceremony failures
   /// are logged instead of presented. Other errors, such as the server rejecting a
   /// credential the user selected, remain actionable and are presented.
-  private func presentAutomaticPasskeyError(_ error: any Error, isPreSelection: Bool = false) {
-    guard Self.shouldPresentAutomaticPasskeyError(error, isPreSelection: isPreSelection) else { return }
-    generalError = error
+  private func presentAutomaticPasskeyError(_ failure: PasskeyAuthenticationFailure) {
+    guard Self.shouldPresentAutomaticPasskeyError(at: failure.stage) else { return }
+    generalError = failure.underlyingError
   }
 
   static func shouldPresentAutomaticPasskeyError(
-    _ error: any Error,
-    isPreSelection: Bool = false
+    at stage: PasskeyAuthenticationFailure.Stage
   ) -> Bool {
-    !isPreSelection && !(error is ASAuthorizationError)
+    stage == .attemptingFirstFactor
   }
 
   @discardableResult
@@ -513,7 +510,7 @@ extension AuthStartView {
     preferImmediatelyAvailableCredentials: Bool
   ) async -> PasskeySignInResult {
     do {
-      let signIn = try await signIn.authenticateWithPasskey(
+      let signIn = try await signIn.authenticateWithPasskeyWithFailureContext(
         autofill: autofill,
         preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
       )
@@ -524,15 +521,16 @@ extension AuthStartView {
       navigation.setToStepForStatus(signIn: signIn)
       return .completed
     } catch {
-      if Task.isCancelled || error.isCancellationError { return .stopped }
-      if error.isUserCancelledError { return .continueWithAutofill }
+      let underlyingError = error.underlyingError
+      if Task.isCancelled || underlyingError.isCancellationError { return .stopped }
+      if underlyingError.isUserCancelledError { return .continueWithAutofill }
       guard navigation.path.isEmpty else { return .stopped }
 
       presentAutomaticPasskeyError(error)
       if autofill {
-        ClerkLogger.error("Failed to authenticate with passkey autofill", error: error)
+        ClerkLogger.error("Failed to authenticate with passkey autofill", error: underlyingError)
       } else {
-        ClerkLogger.error("Failed to authenticate with passkey", error: error)
+        ClerkLogger.error("Failed to authenticate with passkey", error: underlyingError)
       }
       // Keep iOS text-field AutoFill armed after a modal error so users can
       // pick another passkey without a second modal.

--- a/Tests/Core/SharedSessionSyncTests.swift
+++ b/Tests/Core/SharedSessionSyncTests.swift
@@ -2197,7 +2197,7 @@ struct SharedSessionSyncTests {
   @Test
   func shutdownDeletesOwnSlotAfterSuspendedPublicationAndFencesOldWork() async throws {
     let backend = TestSlotBackend()
-    backend.saveDelay = 0.05
+    backend.suspendNextSave()
     let node = try makeNode(owner: "app.old", backend: backend)
     let publication = Task { @MainActor in
       try await node.coordinator.publishLocalIdentity(
@@ -2207,9 +2207,17 @@ struct SharedSessionSyncTests {
         serverDate: nil
       )
     }
-    try await Task.sleep(for: .milliseconds(10))
+    try await waitUntil { backend.isSaveSuspended }
 
-    await node.coordinator.shutdown(deleteOwnSlot: true)
+    let initialHandlerSetCount = node.notifier.handlerSetCount
+    let shutdown = Task { @MainActor in
+      await node.coordinator.shutdown(deleteOwnSlot: true)
+    }
+    try await waitUntil {
+      node.notifier.handlerSetCount > initialHandlerSetCount
+    }
+    backend.resumeSuspendedSave(failing: false)
+    await shutdown.value
 
     await #expect(throws: CancellationError.self) {
       try await publication.value
@@ -2941,11 +2949,13 @@ private final class TestLocalIdentityStore: @unchecked Sendable, SharedSessionLo
 @MainActor
 private final class TestSharedSessionSyncNotifier: SharedSessionSyncNotifying {
   private var handler: (@MainActor () -> Void)?
+  private(set) var handlerSetCount = 0
   var postCount = 0
   var onPost: (@MainActor () -> Void)?
 
   func setHandler(_ handler: @escaping @MainActor () -> Void) {
     self.handler = handler
+    handlerSetCount += 1
   }
 
   func post() {

--- a/Tests/Domains/Auth/SignIn/SignInTests.swift
+++ b/Tests/Domains/Auth/SignIn/SignInTests.swift
@@ -6,6 +6,12 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct SignInTests {
+  private enum PasskeyTestError: Error {
+    case preparationFailed
+    case authorizationFailed
+    case attemptFailed
+  }
+
   init() {
     configureClerkForTesting()
   }
@@ -42,6 +48,73 @@ struct SignInTests {
     try! (Clerk.shared.dependencies as! MockDependencyContainer)
       .configurationManager
       .configure(publishableKey: testPublishableKey, options: .init())
+  }
+
+  @Test(arguments: [
+    PasskeyAuthenticationFailure.Stage.preparingFirstFactor,
+    .requestingAuthorization,
+    .attemptingFirstFactor,
+  ])
+  func passkeyFailureContextIdentifiesFailureStage(
+    _ expectedStage: PasskeyAuthenticationFailure.Stage
+  ) async {
+    let signIn = SignIn.mock
+    let service = MockSignInService(
+      prepareFirstFactor: { _, _ in
+        if expectedStage == .preparingFirstFactor {
+          throw PasskeyTestError.preparationFailed
+        }
+        return .mock
+      },
+      attemptFirstFactor: { _, _ in
+        if expectedStage == .attemptingFirstFactor {
+          throw PasskeyTestError.attemptFailed
+        }
+        return .mock
+      }
+    )
+
+    configureService(service)
+
+    do {
+      _ = try await signIn.authenticateWithPasskeyWithFailureContext { _ in
+        if expectedStage == .requestingAuthorization {
+          throw PasskeyTestError.authorizationFailed
+        }
+        return "credential"
+      }
+      Issue.record("Expected passkey authentication to fail.")
+    } catch {
+      #expect(error.stage == expectedStage)
+      #expect(error.underlyingError as? PasskeyTestError == passkeyTestError(for: expectedStage))
+    }
+  }
+
+  @Test
+  func publicPasskeyAuthenticationPreservesUnderlyingError() async {
+    let signIn = SignIn.mock
+    let service = MockSignInService(prepareFirstFactor: { _, _ in
+      throw PasskeyTestError.preparationFailed
+    })
+
+    configureService(service)
+
+    await #expect(throws: PasskeyTestError.self) {
+      try await signIn.authenticateWithPasskey()
+    }
+  }
+
+  private func passkeyTestError(
+    for stage: PasskeyAuthenticationFailure.Stage
+  ) -> PasskeyTestError {
+    switch stage {
+    case .preparingFirstFactor:
+      .preparationFailed
+    case .requestingAuthorization:
+      .authorizationFailed
+    case .attemptingFirstFactor:
+      .attemptFailed
+    }
   }
 
   @Test

--- a/Tests/UI/AutomaticPasskeyErrorPresentationTests.swift
+++ b/Tests/UI/AutomaticPasskeyErrorPresentationTests.swift
@@ -1,43 +1,21 @@
-import AuthenticationServices
+import ClerkKit
 @testable import ClerkKitUI
-import Foundation
 import Testing
 
 @MainActor
 struct AutomaticPasskeyErrorPresentationTests {
-  private enum TestError: Error {
-    case failed
+  @Test(arguments: [
+    PasskeyAuthenticationFailure.Stage.preparingFirstFactor,
+    .requestingAuthorization,
+  ])
+  func errorsBeforeFirstFactorAttemptAreNotPresented(
+    _ stage: PasskeyAuthenticationFailure.Stage
+  ) {
+    #expect(!AuthStartView.shouldPresentAutomaticPasskeyError(at: stage))
   }
 
   @Test
-  func noCredentialAuthorizationErrorIsNotPresented() {
-    let error = ASAuthorizationError(
-      .canceled,
-      userInfo: [
-        NSLocalizedFailureReasonErrorKey: "No credentials available for login.",
-      ]
-    )
-
-    #expect(!AuthStartView.shouldPresentAutomaticPasskeyError(error))
-  }
-
-  @Test
-  func authorizationErrorWithoutFailureReasonIsNotPresented() {
-    let error = ASAuthorizationError(.failed)
-
-    #expect(!AuthStartView.shouldPresentAutomaticPasskeyError(error))
-  }
-
-  @Test
-  func preSelectionErrorIsNotPresented() {
-    #expect(!AuthStartView.shouldPresentAutomaticPasskeyError(
-      TestError.failed,
-      isPreSelection: true
-    ))
-  }
-
-  @Test
-  func postSelectionNonAuthorizationErrorIsPresented() {
-    #expect(AuthStartView.shouldPresentAutomaticPasskeyError(TestError.failed))
+  func firstFactorAttemptErrorIsPresented() {
+    #expect(AuthStartView.shouldPresentAutomaticPasskeyError(at: .attemptingFirstFactor))
   }
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Present only actionable passkey errors during automatic sign-in
- Introduces `PasskeyAuthenticationFailure`, a typed error that wraps the underlying error and identifies which stage of passkey auth failed: `preparingFirstFactor`, `requestingAuthorization`, or `attemptingFirstFactor`.
- Adds `SignIn.authenticateWithPasskeyWithFailureContext` as an internal overload that throws `PasskeyAuthenticationFailure` instead of the raw error; the public `authenticateWithPasskey` method unwraps and rethrows the underlying error, preserving existing external behavior.
- Updates `AuthStartView` to only present errors to the user when the failure occurs at the `attemptingFirstFactor` stage — errors before the user selects a credential are now silently logged.
- Behavioral Change: automatic passkey sign-in no longer surfaces UI errors for pre-selection failures (e.g. preparation or authorization request failures).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49fad44.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->