### PR TITLE
Add session minter token freshness handling

### DIFF
--- a/Sources/ClerkKit/Domains/Auth/Session/Session.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/Session.swift
@@ -294,12 +294,13 @@ extension Session {
   ///
   /// For example:
   /// - If the template is null, the key includes the active organization.
-  /// - If the template is 'supabase', the key includes the template name.
+  /// - If the template is 'supabase', the key includes the active organization and template name.
   func tokenCacheKey(template: String?) -> String {
+    let organizationKey = "\(id)-organization-\(lastActiveOrganizationId ?? "")"
     if let template {
-      return "\(id)-template-\(template)"
+      return "\(organizationKey)-template-\(template)"
     }
-    return "\(id)-organization-\(lastActiveOrganizationId ?? "")"
+    return organizationKey
   }
 }
 

--- a/Sources/ClerkKit/Domains/Auth/Session/Session.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/Session.swift
@@ -293,14 +293,13 @@ extension Session {
   /// Format for the session token cache key
   ///
   /// For example:
-  /// - If the template is null, the key will be 'sess_abc12345'
-  /// - If the template is 'supabase', the key will be 'sess_abc12345-supabase'
+  /// - If the template is null, the key includes the active organization.
+  /// - If the template is 'supabase', the key includes the template name.
   func tokenCacheKey(template: String?) -> String {
-    var tokenCacheKey = id
     if let template {
-      tokenCacheKey += "-\(template)"
+      return "\(id)-template-\(template)"
     }
-    return tokenCacheKey
+    return "\(id)-organization-\(lastActiveOrganizationId ?? "")"
   }
 }
 

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionService.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionService.swift
@@ -5,6 +5,22 @@
 
 import Foundation
 
+package struct SessionTokenRequestParams: Encodable, Equatable {
+  package var organizationId: String
+  package var token: String?
+  package var forceOrigin: String?
+
+  package init(
+    organizationId: String,
+    token: String? = nil,
+    forceOrigin: String? = nil
+  ) {
+    self.organizationId = organizationId
+    self.token = token
+    self.forceOrigin = forceOrigin
+  }
+}
+
 protocol SessionServiceProtocol: Sendable {
   @MainActor func revoke(sessionId: String) async throws -> Session
 
@@ -22,7 +38,12 @@ protocol SessionServiceProtocol: Sendable {
   /// - Parameters:
   ///   - sessionId: The session ID to generate a token for.
   ///   - template: Optional JWT template name.
-  @MainActor func fetchToken(sessionId: String, template: String?) async throws -> TokenResource?
+  ///   - params: Parameters used when generating the default session token.
+  @MainActor func fetchToken(
+    sessionId: String,
+    template: String?,
+    params: SessionTokenRequestParams?
+  ) async throws -> TokenResource?
 
   /// Starts an in-session reverification (step-up) flow.
   @MainActor func startVerification(
@@ -107,7 +128,11 @@ final class SessionService: SessionServiceProtocol {
   }
 
   @MainActor
-  func fetchToken(sessionId: String, template: String?) async throws -> TokenResource? {
+  func fetchToken(
+    sessionId: String,
+    template: String?,
+    params: SessionTokenRequestParams?
+  ) async throws -> TokenResource? {
     let path = if let template {
       "/v1/client/sessions/\(sessionId)/tokens/\(template)"
     } else {
@@ -116,7 +141,8 @@ final class SessionService: SessionServiceProtocol {
 
     let request = Request<TokenResource?>(
       path: path,
-      method: .post
+      method: .post,
+      body: template == nil ? params : nil
     )
 
     return try await apiClient.send(request).value

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionService.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionService.swift
@@ -103,6 +103,7 @@ final class SessionService: SessionServiceProtocol {
       )
 
       try await apiClient.send(request)
+      await SessionTokensCache.shared.removeTokens(sessionId: sessionId)
     } else {
       let request = Request<EmptyResponse>(
         path: "/v1/client/sessions",
@@ -110,21 +111,42 @@ final class SessionService: SessionServiceProtocol {
       )
 
       try await apiClient.send(request)
+      await SessionTokensCache.shared.clear()
     }
   }
 
   @MainActor
   func setActive(sessionId: String, organizationId: String?) async throws {
+    let runtime = try Clerk.requireStableRuntime()
     let request = Request<ClientResponse<Session>>(
       path: "/v1/client/sessions/\(sessionId)/touch",
       method: .post,
       body: [
         "active_organization_id": organizationId ?? "",
         "intent": "select_org",
-      ]
+      ],
+      automaticallySyncClient: false
     )
 
-    try await apiClient.send(request)
+    let response = try await apiClient.send(request)
+    guard let clientSyncMetadata = response.deferredClientSyncMetadata else {
+      throw ClerkClientError(
+        message: "Session activation response was missing identity synchronization metadata."
+      )
+    }
+    let clientUpdate: ClientResponseUpdate =
+      if clientSyncMetadata.deviceTokenUpdate == .clear {
+        .explicitClear
+      } else {
+        response.value.client.map(ClientResponseUpdate.client) ?? .absent
+      }
+
+    try runtime.validateStableRuntime()
+    await SessionTokensCache.shared.removeTokens(sessionId: sessionId)
+    let clerk = try runtime.requireCurrentClerk()
+    try await clerk.identityController.applyNetworkResponse(
+      clientSyncMetadata.context(update: clientUpdate)
+    )
   }
 
   @MainActor
@@ -138,11 +160,13 @@ final class SessionService: SessionServiceProtocol {
     } else {
       "/v1/client/sessions/\(sessionId)/tokens"
     }
+    let body = template == nil ? params : nil
 
     let request = Request<TokenResource?>(
       path: path,
       method: .post,
-      body: template == nil ? params : nil
+      body: body,
+      logBodies: false
     )
 
     return try await apiClient.send(request).value

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
@@ -190,7 +190,7 @@ actor SessionTokenFetcher {
       )
       try Task.checkCancellation()
       try runtime.validateStableRuntime()
-      if storeResult.didStoreIncoming {
+      if storeResult.didChangeCanonicalToken {
         Clerk.shared.auth.send(.tokenRefreshed(token: token.jwt))
       }
     }
@@ -204,7 +204,7 @@ actor SessionTokensCache {
 
   struct StoreResult {
     let canonicalToken: TokenResource
-    let didStoreIncoming: Bool
+    let didChangeCanonicalToken: Bool
   }
 
   private var cache: [String: TokenResource] = [:]
@@ -223,15 +223,16 @@ actor SessionTokensCache {
     cacheKey: String,
     now: Date = .now
   ) -> StoreResult {
+    let previousToken = cache[cacheKey]
     let canonicalToken = TokenFreshness.pickFreshest(
-      existing: cache[cacheKey],
+      existing: previousToken,
       incoming: token,
       now: now
     )
     cache[cacheKey] = canonicalToken
     return StoreResult(
       canonicalToken: canonicalToken,
-      didStoreIncoming: canonicalToken.jwt == token.jwt
+      didChangeCanonicalToken: previousToken?.jwt != canonicalToken.jwt
     )
   }
 

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
@@ -39,7 +39,7 @@ private func cacheLastActiveTokenIfNeeded(
     return
   }
 
-  await SessionTokensCache.shared.storeIfFresher(
+  await SessionTokensCache.shared.hydrate(
     lastActiveToken,
     cacheKey: context.cacheKey
   )
@@ -214,6 +214,19 @@ actor SessionTokensCache {
   /// - Returns: ``TokenResource``
   func getToken(cacheKey: String) -> TokenResource? {
     cache[cacheKey]
+  }
+
+  /// Reconciles a session snapshot without replacing an equally fresh canonical token.
+  func hydrate(
+    _ token: TokenResource,
+    cacheKey: String
+  ) {
+    let canonicalToken = TokenFreshness.pickFreshest(
+      existing: cache[cacheKey],
+      incoming: token,
+      tieBreaker: .existing
+    )
+    cache[cacheKey] = canonicalToken
   }
 
   /// Atomically keeps the freshest token for a cache key.

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
@@ -75,12 +75,17 @@ private func makeSessionTokenRequestParams(
 actor SessionTokenFetcher {
   static let shared = SessionTokenFetcher()
 
+  struct InFlightTokenTask {
+    let id: UUID
+    let task: Task<TokenResource?, Error>
+  }
+
   /// Key is `tokenCacheKey` property of a `session`
-  var tokenTasks: [String: Task<TokenResource?, Error>] = [:]
+  var tokenTasks: [String: InFlightTokenTask] = [:]
 
   func reset() {
-    for task in tokenTasks.values {
-      task.cancel()
+    for inFlightTask in tokenTasks.values {
+      inFlightTask.task.cancel()
     }
     tokenTasks.removeAll()
   }
@@ -96,22 +101,27 @@ actor SessionTokenFetcher {
     }
 
     if let inProgressTask = tokenTasks[context.cacheKey] {
-      let result = await inProgressTask.result
+      let result = await inProgressTask.task.result
       try runtime.validateStableRuntime()
       return try result.get()
     }
 
+    let requestId = UUID()
     let task: Task<TokenResource?, Error> = Task {
       try Task.checkCancellation()
       return try await fetchToken(context, options: options, runtime: runtime)
     }
 
-    tokenTasks[context.cacheKey] = task
+    tokenTasks[context.cacheKey] = InFlightTokenTask(
+      id: requestId,
+      task: task
+    )
 
     let result = await task.result
 
-    // clear the inProgressTask on success AND failure
-    tokenTasks[context.cacheKey] = nil
+    if tokenTasks[context.cacheKey]?.id == requestId {
+      tokenTasks[context.cacheKey] = nil
+    }
 
     try runtime.validateStableRuntime()
     return try result.get()

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
@@ -9,6 +9,8 @@ private struct SessionTokenFetchContext {
   let session: Session
   let cacheKey: String
   let sessionMinterEnabled: Bool
+  let sessionSnapshotToken: TokenResource?
+  let isCurrentActiveSession: Bool
 }
 
 @MainActor
@@ -16,20 +18,25 @@ private func makeSessionTokenFetchContext(
   session: Session,
   template: String?
 ) -> SessionTokenFetchContext {
-  let currentSession = Clerk.shared.client?.sessions.first { $0.id == session.id } ?? session
+  let currentSession = Clerk.shared.client?.activeSessions.first { $0.id == session.id }
+  let resolvedSession = currentSession ?? session
   return SessionTokenFetchContext(
-    session: currentSession,
-    cacheKey: currentSession.tokenCacheKey(template: template),
-    sessionMinterEnabled: Clerk.shared.environment?.authConfig.sessionMinter == true
+    session: resolvedSession,
+    cacheKey: resolvedSession.tokenCacheKey(template: template),
+    sessionMinterEnabled: Clerk.shared.environment?.authConfig.sessionMinter == true,
+    sessionSnapshotToken: currentSession?.lastActiveToken,
+    isCurrentActiveSession: currentSession != nil
   )
 }
 
 private func cacheLastActiveTokenIfNeeded(
   context: SessionTokenFetchContext,
-  template: String?
+  template: String?,
+  generation: SessionTokensCache.Generation
 ) async {
-  guard template == nil,
-        let lastActiveToken = context.session.lastActiveToken,
+  guard context.isCurrentActiveSession,
+        template == nil,
+        let lastActiveToken = context.sessionSnapshotToken,
         TokenFreshness.matches(
           lastActiveToken,
           sessionId: context.session.id,
@@ -41,7 +48,8 @@ private func cacheLastActiveTokenIfNeeded(
 
   await SessionTokensCache.shared.hydrate(
     lastActiveToken,
-    cacheKey: context.cacheKey
+    cacheKey: context.cacheKey,
+    generation: generation
   )
 }
 
@@ -53,14 +61,19 @@ private func makeSessionTokenRequestParams(
     return nil
   }
 
-  let cachedToken = await SessionTokensCache.shared.getToken(cacheKey: context.cacheKey)
-  let previousToken = if let cachedToken {
-    TokenFreshness.pickFreshest(
-      existing: context.session.lastActiveToken,
-      incoming: cachedToken
-    )
+  let previousToken: TokenResource?
+  if context.isCurrentActiveSession {
+    let cachedToken = await SessionTokensCache.shared.getToken(cacheKey: context.cacheKey)
+    previousToken = if let cachedToken {
+      TokenFreshness.pickFreshest(
+        existing: context.sessionSnapshotToken,
+        incoming: cachedToken
+      )
+    } else {
+      context.sessionSnapshotToken
+    }
   } else {
-    context.session.lastActiveToken
+    previousToken = nil
   }
 
   return SessionTokenRequestParams(
@@ -77,12 +90,14 @@ actor SessionTokenFetcher {
 
   struct InFlightTokenTask {
     let id: UUID
+    let cacheGeneration: SessionTokensCache.Generation
+    let isCurrentActiveSession: Bool
     let task: Task<TokenResource?, Error>
   }
 
   /// Key is `tokenCacheKey` property of a `session`
   var tokenTasks: [String: InFlightTokenTask] = [:]
-  var forcedTokenTasks: [UUID: Task<TokenResource?, Error>] = [:]
+  var forcedTokenTasks: [UUID: InFlightTokenTask] = [:]
 
   func reset() {
     for inFlightTask in tokenTasks.values {
@@ -90,13 +105,16 @@ actor SessionTokenFetcher {
     }
     tokenTasks.removeAll()
 
-    for task in forcedTokenTasks.values {
-      task.cancel()
+    for inFlightTask in forcedTokenTasks.values {
+      inFlightTask.task.cancel()
     }
     forcedTokenTasks.removeAll()
   }
 
   func getToken(_ session: Session, options: Session.GetTokenOptions = .init()) async throws -> TokenResource? {
+    let cacheGeneration = await SessionTokensCache.shared.generation(
+      sessionId: session.id
+    )
     let runtime = try await Clerk.requireStableRuntime()
     let context = await makeSessionTokenFetchContext(session: session, template: options.template)
 
@@ -104,24 +122,38 @@ actor SessionTokenFetcher {
       return try await getForcedToken(
         context,
         options: options,
-        runtime: runtime
+        runtime: runtime,
+        cacheGeneration: cacheGeneration
       )
     }
 
     if let inProgressTask = tokenTasks[context.cacheKey] {
-      let result = await inProgressTask.task.result
-      try runtime.validateStableRuntime()
-      return try result.get()
+      if inProgressTask.cacheGeneration == cacheGeneration,
+         inProgressTask.isCurrentActiveSession == context.isCurrentActiveSession
+      {
+        let result = await inProgressTask.task.result
+        try runtime.validateStableRuntime()
+        return try result.get()
+      }
+
+      inProgressTask.task.cancel()
     }
 
     let requestId = UUID()
     let task: Task<TokenResource?, Error> = Task {
       try Task.checkCancellation()
-      return try await fetchToken(context, options: options, runtime: runtime)
+      return try await fetchToken(
+        context,
+        options: options,
+        runtime: runtime,
+        cacheGeneration: cacheGeneration
+      )
     }
 
     tokenTasks[context.cacheKey] = InFlightTokenTask(
       id: requestId,
+      cacheGeneration: cacheGeneration,
+      isCurrentActiveSession: context.isCurrentActiveSession,
       task: task
     )
 
@@ -138,14 +170,25 @@ actor SessionTokenFetcher {
   private func getForcedToken(
     _ context: SessionTokenFetchContext,
     options: Session.GetTokenOptions,
-    runtime: ClerkRuntimeScope
+    runtime: ClerkRuntimeScope,
+    cacheGeneration: SessionTokensCache.Generation
   ) async throws -> TokenResource? {
     let requestId = UUID()
     let task: Task<TokenResource?, Error> = Task {
       try Task.checkCancellation()
-      return try await fetchToken(context, options: options, runtime: runtime)
+      return try await fetchToken(
+        context,
+        options: options,
+        runtime: runtime,
+        cacheGeneration: cacheGeneration
+      )
     }
-    forcedTokenTasks[requestId] = task
+    forcedTokenTasks[requestId] = InFlightTokenTask(
+      id: requestId,
+      cacheGeneration: cacheGeneration,
+      isCurrentActiveSession: context.isCurrentActiveSession,
+      task: task
+    )
     defer { forcedTokenTasks[requestId] = nil }
 
     let result = await withTaskCancellationHandler {
@@ -163,26 +206,37 @@ actor SessionTokenFetcher {
    */
   @discardableResult @MainActor
   func fetchToken(_ session: Session, options: Session.GetTokenOptions = .init()) async throws -> TokenResource? {
+    let cacheGeneration = await SessionTokensCache.shared.generation(
+      sessionId: session.id
+    )
     let runtime = try Clerk.requireStableRuntime()
     let context = makeSessionTokenFetchContext(session: session, template: options.template)
-    return try await fetchToken(context, options: options, runtime: runtime)
+    return try await fetchToken(
+      context,
+      options: options,
+      runtime: runtime,
+      cacheGeneration: cacheGeneration
+    )
   }
 
   @discardableResult @MainActor
   private func fetchToken(
     _ context: SessionTokenFetchContext,
     options: Session.GetTokenOptions,
-    runtime: ClerkRuntimeScope
+    runtime: ClerkRuntimeScope,
+    cacheGeneration: SessionTokensCache.Generation
   ) async throws -> TokenResource? {
     try Task.checkCancellation()
     try runtime.validateStableRuntime()
 
     await cacheLastActiveTokenIfNeeded(
       context: context,
-      template: options.template
+      template: options.template,
+      generation: cacheGeneration
     )
 
-    if options.skipCache == false,
+    if context.isCurrentActiveSession,
+       options.skipCache == false,
        let token = await SessionTokensCache.shared.getToken(cacheKey: context.cacheKey),
        let expiresAt = token.decodedJWT?.expiresAt,
        Date.now.distance(to: expiresAt) > options.expirationBuffer
@@ -217,11 +271,12 @@ actor SessionTokenFetcher {
       try runtime.validateStableRuntime()
       let storeResult = await SessionTokensCache.shared.storeIfFresher(
         token,
-        cacheKey: context.cacheKey
+        cacheKey: context.cacheKey,
+        generation: cacheGeneration
       )
       try Task.checkCancellation()
       try runtime.validateStableRuntime()
-      if storeResult.didChangeCanonicalToken {
+      if storeResult?.didChangeCanonicalToken == true {
         Clerk.shared.auth.send(.tokenRefreshed(token: token.jwt))
       }
     }
@@ -233,12 +288,18 @@ actor SessionTokenFetcher {
 actor SessionTokensCache {
   static let shared = SessionTokensCache()
 
+  struct Generation: Equatable {
+    let sessionId: String
+    let value: UInt64
+  }
+
   struct StoreResult {
     let canonicalToken: TokenResource
     let didChangeCanonicalToken: Bool
   }
 
   private var cache: [String: TokenResource] = [:]
+  private var generations: [String: UInt64] = [:]
 
   /// Returns a session token from the cache.
   /// - Parameter cacheKey: Cache key for a session's organization or token template.
@@ -247,11 +308,23 @@ actor SessionTokensCache {
     cache[cacheKey]
   }
 
+  /// Captures the current cache generation before a token request starts.
+  func generation(sessionId: String) -> Generation {
+    let value = generations[sessionId] ?? 0
+    generations[sessionId] = value
+    return Generation(sessionId: sessionId, value: value)
+  }
+
   /// Reconciles a session snapshot without replacing an equally fresh canonical token.
   func hydrate(
     _ token: TokenResource,
-    cacheKey: String
+    cacheKey: String,
+    generation: Generation? = nil
   ) {
+    if let generation, !isCurrent(generation) {
+      return
+    }
+
     let canonicalToken = TokenFreshness.pickFreshest(
       existing: cache[cacheKey],
       incoming: token,
@@ -266,6 +339,28 @@ actor SessionTokensCache {
     _ token: TokenResource,
     cacheKey: String,
     now: Date = .now
+  ) -> StoreResult {
+    storeIfFresherUnchecked(token, cacheKey: cacheKey, now: now)
+  }
+
+  /// Atomically keeps the freshest token when the session has not been invalidated.
+  func storeIfFresher(
+    _ token: TokenResource,
+    cacheKey: String,
+    generation: Generation,
+    now: Date = .now
+  ) -> StoreResult? {
+    guard isCurrent(generation) else {
+      return nil
+    }
+
+    return storeIfFresherUnchecked(token, cacheKey: cacheKey, now: now)
+  }
+
+  private func storeIfFresherUnchecked(
+    _ token: TokenResource,
+    cacheKey: String,
+    now: Date
   ) -> StoreResult {
     let previousToken = cache[cacheKey]
     let canonicalToken = TokenFreshness.pickFreshest(
@@ -288,7 +383,21 @@ actor SessionTokensCache {
     cache[cacheKey] = token
   }
 
+  /// Removes every cached token for a session and invalidates earlier requests.
+  func removeTokens(sessionId: String) {
+    let cacheKeyPrefix = "\(sessionId)-"
+    cache = cache.filter { key, _ in
+      !key.hasPrefix(cacheKeyPrefix)
+    }
+    generations[sessionId] = (generations[sessionId] ?? 0) &+ 1
+  }
+
   func clear() {
     cache.removeAll()
+    generations = generations.mapValues { $0 &+ 1 }
+  }
+
+  private func isCurrent(_ generation: Generation) -> Bool {
+    generations[generation.sessionId] ?? 0 == generation.value
   }
 }

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
@@ -5,6 +5,71 @@
 
 import Foundation
 
+private struct SessionTokenFetchContext {
+  let session: Session
+  let cacheKey: String
+  let sessionMinterEnabled: Bool
+}
+
+@MainActor
+private func makeSessionTokenFetchContext(
+  session: Session,
+  template: String?
+) -> SessionTokenFetchContext {
+  let currentSession = Clerk.shared.client?.sessions.first { $0.id == session.id } ?? session
+  return SessionTokenFetchContext(
+    session: currentSession,
+    cacheKey: currentSession.tokenCacheKey(template: template),
+    sessionMinterEnabled: Clerk.shared.environment?.authConfig.sessionMinter == true
+  )
+}
+
+private func cacheLastActiveTokenIfNeeded(
+  context: SessionTokenFetchContext,
+  template: String?
+) async {
+  guard template == nil,
+        let lastActiveToken = context.session.lastActiveToken,
+        TokenFreshness.matches(
+          lastActiveToken,
+          sessionId: context.session.id,
+          organizationId: context.session.lastActiveOrganizationId
+        )
+  else {
+    return
+  }
+
+  await SessionTokensCache.shared.storeIfFresher(
+    lastActiveToken,
+    cacheKey: context.cacheKey
+  )
+}
+
+private func makeSessionTokenRequestParams(
+  context: SessionTokenFetchContext,
+  options: Session.GetTokenOptions
+) async -> SessionTokenRequestParams? {
+  guard options.template == nil else {
+    return nil
+  }
+
+  let cachedToken = await SessionTokensCache.shared.getToken(cacheKey: context.cacheKey)
+  let previousToken = if let cachedToken {
+    TokenFreshness.pickFreshest(
+      existing: context.session.lastActiveToken,
+      incoming: cachedToken
+    )
+  } else {
+    context.session.lastActiveToken
+  }
+
+  return SessionTokenRequestParams(
+    organizationId: context.session.lastActiveOrganizationId ?? "",
+    token: context.sessionMinterEnabled ? previousToken?.jwt : nil,
+    forceOrigin: context.sessionMinterEnabled && options.skipCache ? "true" : nil
+  )
+}
+
 /// The purpose of this actor is to NOT trigger refreshes of tokens if a refresh is already in progress.
 /// This is not a token cache. It is only responsible to returning in progress tasks to refresh a token.
 actor SessionTokenFetcher {
@@ -22,9 +87,15 @@ actor SessionTokenFetcher {
 
   func getToken(_ session: Session, options: Session.GetTokenOptions = .init()) async throws -> TokenResource? {
     let runtime = try await Clerk.requireStableRuntime()
-    let cacheKey = session.tokenCacheKey(template: options.template)
+    let context = await makeSessionTokenFetchContext(session: session, template: options.template)
 
-    if let inProgressTask = tokenTasks[cacheKey] {
+    if options.skipCache {
+      let token = try await fetchToken(context, options: options, runtime: runtime)
+      try runtime.validateStableRuntime()
+      return token
+    }
+
+    if let inProgressTask = tokenTasks[context.cacheKey] {
       let result = await inProgressTask.result
       try runtime.validateStableRuntime()
       return try result.get()
@@ -32,15 +103,15 @@ actor SessionTokenFetcher {
 
     let task: Task<TokenResource?, Error> = Task {
       try Task.checkCancellation()
-      return try await fetchToken(session, options: options, runtime: runtime)
+      return try await fetchToken(context, options: options, runtime: runtime)
     }
 
-    tokenTasks[cacheKey] = task
+    tokenTasks[context.cacheKey] = task
 
     let result = await task.result
 
     // clear the inProgressTask on success AND failure
-    tokenTasks[cacheKey] = nil
+    tokenTasks[context.cacheKey] = nil
 
     try runtime.validateStableRuntime()
     return try result.get()
@@ -52,22 +123,26 @@ actor SessionTokenFetcher {
   @discardableResult @MainActor
   func fetchToken(_ session: Session, options: Session.GetTokenOptions = .init()) async throws -> TokenResource? {
     let runtime = try Clerk.requireStableRuntime()
-    return try await fetchToken(session, options: options, runtime: runtime)
+    let context = makeSessionTokenFetchContext(session: session, template: options.template)
+    return try await fetchToken(context, options: options, runtime: runtime)
   }
 
   @discardableResult @MainActor
   private func fetchToken(
-    _ session: Session,
+    _ context: SessionTokenFetchContext,
     options: Session.GetTokenOptions,
     runtime: ClerkRuntimeScope
   ) async throws -> TokenResource? {
-    let cacheKey = session.tokenCacheKey(template: options.template)
-
     try Task.checkCancellation()
     try runtime.validateStableRuntime()
 
+    await cacheLastActiveTokenIfNeeded(
+      context: context,
+      template: options.template
+    )
+
     if options.skipCache == false,
-       let token = await SessionTokensCache.shared.getToken(cacheKey: cacheKey),
+       let token = await SessionTokensCache.shared.getToken(cacheKey: context.cacheKey),
        let expiresAt = token.decodedJWT?.expiresAt,
        Date.now.distance(to: expiresAt) > options.expirationBuffer
     {
@@ -79,9 +154,18 @@ actor SessionTokenFetcher {
     try Task.checkCancellation()
     try runtime.validateStableRuntime()
 
+    let requestParams = await makeSessionTokenRequestParams(
+      context: context,
+      options: options
+    )
+
+    try Task.checkCancellation()
+    try runtime.validateStableRuntime()
+
     let token = try await Clerk.shared.dependencies.sessionService.fetchToken(
-      sessionId: session.id,
-      template: options.template
+      sessionId: context.session.id,
+      template: options.template,
+      params: requestParams
     )
 
     try Task.checkCancellation()
@@ -90,10 +174,15 @@ actor SessionTokenFetcher {
     if let token {
       try Task.checkCancellation()
       try runtime.validateStableRuntime()
-      await SessionTokensCache.shared.insertToken(token, cacheKey: cacheKey)
+      let storeResult = await SessionTokensCache.shared.storeIfFresher(
+        token,
+        cacheKey: context.cacheKey
+      )
       try Task.checkCancellation()
       try runtime.validateStableRuntime()
-      Clerk.shared.auth.send(.tokenRefreshed(token: token.jwt))
+      if storeResult.didStoreIncoming {
+        Clerk.shared.auth.send(.tokenRefreshed(token: token.jwt))
+      }
     }
 
     return token
@@ -103,21 +192,43 @@ actor SessionTokenFetcher {
 actor SessionTokensCache {
   static let shared = SessionTokensCache()
 
+  struct StoreResult {
+    let canonicalToken: TokenResource
+    let didStoreIncoming: Bool
+  }
+
   private var cache: [String: TokenResource] = [:]
 
   /// Returns a session token from the cache.
-  /// - Parameter cacheKey: cacheKey is the session id + template name if there is one.
-  ///                       For example, `sess_abc12345` or `sess_abc12345-supabase`.
+  /// - Parameter cacheKey: Cache key for a session's organization or token template.
   /// - Returns: ``TokenResource``
   func getToken(cacheKey: String) -> TokenResource? {
     cache[cacheKey]
   }
 
+  /// Atomically keeps the freshest token for a cache key.
+  @discardableResult
+  func storeIfFresher(
+    _ token: TokenResource,
+    cacheKey: String,
+    now: Date = .now
+  ) -> StoreResult {
+    let canonicalToken = TokenFreshness.pickFreshest(
+      existing: cache[cacheKey],
+      incoming: token,
+      now: now
+    )
+    cache[cacheKey] = canonicalToken
+    return StoreResult(
+      canonicalToken: canonicalToken,
+      didStoreIncoming: canonicalToken.jwt == token.jwt
+    )
+  }
+
   /// Inserts a session token into the cache.
   /// - Parameters:
   ///   - token: ``TokenResource``
-  ///   - cacheKey: cacheKey is the session id + template name if there is one.
-  ///               For example, `sess_abc12345` or `sess_abc12345-supabase`.
+  ///   - cacheKey: Cache key for a session's organization or token template.
   func insertToken(_ token: TokenResource, cacheKey: String) {
     cache[cacheKey] = token
   }

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
@@ -82,12 +82,18 @@ actor SessionTokenFetcher {
 
   /// Key is `tokenCacheKey` property of a `session`
   var tokenTasks: [String: InFlightTokenTask] = [:]
+  var forcedTokenTasks: [UUID: Task<TokenResource?, Error>] = [:]
 
   func reset() {
     for inFlightTask in tokenTasks.values {
       inFlightTask.task.cancel()
     }
     tokenTasks.removeAll()
+
+    for task in forcedTokenTasks.values {
+      task.cancel()
+    }
+    forcedTokenTasks.removeAll()
   }
 
   func getToken(_ session: Session, options: Session.GetTokenOptions = .init()) async throws -> TokenResource? {
@@ -95,9 +101,11 @@ actor SessionTokenFetcher {
     let context = await makeSessionTokenFetchContext(session: session, template: options.template)
 
     if options.skipCache {
-      let token = try await fetchToken(context, options: options, runtime: runtime)
-      try runtime.validateStableRuntime()
-      return token
+      return try await getForcedToken(
+        context,
+        options: options,
+        runtime: runtime
+      )
     }
 
     if let inProgressTask = tokenTasks[context.cacheKey] {
@@ -121,6 +129,29 @@ actor SessionTokenFetcher {
 
     if tokenTasks[context.cacheKey]?.id == requestId {
       tokenTasks[context.cacheKey] = nil
+    }
+
+    try runtime.validateStableRuntime()
+    return try result.get()
+  }
+
+  private func getForcedToken(
+    _ context: SessionTokenFetchContext,
+    options: Session.GetTokenOptions,
+    runtime: ClerkRuntimeScope
+  ) async throws -> TokenResource? {
+    let requestId = UUID()
+    let task: Task<TokenResource?, Error> = Task {
+      try Task.checkCancellation()
+      return try await fetchToken(context, options: options, runtime: runtime)
+    }
+    forcedTokenTasks[requestId] = task
+    defer { forcedTokenTasks[requestId] = nil }
+
+    let result = await withTaskCancellationHandler {
+      await task.result
+    } onCancel: {
+      task.cancel()
     }
 
     try runtime.validateStableRuntime()

--- a/Sources/ClerkKit/Domains/Auth/TokenFreshness.swift
+++ b/Sources/ClerkKit/Domains/Auth/TokenFreshness.swift
@@ -19,19 +19,22 @@ enum TokenFreshness {
     let existingJWT = try? DecodedJWT(jwt: existing.jwt)
     let incomingJWT = try? DecodedJWT(jwt: incoming.jwt)
 
-    if let expiresAt = existingJWT?.expiresAt, expiresAt <= now {
-      return incoming
-    }
-
     guard let existingJWT, let incomingJWT else {
       return incoming
     }
 
-    guard existingJWT.sessionId == incomingJWT.sessionId,
-          normalizedOrganizationId(existingJWT.organizationId)
-          == normalizedOrganizationId(incomingJWT.organizationId)
-    else {
+    guard haveMatchingContext(existingJWT, incomingJWT) else {
       return incoming
+    }
+
+    if let freshestByExpiration = pickByExpiration(
+      existing: existing,
+      existingJWT: existingJWT,
+      incoming: incoming,
+      incomingJWT: incomingJWT,
+      now: now
+    ) {
+      return freshestByExpiration
     }
 
     switch (existingJWT.originIssuedAt, incomingJWT.originIssuedAt) {
@@ -62,6 +65,35 @@ enum TokenFreshness {
         incomingJWT: incomingJWT,
         tieBreaker: tieBreaker
       )
+    }
+  }
+
+  private static func haveMatchingContext(
+    _ existingJWT: DecodedJWT,
+    _ incomingJWT: DecodedJWT
+  ) -> Bool {
+    existingJWT.sessionId == incomingJWT.sessionId
+      && normalizedOrganizationId(existingJWT.organizationId)
+      == normalizedOrganizationId(incomingJWT.organizationId)
+  }
+
+  private static func pickByExpiration(
+    existing: TokenResource,
+    existingJWT: DecodedJWT,
+    incoming: TokenResource,
+    incomingJWT: DecodedJWT,
+    now: Date
+  ) -> TokenResource? {
+    let existingIsExpired = existingJWT.expiresAt.map { $0 <= now }
+    let incomingIsExpired = incomingJWT.expiresAt.map { $0 <= now }
+
+    switch (existingIsExpired, incomingIsExpired) {
+    case (.some(true), .some(false)):
+      return incoming
+    case (.some(false), .some(true)):
+      return existing
+    default:
+      return nil
     }
   }
 

--- a/Sources/ClerkKit/Domains/Auth/TokenFreshness.swift
+++ b/Sources/ClerkKit/Domains/Auth/TokenFreshness.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+enum TokenFreshness {
+  static func pickFreshest(
+    existing: TokenResource?,
+    incoming: TokenResource,
+    now: Date = .now
+  ) -> TokenResource {
+    guard let existing else {
+      return incoming
+    }
+
+    let existingJWT = try? DecodedJWT(jwt: existing.jwt)
+    let incomingJWT = try? DecodedJWT(jwt: incoming.jwt)
+
+    if let expiresAt = existingJWT?.expiresAt, expiresAt <= now {
+      return incoming
+    }
+
+    guard let existingJWT, let incomingJWT else {
+      return incoming
+    }
+
+    guard existingJWT.sessionId == incomingJWT.sessionId,
+          normalizedOrganizationId(existingJWT.organizationId)
+          == normalizedOrganizationId(incomingJWT.organizationId)
+    else {
+      return incoming
+    }
+
+    switch (existingJWT.originIssuedAt, incomingJWT.originIssuedAt) {
+    case (nil, nil):
+      return incoming
+    case (.some, nil):
+      return existing
+    case (nil, .some):
+      return incoming
+    case (.some(let existingOriginIssuedAt), .some(let incomingOriginIssuedAt)):
+      if existingOriginIssuedAt > incomingOriginIssuedAt {
+        return existing
+      }
+      if incomingOriginIssuedAt > existingOriginIssuedAt {
+        return incoming
+      }
+
+      let existingIssuedAt = existingJWT.issuedAt?.timeIntervalSince1970 ?? 0
+      let incomingIssuedAt = incomingJWT.issuedAt?.timeIntervalSince1970 ?? 0
+      return existingIssuedAt > incomingIssuedAt ? existing : incoming
+    }
+  }
+
+  static func matches(
+    _ token: TokenResource,
+    sessionId: String,
+    organizationId: String?
+  ) -> Bool {
+    guard let jwt = try? DecodedJWT(jwt: token.jwt) else {
+      return true
+    }
+    guard let tokenSessionId = jwt.sessionId else {
+      return true
+    }
+    return tokenSessionId == sessionId
+      && normalizedOrganizationId(jwt.organizationId) == normalizedOrganizationId(organizationId)
+  }
+
+  static func normalizedOrganizationId(_ organizationId: String?) -> String {
+    organizationId ?? ""
+  }
+}

--- a/Sources/ClerkKit/Domains/Auth/TokenFreshness.swift
+++ b/Sources/ClerkKit/Domains/Auth/TokenFreshness.swift
@@ -19,9 +19,34 @@ enum TokenFreshness {
     let existingJWT = try? DecodedJWT(jwt: existing.jwt)
     let incomingJWT = try? DecodedJWT(jwt: incoming.jwt)
 
-    guard let existingJWT, let incomingJWT else {
+    switch (existingJWT, incomingJWT) {
+    case (.some(let existingJWT), .some(let incomingJWT)):
+      return pickFreshestDecoded(
+        existing: existing,
+        incoming: incoming,
+        decodedJWTs: (
+          existing: existingJWT,
+          incoming: incomingJWT
+        ),
+        now: now,
+        tieBreaker: tieBreaker
+      )
+    case (.some, nil):
+      return existing
+    case (nil, _):
       return incoming
     }
+  }
+
+  private static func pickFreshestDecoded(
+    existing: TokenResource,
+    incoming: TokenResource,
+    decodedJWTs: (existing: DecodedJWT, incoming: DecodedJWT),
+    now: Date,
+    tieBreaker: TieBreaker
+  ) -> TokenResource {
+    let existingJWT = decodedJWTs.existing
+    let incomingJWT = decodedJWTs.incoming
 
     guard haveMatchingContext(existingJWT, incomingJWT) else {
       return incoming

--- a/Sources/ClerkKit/Domains/Auth/TokenFreshness.swift
+++ b/Sources/ClerkKit/Domains/Auth/TokenFreshness.swift
@@ -1,10 +1,16 @@
 import Foundation
 
 enum TokenFreshness {
+  enum TieBreaker {
+    case existing
+    case incoming
+  }
+
   static func pickFreshest(
     existing: TokenResource?,
     incoming: TokenResource,
-    now: Date = .now
+    now: Date = .now,
+    tieBreaker: TieBreaker = .incoming
   ) -> TokenResource {
     guard let existing else {
       return incoming
@@ -30,7 +36,13 @@ enum TokenFreshness {
 
     switch (existingJWT.originIssuedAt, incomingJWT.originIssuedAt) {
     case (nil, nil):
-      return incoming
+      return pickByIssuedAt(
+        existing: existing,
+        existingJWT: existingJWT,
+        incoming: incoming,
+        incomingJWT: incomingJWT,
+        tieBreaker: tieBreaker
+      )
     case (.some, nil):
       return existing
     case (nil, .some):
@@ -43,9 +55,37 @@ enum TokenFreshness {
         return incoming
       }
 
-      let existingIssuedAt = existingJWT.issuedAt?.timeIntervalSince1970 ?? 0
-      let incomingIssuedAt = incomingJWT.issuedAt?.timeIntervalSince1970 ?? 0
-      return existingIssuedAt > incomingIssuedAt ? existing : incoming
+      return pickByIssuedAt(
+        existing: existing,
+        existingJWT: existingJWT,
+        incoming: incoming,
+        incomingJWT: incomingJWT,
+        tieBreaker: tieBreaker
+      )
+    }
+  }
+
+  private static func pickByIssuedAt(
+    existing: TokenResource,
+    existingJWT: DecodedJWT,
+    incoming: TokenResource,
+    incomingJWT: DecodedJWT,
+    tieBreaker: TieBreaker
+  ) -> TokenResource {
+    let existingIssuedAt = existingJWT.issuedAt?.timeIntervalSince1970 ?? 0
+    let incomingIssuedAt = incomingJWT.issuedAt?.timeIntervalSince1970 ?? 0
+
+    if existingIssuedAt > incomingIssuedAt {
+      return existing
+    }
+    if incomingIssuedAt > existingIssuedAt {
+      return incoming
+    }
+    switch tieBreaker {
+    case .existing:
+      return existing
+    case .incoming:
+      return incoming
     }
   }
 

--- a/Sources/ClerkKit/Domains/Environment/AuthConfig.swift
+++ b/Sources/ClerkKit/Domains/Environment/AuthConfig.swift
@@ -8,5 +8,20 @@ import Foundation
 extension Clerk.Environment {
   public struct AuthConfig: Codable, Sendable, Equatable {
     public var singleSessionMode: Bool
+    public var sessionMinter: Bool
+
+    public init(
+      singleSessionMode: Bool,
+      sessionMinter: Bool = false
+    ) {
+      self.singleSessionMode = singleSessionMode
+      self.sessionMinter = sessionMinter
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      singleSessionMode = try container.decode(Bool.self, forKey: .singleSessionMode)
+      sessionMinter = try container.decodeIfPresent(Bool.self, forKey: .sessionMinter) ?? false
+    }
   }
 }

--- a/Sources/ClerkKit/Mocks/MockServices/MockSessionService.swift
+++ b/Sources/ClerkKit/Mocks/MockServices/MockSessionService.swift
@@ -21,8 +21,9 @@ package final class MockSessionService: SessionServiceProtocol {
   /// Custom handler for the `setActive(sessionId:organizationId:)` method.
   package nonisolated(unsafe) var setActiveHandler: ((String, String?) async throws -> Void)?
 
-  /// Custom handler for the `fetchToken(sessionId:template:)` method.
-  package nonisolated(unsafe) var fetchTokenHandler: ((String, String?) async throws -> TokenResource?)?
+  /// Custom handler for the `fetchToken(sessionId:template:params:)` method.
+  package nonisolated(unsafe) var fetchTokenHandler:
+    ((String, String?, SessionTokenRequestParams?) async throws -> TokenResource?)?
 
   /// Custom handler for the `startVerification(sessionId:params:)` method.
   nonisolated(unsafe) var startVerificationHandler: ((String, Session.StartVerificationParams) async throws -> SessionVerification)?
@@ -43,7 +44,7 @@ package final class MockSessionService: SessionServiceProtocol {
     revoke: ((String) async throws -> Session)? = nil,
     signOut: ((String?) async throws -> Void)? = nil,
     setActive: ((String, String?) async throws -> Void)? = nil,
-    fetchToken: ((String, String?) async throws -> TokenResource?)? = nil
+    fetchToken: ((String, String?, SessionTokenRequestParams?) async throws -> TokenResource?)? = nil
   ) {
     self.init(
       revoke: revoke,
@@ -62,7 +63,7 @@ package final class MockSessionService: SessionServiceProtocol {
     revoke: ((String) async throws -> Session)? = nil,
     signOut: ((String?) async throws -> Void)? = nil,
     setActive: ((String, String?) async throws -> Void)? = nil,
-    fetchToken: ((String, String?) async throws -> TokenResource?)? = nil,
+    fetchToken: ((String, String?, SessionTokenRequestParams?) async throws -> TokenResource?)? = nil,
     startVerification: ((String, Session.StartVerificationParams) async throws -> SessionVerification)? = nil,
     prepareFirstFactorVerification: ((String, Session.PrepareFirstFactorVerificationParams) async throws -> SessionVerification)? = nil,
     attemptFirstFactorVerification: ((String, Session.AttemptFirstFactorVerificationParams) async throws -> SessionVerification)? = nil,
@@ -104,9 +105,13 @@ package final class MockSessionService: SessionServiceProtocol {
   }
 
   @MainActor
-  package func fetchToken(sessionId: String, template: String?) async throws -> TokenResource? {
+  package func fetchToken(
+    sessionId: String,
+    template: String?,
+    params: SessionTokenRequestParams?
+  ) async throws -> TokenResource? {
     if let handler = fetchTokenHandler {
-      return try await handler(sessionId, template)
+      return try await handler(sessionId, template, params)
     }
 
     return .mock

--- a/Sources/ClerkKit/Utils/JWTDecoder.swift
+++ b/Sources/ClerkKit/Utils/JWTDecoder.swift
@@ -157,6 +157,21 @@ struct DecodedJWT: JWT {
     claim(name: "iat").date
   }
 
+  var originIssuedAt: Date? {
+    Claim(value: header["oiat"]).date
+  }
+
+  var sessionId: String? {
+    claim(name: "sid").string
+  }
+
+  var organizationId: String? {
+    if let organizationId = claim(name: "org_id").string {
+      return organizationId
+    }
+    return (body["o"] as? [String: Any])?["id"] as? String
+  }
+
   var notBefore: Date? {
     claim(name: "nbf").date
   }

--- a/Tests/Core/ClerkReconfigureTests.swift
+++ b/Tests/Core/ClerkReconfigureTests.swift
@@ -545,7 +545,7 @@ struct ClerkReconfigureTests {
   @Test
   func reconfigureClearsTokensBeforeSessionChangedEvent() async throws {
     let cachedJWT = try unexpiredJWT()
-    let sessionService = MockSessionService(fetchToken: { _, _ in
+    let sessionService = MockSessionService(fetchToken: { _, _, _ in
       throw CancellationError()
     })
     let dependencies = MockDependencyContainer(

--- a/Tests/Domains/Auth/Session/SessionServiceTests.swift
+++ b/Tests/Domains/Auth/Session/SessionServiceTests.swift
@@ -5,14 +5,22 @@ import Mocker
 import Testing
 
 @MainActor
-@Suite(.serialized)
-struct SessionServiceTests {
-  init() {
-    configureClerkForTesting()
-  }
-
+extension SessionServiceAndTokenFetcherTests {
   @Test
   func signOut() async throws {
+    await SessionTokensCache.shared.clear()
+    let firstSession = Session.mock
+    var secondSession = Session.mock
+    secondSession.id = "sess_other"
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "first.jwt"),
+      cacheKey: firstSession.tokenCacheKey(template: nil)
+    )
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "second.jwt"),
+      cacheKey: secondSession.tokenCacheKey(template: nil)
+    )
+
     let requestHandled = LockIsolated(false)
     let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions")!
 
@@ -31,11 +39,35 @@ struct SessionServiceTests {
 
     try await Clerk.shared.dependencies.sessionService.signOut(sessionId: nil)
     #expect(requestHandled.value)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: firstSession.tokenCacheKey(template: nil)
+    ) == nil)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: secondSession.tokenCacheKey(template: nil)
+    ) == nil)
   }
 
   @Test
   func signOutWithSessionId() async throws {
     let sessionId = "sess_test123"
+    var session = Session.mock
+    session.id = sessionId
+    var otherSession = Session.mock
+    otherSession.id = "sess_other"
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "default.jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "template.jwt"),
+      cacheKey: session.tokenCacheKey(template: "firebase")
+    )
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "other.jwt"),
+      cacheKey: otherSession.tokenCacheKey(template: nil)
+    )
+
     let requestHandled = LockIsolated(false)
     let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(sessionId)/remove")!
 
@@ -54,6 +86,104 @@ struct SessionServiceTests {
 
     try await Clerk.shared.dependencies.sessionService.signOut(sessionId: sessionId)
     #expect(requestHandled.value)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: session.tokenCacheKey(template: nil)
+    ) == nil)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: session.tokenCacheKey(template: "firebase")
+    ) == nil)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: otherSession.tokenCacheKey(template: nil)
+    )?.jwt == "other.jwt")
+  }
+
+  @Test
+  func signOutWithSessionIdPreservesCachedTokensWhenRequestFails() async throws {
+    let sessionId = "sess_test123"
+    var session = Session.mock
+    session.id = sessionId
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "cached.jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "template.jwt"),
+      cacheKey: session.tokenCacheKey(template: "firebase")
+    )
+
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(sessionId)/remove")!
+    let mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 500,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(
+          ClerkErrorResponse(
+            errors: [
+              ClerkAPIError(
+                code: "internal_server_error",
+                message: "Something went wrong",
+                longMessage: nil,
+                meta: nil,
+                clerkTraceId: nil
+              ),
+            ],
+            clerkTraceId: nil
+          )
+        ),
+      ]
+    )
+    mock.register()
+
+    await #expect(throws: (any Error).self) {
+      try await Clerk.shared.dependencies.sessionService.signOut(sessionId: sessionId)
+    }
+
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: session.tokenCacheKey(template: nil)
+    )?.jwt == "cached.jwt")
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: session.tokenCacheKey(template: "firebase")
+    )?.jwt == "template.jwt")
+  }
+
+  @Test
+  func signOutPreservesCachedTokensWhenRequestFails() async throws {
+    let session = Session.mock
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "cached.jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions")!
+    let mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 500,
+      data: [
+        .delete: JSONEncoder.clerkEncoder.encode(
+          ClerkErrorResponse(
+            errors: [
+              ClerkAPIError(
+                code: "internal_server_error",
+                message: "Something went wrong",
+                longMessage: nil,
+                meta: nil,
+                clerkTraceId: nil
+              ),
+            ],
+            clerkTraceId: nil
+          )
+        ),
+      ]
+    )
+    mock.register()
+
+    await #expect(throws: (any Error).self) {
+      try await Clerk.shared.dependencies.sessionService.signOut(sessionId: nil)
+    }
+
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: session.tokenCacheKey(template: nil)
+    )?.jwt == "cached.jwt")
   }
 
   struct SetActiveErrorScenario {
@@ -101,6 +231,21 @@ struct SessionServiceTests {
     var updatedClient = Client.mock
     updatedClient.lastActiveSessionId = session.id
     updatedClient.sessions = [session]
+    var otherSession = Session.mock
+    otherSession.id = "sess_other"
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "default.jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "template.jwt"),
+      cacheKey: session.tokenCacheKey(template: "firebase")
+    )
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "other.jwt"),
+      cacheKey: otherSession.tokenCacheKey(template: nil)
+    )
 
     let requestHandled = LockIsolated(false)
     let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/touch")!
@@ -114,6 +259,7 @@ struct SessionServiceTests {
 
     mock.onRequestHandler = OnRequestHandler { @Sendable request in
       #expect(request.httpMethod == "POST")
+      #expect(request.shouldAutomaticallySyncClerkClient == false)
       let body = request.urlEncodedFormBody!
       #expect(body["active_organization_id"] == organizationId)
       #expect(body["intent"] == "select_org")
@@ -127,6 +273,99 @@ struct SessionServiceTests {
     )
 
     #expect(requestHandled.value)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: session.tokenCacheKey(template: nil)
+    ) == nil)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: session.tokenCacheKey(template: "firebase")
+    ) == nil)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: otherSession.tokenCacheKey(template: nil)
+    )?.jwt == "other.jwt")
+  }
+
+  @Test
+  func setActiveInvalidatesTemplateTokenBeforePublishingSessionChange() async throws {
+    let identityKeychain = Clerk.shared.dependencies.identityKeychain
+    let deviceTokenKey = ClerkKeychainKey.clerkDeviceToken.rawValue
+    let previousDeviceToken = try identityKeychain.string(forKey: deviceTokenKey)
+    try identityKeychain.set("set-active-ordering-token", forKey: deviceTokenKey)
+    defer {
+      if let previousDeviceToken {
+        try? identityKeychain.set(previousDeviceToken, forKey: deviceTokenKey)
+      } else {
+        try? identityKeychain.deleteItem(forKey: deviceTokenKey)
+      }
+    }
+
+    var previousSession = Session.mock
+    previousSession.lastActiveOrganizationId = "org_previous"
+    var previousClient = Client.mock
+    previousClient.lastActiveSessionId = previousSession.id
+    previousClient.sessions = [previousSession]
+    Clerk.shared.client = previousClient
+
+    var updatedSession = previousSession
+    updatedSession.lastActiveOrganizationId = "org_updated"
+    var updatedClient = previousClient
+    updatedClient.sessions = [updatedSession]
+
+    let template = "firebase"
+    let cacheKey = previousSession.tokenCacheKey(template: template)
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "previous-organization.jwt"),
+      cacheKey: cacheKey
+    )
+
+    let originalURL = URL(
+      string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(previousSession.id)/touch"
+    )!
+    let mock = try Mock(
+      url: originalURL,
+      ignoreQuery: true,
+      contentType: .json,
+      statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(
+          ClientResponse<Session>(response: updatedSession, client: updatedClient)
+        ),
+      ]
+    )
+    mock.register()
+
+    let observedCacheState = AsyncStream<Bool>.makeStream(
+      bufferingPolicy: .bufferingNewest(1)
+    )
+    let events = Clerk.shared.auth.events
+    let observer = Task { @MainActor in
+      for await event in events {
+        guard case .sessionChanged(_, let newSession) = event,
+              newSession?.lastActiveOrganizationId == updatedSession.lastActiveOrganizationId
+        else {
+          continue
+        }
+
+        let cachedToken = await SessionTokensCache.shared.getToken(cacheKey: cacheKey)
+        observedCacheState.continuation.yield(cachedToken == nil)
+        return
+      }
+    }
+    defer {
+      observer.cancel()
+      observedCacheState.continuation.finish()
+    }
+
+    try await Clerk.shared.dependencies.sessionService.setActive(
+      sessionId: previousSession.id,
+      organizationId: updatedSession.lastActiveOrganizationId
+    )
+
+    let cacheWasEmptyWhenSessionChanged = try await waitForSessionServiceSignal(
+      observedCacheState.stream,
+      message: "Timed out waiting for the updated session to be published."
+    )
+    #expect(cacheWasEmptyWhenSessionChanged)
   }
 
   @Test
@@ -206,6 +445,11 @@ struct SessionServiceTests {
   )
   func setActiveWithOrganizationIdPropagatesAPIErrors(scenario: SetActiveErrorScenario) async throws {
     let session = Session.mock
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "cached.jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
     let requestHandled = LockIsolated(false)
     let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/touch")!
 
@@ -247,6 +491,10 @@ struct SessionServiceTests {
     } catch {
       #expect(Bool(false), "Expected ClerkAPIError, got \(error)")
     }
+
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: session.tokenCacheKey(template: nil)
+    )?.jwt == "cached.jwt")
   }
 
   @Test
@@ -255,6 +503,7 @@ struct SessionServiceTests {
     let organizationId = "org_test456"
     let previousToken = "previous.jwt.value"
     let requestHandled = LockIsolated(false)
+    let capturedBodyLogging = LockIsolated<Bool?>(nil)
     let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/tokens")!
 
     var mock = try Mock(
@@ -270,6 +519,7 @@ struct SessionServiceTests {
       #expect(body["organization_id"] == organizationId)
       #expect(body["token"] == previousToken)
       #expect(body["force_origin"] == "true")
+      capturedBodyLogging.setValue(request.shouldLogClerkBodies)
       requestHandled.setValue(true)
     }
     mock.register()
@@ -284,12 +534,14 @@ struct SessionServiceTests {
       )
     )
     #expect(requestHandled.value)
+    #expect(capturedBodyLogging.value == false)
   }
 
   @Test
   func fetchTokenForFirstMintOmitsPreviousTokenAndForceOrigin() async throws {
     let session = Session.mock
     let requestHandled = LockIsolated(false)
+    let capturedBodyLogging = LockIsolated<Bool?>(nil)
     let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/tokens")!
 
     var mock = try Mock(
@@ -304,6 +556,7 @@ struct SessionServiceTests {
       #expect(body["organization_id"] == "")
       #expect(body["token"] == nil)
       #expect(body["force_origin"] == nil)
+      capturedBodyLogging.setValue(request.shouldLogClerkBodies)
       requestHandled.setValue(true)
     }
     mock.register()
@@ -315,6 +568,7 @@ struct SessionServiceTests {
     )
 
     #expect(requestHandled.value)
+    #expect(capturedBodyLogging.value == false)
   }
 
   @Test
@@ -322,6 +576,7 @@ struct SessionServiceTests {
     let session = Session.mock
     let template = "firebase"
     let requestHandled = LockIsolated(false)
+    let capturedBodyLogging = LockIsolated<Bool?>(nil)
     let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/tokens/\(template)")!
 
     var mock = try Mock(
@@ -334,6 +589,7 @@ struct SessionServiceTests {
     mock.onRequestHandler = OnRequestHandler { @Sendable request in
       #expect(request.httpMethod == "POST")
       #expect(request.httpBody == nil)
+      capturedBodyLogging.setValue(request.shouldLogClerkBodies)
       requestHandled.setValue(true)
     }
     mock.register()
@@ -348,6 +604,7 @@ struct SessionServiceTests {
       )
     )
     #expect(requestHandled.value)
+    #expect(capturedBodyLogging.value == false)
   }
 
   @Test
@@ -548,5 +805,34 @@ struct SessionServiceTests {
 
     _ = try await Clerk.shared.dependencies.sessionService.revoke(sessionId: session.id)
     #expect(requestHandled.value)
+  }
+}
+
+private struct SessionServiceSignalTimeoutError: Error, CustomStringConvertible {
+  let description: String
+}
+
+private func waitForSessionServiceSignal<Value: Sendable>(
+  _ stream: AsyncStream<Value>,
+  timeout: Duration = .seconds(1),
+  message: String
+) async throws -> Value {
+  try await withThrowingTaskGroup(of: Value.self) { group in
+    group.addTask {
+      for await value in stream {
+        return value
+      }
+      throw SessionServiceSignalTimeoutError(description: message)
+    }
+    group.addTask {
+      try await Task.sleep(for: timeout)
+      throw SessionServiceSignalTimeoutError(description: message)
+    }
+
+    defer { group.cancelAll() }
+    guard let value = try await group.next() else {
+      throw SessionServiceSignalTimeoutError(description: message)
+    }
+    return value
   }
 }

--- a/Tests/Domains/Auth/Session/SessionServiceTests.swift
+++ b/Tests/Domains/Auth/Session/SessionServiceTests.swift
@@ -252,6 +252,8 @@ struct SessionServiceTests {
   @Test
   func fetchToken() async throws {
     let session = Session.mock
+    let organizationId = "org_test456"
+    let previousToken = "previous.jwt.value"
     let requestHandled = LockIsolated(false)
     let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/tokens")!
 
@@ -264,11 +266,54 @@ struct SessionServiceTests {
 
     mock.onRequestHandler = OnRequestHandler { @Sendable request in
       #expect(request.httpMethod == "POST")
+      let body = request.urlEncodedFormBody!
+      #expect(body["organization_id"] == organizationId)
+      #expect(body["token"] == previousToken)
+      #expect(body["force_origin"] == "true")
       requestHandled.setValue(true)
     }
     mock.register()
 
-    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(sessionId: session.id, template: nil)
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: nil,
+      params: .init(
+        organizationId: organizationId,
+        token: previousToken,
+        forceOrigin: "true"
+      )
+    )
+    #expect(requestHandled.value)
+  }
+
+  @Test
+  func fetchTokenForFirstMintOmitsPreviousTokenAndForceOrigin() async throws {
+    let session = Session.mock
+    let requestHandled = LockIsolated(false)
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/tokens")!
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(TokenResource.mock),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { @Sendable request in
+      let body = request.urlEncodedFormBody!
+      #expect(body["organization_id"] == "")
+      #expect(body["token"] == nil)
+      #expect(body["force_origin"] == nil)
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: nil,
+      params: .init(organizationId: "")
+    )
+
     #expect(requestHandled.value)
   }
 
@@ -288,11 +333,20 @@ struct SessionServiceTests {
 
     mock.onRequestHandler = OnRequestHandler { @Sendable request in
       #expect(request.httpMethod == "POST")
+      #expect(request.httpBody == nil)
       requestHandled.setValue(true)
     }
     mock.register()
 
-    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(sessionId: session.id, template: template)
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: template,
+      params: .init(
+        organizationId: "org_ignored",
+        token: "token_ignored",
+        forceOrigin: "true"
+      )
+    )
     #expect(requestHandled.value)
   }
 

--- a/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
+++ b/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
@@ -213,12 +213,17 @@ struct SessionTokenFetcherTests {
     configureCurrentState(session: session, sessionMinterEnabled: true)
 
     let callCount = LockIsolated(0)
+    let firstCallStarted = AsyncStream<Void>.makeStream(
+      bufferingPolicy: .bufferingNewest(1)
+    )
+    defer { firstCallStarted.continuation.finish() }
     let service = MockSessionService(fetchToken: { _, _, _ in
       let callIndex = callCount.withValue { count in
         defer { count += 1 }
         return count
       }
       if callIndex == 0 {
+        firstCallStarted.continuation.yield()
         try await Task.sleep(for: .milliseconds(100))
         return staleResponse
       }
@@ -235,16 +240,18 @@ struct SessionTokenFetcherTests {
         options: .init(skipCache: true)
       )
     }
-    let deadline = ContinuousClock.now + .seconds(1)
-    while callCount.value == 0, ContinuousClock.now < deadline {
-      await Task.yield()
-    }
+    defer { first.cancel() }
+    try await waitForSignal(
+      firstCallStarted.stream,
+      message: "Timed out waiting for the first forced token refresh to start."
+    )
     let second = Task {
       try await SessionTokenFetcher.shared.getToken(
         session,
         options: .init(skipCache: true)
       )
     }
+    defer { second.cancel() }
 
     let firstResult = try await first.value
     let secondResult = try await second.value
@@ -256,6 +263,100 @@ struct SessionTokenFetcherTests {
     #expect(firstResult == staleResponse)
     #expect(secondResult == freshResponse)
     #expect(cachedToken == freshResponse)
+  }
+
+  @Test
+  func completedRequestDoesNotClearReplacementTaskAfterReset() async throws {
+    await SessionTokenFetcher.shared.reset()
+    await SessionTokensCache.shared.clear()
+
+    let session = Session.mock
+    let firstResponse = TokenResource(jwt: "first.jwt.value")
+    let secondResponse = TokenResource(jwt: "second.jwt.value")
+    configureCurrentState(session: session, sessionMinterEnabled: false)
+
+    let firstCallStarted = AsyncStream<Void>.makeStream(
+      bufferingPolicy: .bufferingNewest(1)
+    )
+    let secondCallStarted = AsyncStream<Void>.makeStream(
+      bufferingPolicy: .bufferingNewest(1)
+    )
+    defer {
+      firstCallStarted.continuation.finish()
+      secondCallStarted.continuation.finish()
+    }
+
+    let firstGate = SessionTokenFetchGate()
+    let secondGate = SessionTokenFetchGate()
+    let callCount = LockIsolated(0)
+    let service = MockSessionService(fetchToken: { _, _, _ in
+      let callIndex = callCount.withValue { count in
+        defer { count += 1 }
+        return count
+      }
+
+      switch callIndex {
+      case 0:
+        firstCallStarted.continuation.yield()
+        await firstGate.suspend()
+        return firstResponse
+      case 1:
+        secondCallStarted.continuation.yield()
+        await secondGate.suspend()
+        return secondResponse
+      default:
+        return TokenResource(jwt: "unexpected.jwt.value")
+      }
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let first = Task {
+      try await SessionTokenFetcher.shared.getToken(session)
+    }
+    defer {
+      first.cancel()
+      Task { await firstGate.resume() }
+    }
+    try await waitForSignal(
+      firstCallStarted.stream,
+      message: "Timed out waiting for token request A to start."
+    )
+
+    await SessionTokenFetcher.shared.reset()
+
+    let second = Task {
+      try await SessionTokenFetcher.shared.getToken(session)
+    }
+    defer {
+      second.cancel()
+      Task { await secondGate.resume() }
+    }
+    try await waitForSignal(
+      secondCallStarted.stream,
+      message: "Timed out waiting for replacement token request B to start."
+    )
+
+    let cacheKey = session.tokenCacheKey(template: nil)
+    let registeredReplacement = await SessionTokenFetcher.shared.tokenTasks[cacheKey]
+    let replacementId = try #require(registeredReplacement?.id)
+
+    await firstGate.resume()
+    do {
+      _ = try await first.value
+      Issue.record("Expected reset to cancel token request A.")
+    } catch is CancellationError {
+      // Expected.
+    }
+
+    let remainingTask = await SessionTokenFetcher.shared.tokenTasks[cacheKey]
+    #expect(remainingTask?.id == replacementId)
+
+    await secondGate.resume()
+    #expect(try await second.value == secondResponse)
+    #expect(callCount.value == 2)
   }
 
   private func configureCurrentState(
@@ -295,5 +396,52 @@ struct SessionTokenFetcherTests {
     return try TokenResource(
       jwt: testJWT(header: header, claims: claims, signature: signature)
     )
+  }
+}
+
+private actor SessionTokenFetchGate {
+  private var isOpen = false
+  private var continuation: CheckedContinuation<Void, Never>?
+
+  func suspend() async {
+    if isOpen {
+      return
+    }
+    await withCheckedContinuation { continuation = $0 }
+  }
+
+  func resume() {
+    if let continuation {
+      continuation.resume()
+      self.continuation = nil
+    } else {
+      isOpen = true
+    }
+  }
+}
+
+private struct SessionTokenSignalTimeoutError: Error, CustomStringConvertible {
+  let description: String
+}
+
+private func waitForSignal(
+  _ stream: AsyncStream<Void>,
+  timeout: Duration = .seconds(1),
+  message: String
+) async throws {
+  try await withThrowingTaskGroup(of: Void.self) { group in
+    group.addTask {
+      for await _ in stream {
+        return
+      }
+      throw SessionTokenSignalTimeoutError(description: message)
+    }
+    group.addTask {
+      try await Task.sleep(for: timeout)
+      throw SessionTokenSignalTimeoutError(description: message)
+    }
+
+    defer { group.cancelAll() }
+    _ = try await group.next()
   }
 }

--- a/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
+++ b/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
@@ -85,6 +85,25 @@ struct SessionTokenFetcherTests {
   }
 
   @Test
+  func storingSameJWTDoesNotReportCanonicalTokenChange() async {
+    await SessionTokensCache.shared.clear()
+    let cacheKey = UUID().uuidString
+    let tokenResource = TokenResource(jwt: "jwt_123")
+
+    let initialStore = await SessionTokensCache.shared.storeIfFresher(
+      tokenResource,
+      cacheKey: cacheKey
+    )
+    let duplicateStore = await SessionTokensCache.shared.storeIfFresher(
+      tokenResource,
+      cacheKey: cacheKey
+    )
+
+    #expect(initialStore.didChangeCanonicalToken)
+    #expect(duplicateStore.didChangeCanonicalToken == false)
+  }
+
+  @Test
   func sessionMinterUsesLatestSessionTokenAndForcesOrigin() async throws {
     await SessionTokensCache.shared.clear()
     let staleSession = Session.mock

--- a/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
+++ b/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
@@ -232,6 +232,7 @@ struct SessionTokenFetcherTests {
     configureCurrentState(session: session, sessionMinterEnabled: true)
 
     let callCount = LockIsolated(0)
+    let firstCallGate = SessionTokenFetchGate()
     let firstCallStarted = AsyncStream<Void>.makeStream(
       bufferingPolicy: .bufferingNewest(1)
     )
@@ -243,7 +244,7 @@ struct SessionTokenFetcherTests {
       }
       if callIndex == 0 {
         firstCallStarted.continuation.yield()
-        try await Task.sleep(for: .milliseconds(100))
+        await firstCallGate.suspend()
         return staleResponse
       }
       return freshResponse
@@ -259,7 +260,10 @@ struct SessionTokenFetcherTests {
         options: .init(skipCache: true)
       )
     }
-    defer { first.cancel() }
+    defer {
+      first.cancel()
+      Task { await firstCallGate.resume() }
+    }
     try await waitForSignal(
       firstCallStarted.stream,
       message: "Timed out waiting for the first forced token refresh to start."
@@ -272,8 +276,9 @@ struct SessionTokenFetcherTests {
     }
     defer { second.cancel() }
 
-    let firstResult = try await first.value
     let secondResult = try await second.value
+    await firstCallGate.resume()
+    let firstResult = try await first.value
     let cachedToken = await SessionTokensCache.shared.getToken(
       cacheKey: session.tokenCacheKey(template: nil)
     )

--- a/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
+++ b/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 @MainActor
 @Suite(.serialized)
-struct SessionTokenFetcherTests {
+struct SessionServiceAndTokenFetcherTests {
   init() {
     configureClerkForTesting()
     Clerk.shared.cleanupManagers()
@@ -82,6 +82,499 @@ struct SessionTokenFetcherTests {
       cacheKey: session.tokenCacheKey(template: template)
     )
     #expect(cachedToken == tokenResource)
+  }
+
+  @Test
+  func templateTokenCacheIsPartitionedByActiveOrganization() async throws {
+    await SessionTokenFetcher.shared.reset()
+    await SessionTokensCache.shared.clear()
+
+    let template = "firebase"
+    var previousSession = Session.mock
+    previousSession.lastActiveOrganizationId = "org_previous"
+    let previousToken = try token(
+      sessionId: previousSession.id,
+      organizationId: previousSession.lastActiveOrganizationId,
+      originIssuedAt: 100,
+      issuedAt: 100,
+      signature: "previous"
+    )
+    await SessionTokensCache.shared.insertToken(
+      previousToken,
+      cacheKey: previousSession.tokenCacheKey(template: template)
+    )
+
+    var updatedSession = previousSession
+    updatedSession.lastActiveOrganizationId = "org_updated"
+    configureCurrentState(session: updatedSession, sessionMinterEnabled: true)
+    let updatedToken = try token(
+      sessionId: updatedSession.id,
+      organizationId: updatedSession.lastActiveOrganizationId,
+      originIssuedAt: 200,
+      issuedAt: 200,
+      signature: "updated"
+    )
+    let callCount = LockIsolated(0)
+    let service = MockSessionService(fetchToken: { _, _, _ in
+      callCount.withValue { $0 += 1 }
+      return updatedToken
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let result = try await SessionTokenFetcher.shared.getToken(
+      previousSession,
+      options: .init(template: template)
+    )
+
+    #expect(result == updatedToken)
+    #expect(callCount.value == 1)
+    #expect(
+      previousSession.tokenCacheKey(template: template)
+        != updatedSession.tokenCacheKey(template: template)
+    )
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: previousSession.tokenCacheKey(template: template)
+    ) == previousToken)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: updatedSession.tokenCacheKey(template: template)
+    ) == updatedToken)
+  }
+
+  @Test
+  func invalidationPreventsInFlightResponseFromRestoringCachedToken() async throws {
+    await SessionTokenFetcher.shared.reset()
+    await SessionTokensCache.shared.clear()
+
+    let session = Session.mock
+    let response = TokenResource(jwt: "late.jwt.response")
+    configureCurrentState(session: session, sessionMinterEnabled: false)
+    let generationBeforeRequest = await SessionTokensCache.shared.generation(
+      sessionId: session.id
+    )
+
+    let requestGate = SessionTokenFetchGate()
+    let service = MockSessionService(fetchToken: { _, _, _ in
+      await requestGate.suspend()
+      return response
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let request = Task {
+      try await SessionTokenFetcher.shared.getToken(
+        session,
+        options: .init(skipCache: true)
+      )
+    }
+    defer {
+      request.cancel()
+      Task { await requestGate.resume() }
+    }
+
+    try await waitForCondition(
+      message: "Timed out waiting for the forced token task to be registered."
+    ) {
+      await SessionTokenFetcher.shared.forcedTokenTasks.isEmpty == false
+    }
+    let registeredTask = await SessionTokenFetcher.shared.forcedTokenTasks.values.first
+    let registeredGeneration = try #require(registeredTask?.cacheGeneration)
+    #expect(registeredGeneration == generationBeforeRequest)
+
+    await SessionTokensCache.shared.removeTokens(sessionId: session.id)
+    await requestGate.resume()
+
+    #expect(try await request.value == response)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: session.tokenCacheKey(template: nil)
+    ) == nil)
+  }
+
+  @Test
+  func invalidatedInFlightTaskIsCancelledAndReplaced() async throws {
+    await SessionTokenFetcher.shared.reset()
+    await SessionTokensCache.shared.clear()
+
+    let session = Session.mock
+    let staleResponse = TokenResource(jwt: "stale.jwt.response")
+    let freshResponse = TokenResource(jwt: "fresh.jwt.response")
+    configureCurrentState(session: session, sessionMinterEnabled: false)
+
+    let firstCallStarted = AsyncStream<Void>.makeStream(
+      bufferingPolicy: .bufferingNewest(1)
+    )
+    let secondCallStarted = AsyncStream<Void>.makeStream(
+      bufferingPolicy: .bufferingNewest(1)
+    )
+    defer {
+      firstCallStarted.continuation.finish()
+      secondCallStarted.continuation.finish()
+    }
+
+    let firstGate = SessionTokenFetchGate()
+    let secondGate = SessionTokenFetchGate()
+    let callCount = LockIsolated(0)
+    let service = MockSessionService(fetchToken: { _, _, _ in
+      let callIndex = callCount.withValue { count in
+        defer { count += 1 }
+        return count
+      }
+
+      switch callIndex {
+      case 0:
+        firstCallStarted.continuation.yield()
+        await firstGate.suspend()
+        return staleResponse
+      case 1:
+        secondCallStarted.continuation.yield()
+        await secondGate.suspend()
+        return freshResponse
+      default:
+        return TokenResource(jwt: "unexpected.jwt.response")
+      }
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let first = Task {
+      try await SessionTokenFetcher.shared.getToken(session)
+    }
+    defer {
+      first.cancel()
+      Task { await firstGate.resume() }
+    }
+    try await waitForSignal(
+      firstCallStarted.stream,
+      message: "Timed out waiting for the original token request to start."
+    )
+
+    let cacheKey = session.tokenCacheKey(template: nil)
+    let originalTask = await SessionTokenFetcher.shared.tokenTasks[cacheKey]
+    let originalTaskId = try #require(originalTask?.id)
+
+    await SessionTokensCache.shared.removeTokens(sessionId: session.id)
+    let currentGeneration = await SessionTokensCache.shared.generation(
+      sessionId: session.id
+    )
+
+    let second = Task {
+      try await SessionTokenFetcher.shared.getToken(session)
+    }
+    defer {
+      second.cancel()
+      Task { await secondGate.resume() }
+    }
+    try await waitForSignal(
+      secondCallStarted.stream,
+      message: "Timed out waiting for the replacement token request to start."
+    )
+
+    let replacementTask = await SessionTokenFetcher.shared.tokenTasks[cacheKey]
+    #expect(replacementTask?.id != originalTaskId)
+    #expect(replacementTask?.cacheGeneration == currentGeneration)
+
+    await firstGate.resume()
+    await #expect(throws: CancellationError.self) {
+      try await first.value
+    }
+
+    await secondGate.resume()
+    #expect(try await second.value == freshResponse)
+    #expect(callCount.value == 2)
+    #expect(await SessionTokensCache.shared.getToken(cacheKey: cacheKey) == freshResponse)
+  }
+
+  @Test
+  func retainedSessionDoesNotRehydrateInvalidatedSnapshot() async throws {
+    await SessionTokenFetcher.shared.reset()
+    await SessionTokensCache.shared.clear()
+
+    var session = Session.mock
+    let snapshotToken = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 100,
+      issuedAt: 100,
+      signature: "snapshot"
+    )
+    let serverToken = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 200,
+      issuedAt: 200,
+      signature: "server"
+    )
+    session.lastActiveToken = snapshotToken
+    configureCurrentState(session: session, sessionMinterEnabled: true)
+
+    await SessionTokensCache.shared.removeTokens(sessionId: session.id)
+    var signedOutClient = Client.mock
+    signedOutClient.sessions = []
+    signedOutClient.lastActiveSessionId = nil
+    Clerk.shared.client = signedOutClient
+
+    let callCount = LockIsolated(0)
+    let capturedParams = LockIsolated<SessionTokenRequestParams?>(nil)
+    let service = MockSessionService(fetchToken: { _, _, params in
+      callCount.withValue { $0 += 1 }
+      capturedParams.setValue(params)
+      return serverToken
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let result = try await SessionTokenFetcher.shared.getToken(session)
+
+    #expect(result == serverToken)
+    #expect(callCount.value == 1)
+    #expect(capturedParams.value?.token == nil)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: session.tokenCacheKey(template: nil)
+    ) == serverToken)
+  }
+
+  @Test
+  func nonActiveSessionDoesNotReturnExistingCachedToken() async throws {
+    await SessionTokenFetcher.shared.reset()
+    await SessionTokensCache.shared.clear()
+
+    let session = Session.mock
+    let cachedToken = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 100,
+      issuedAt: 100,
+      signature: "cached"
+    )
+    let serverToken = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 200,
+      issuedAt: 200,
+      signature: "server"
+    )
+    configureCurrentState(session: session, sessionMinterEnabled: true)
+
+    await SessionTokensCache.shared.removeTokens(sessionId: session.id)
+    await SessionTokensCache.shared.insertToken(
+      cachedToken,
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+    var signedOutClient = Client.mock
+    signedOutClient.sessions = []
+    signedOutClient.lastActiveSessionId = nil
+    Clerk.shared.client = signedOutClient
+
+    let callCount = LockIsolated(0)
+    let capturedParams = LockIsolated<SessionTokenRequestParams?>(nil)
+    let service = MockSessionService(fetchToken: { _, _, params in
+      callCount.withValue { $0 += 1 }
+      capturedParams.setValue(params)
+      return serverToken
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let result = try await SessionTokenFetcher.shared.getToken(session)
+
+    #expect(result == serverToken)
+    #expect(callCount.value == 1)
+    #expect(capturedParams.value?.token == nil)
+  }
+
+  @Test
+  func concurrentNonActiveSessionFetchesShareRequest() async throws {
+    await SessionTokenFetcher.shared.reset()
+    await SessionTokensCache.shared.clear()
+
+    let session = Session.mock
+    let serverToken = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 200,
+      issuedAt: 200,
+      signature: "server"
+    )
+    configureCurrentState(session: session, sessionMinterEnabled: true)
+    var signedOutClient = Client.mock
+    signedOutClient.sessions = []
+    signedOutClient.lastActiveSessionId = nil
+    Clerk.shared.client = signedOutClient
+
+    let callCount = LockIsolated(0)
+    let requestStarted = AsyncStream<Void>.makeStream(
+      bufferingPolicy: .bufferingNewest(1)
+    )
+    let secondCallerStarted = AsyncStream<Void>.makeStream(
+      bufferingPolicy: .bufferingNewest(1)
+    )
+    let requestGate = SessionTokenFetchGate()
+    defer {
+      requestStarted.continuation.finish()
+      secondCallerStarted.continuation.finish()
+    }
+    let service = MockSessionService(fetchToken: { _, _, _ in
+      callCount.withValue { $0 += 1 }
+      requestStarted.continuation.yield()
+      await requestGate.suspend()
+      try Task.checkCancellation()
+      return serverToken
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let first = Task {
+      try await SessionTokenFetcher.shared.getToken(session)
+    }
+    defer {
+      first.cancel()
+      Task { await requestGate.resume() }
+    }
+    try await waitForSignal(
+      requestStarted.stream,
+      message: "Timed out waiting for the first inactive-session fetch to start."
+    )
+
+    let cacheKey = session.tokenCacheKey(template: nil)
+    let originalTask = await SessionTokenFetcher.shared.tokenTasks[cacheKey]
+    let originalTaskId = try #require(originalTask?.id)
+
+    let second = Task {
+      secondCallerStarted.continuation.yield()
+      return try await SessionTokenFetcher.shared.getToken(session)
+    }
+    defer { second.cancel() }
+    try await waitForSignal(
+      secondCallerStarted.stream,
+      message: "Timed out waiting for the second inactive-session caller to start."
+    )
+
+    let sharedTask = await SessionTokenFetcher.shared.tokenTasks[cacheKey]
+    #expect(sharedTask?.id == originalTaskId)
+    #expect(sharedTask?.isCurrentActiveSession == false)
+
+    await requestGate.resume()
+
+    #expect(try await first.value == serverToken)
+    #expect(try await second.value == serverToken)
+    #expect(callCount.value == 1)
+  }
+
+  @Test
+  func transitionedActiveSessionCanHydrateCanonicalSnapshot() async throws {
+    await SessionTokenFetcher.shared.reset()
+    await SessionTokensCache.shared.clear()
+
+    var session = Session.mock
+    let snapshotToken = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 200,
+      issuedAt: 200,
+      signature: "transitioned"
+    )
+    session.lastActiveToken = snapshotToken
+    configureCurrentState(session: session, sessionMinterEnabled: true)
+    await SessionTokensCache.shared.removeTokens(sessionId: session.id)
+
+    let callCount = LockIsolated(0)
+    let service = MockSessionService(fetchToken: { _, _, _ in
+      callCount.withValue { $0 += 1 }
+      return TokenResource(jwt: "unexpected.server.response")
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let result = try await SessionTokenFetcher.shared.getToken(session)
+
+    #expect(result == snapshotToken)
+    #expect(callCount.value == 0)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: session.tokenCacheKey(template: nil)
+    ) == snapshotToken)
+  }
+
+  @Test
+  func removeTokensClearsAllTokensForOnlyThatSession() async {
+    let cache = SessionTokensCache()
+    var session = Session.mock
+    session.id = "sess_target"
+    var otherSession = Session.mock
+    otherSession.id = "sess_target2"
+
+    await cache.insertToken(
+      .init(jwt: "default.jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+    await cache.insertToken(
+      .init(jwt: "template.jwt"),
+      cacheKey: session.tokenCacheKey(template: "firebase")
+    )
+    await cache.insertToken(
+      .init(jwt: "other.jwt"),
+      cacheKey: otherSession.tokenCacheKey(template: nil)
+    )
+
+    await cache.removeTokens(sessionId: session.id)
+
+    #expect(await cache.getToken(cacheKey: session.tokenCacheKey(template: nil)) == nil)
+    #expect(await cache.getToken(cacheKey: session.tokenCacheKey(template: "firebase")) == nil)
+    #expect(await cache.getToken(
+      cacheKey: otherSession.tokenCacheKey(template: nil)
+    )?.jwt == "other.jwt")
+  }
+
+  @Test
+  func removeTokensRejectsWritesFromAnEarlierGeneration() async {
+    let cache = SessionTokensCache()
+    let session = Session.mock
+    let generation = await cache.generation(sessionId: session.id)
+
+    await cache.removeTokens(sessionId: session.id)
+    let storeResult = await cache.storeIfFresher(
+      .init(jwt: "late.jwt"),
+      cacheKey: session.tokenCacheKey(template: nil),
+      generation: generation
+    )
+    await cache.hydrate(
+      .init(jwt: "late.snapshot.jwt"),
+      cacheKey: session.tokenCacheKey(template: nil),
+      generation: generation
+    )
+
+    #expect(storeResult?.canonicalToken == nil)
+    #expect(await cache.getToken(cacheKey: session.tokenCacheKey(template: nil)) == nil)
+  }
+
+  @Test
+  func clearRejectsWritesFromAnEarlierGeneration() async {
+    let cache = SessionTokensCache()
+    let session = Session.mock
+    let generation = await cache.generation(sessionId: session.id)
+
+    await cache.clear()
+    let storeResult = await cache.storeIfFresher(
+      .init(jwt: "late.jwt"),
+      cacheKey: session.tokenCacheKey(template: nil),
+      generation: generation
+    )
+
+    #expect(storeResult?.canonicalToken == nil)
+    #expect(await cache.getToken(cacheKey: session.tokenCacheKey(template: nil)) == nil)
   }
 
   @Test
@@ -735,5 +1228,24 @@ private func waitForSignal(
 
     defer { group.cancelAll() }
     _ = try await group.next()
+  }
+}
+
+@MainActor
+private func waitForCondition(
+  timeout: Duration = .seconds(1),
+  message: String,
+  condition: () async -> Bool
+) async throws {
+  let deadline = ContinuousClock.now + timeout
+  while ContinuousClock.now < deadline {
+    if await condition() {
+      return
+    }
+    try await Task.sleep(for: .milliseconds(5))
+  }
+
+  if await condition() == false {
+    throw SessionTokenSignalTimeoutError(description: message)
   }
 }

--- a/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
+++ b/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
@@ -104,6 +104,33 @@ struct SessionTokenFetcherTests {
   }
 
   @Test
+  func malformedIncomingTokenDoesNotReplaceCanonicalToken() async throws {
+    await SessionTokensCache.shared.clear()
+    let cacheKey = UUID().uuidString
+    let canonicalToken = try token(
+      sessionId: "sess_test",
+      organizationId: nil,
+      originIssuedAt: 100,
+      issuedAt: 100
+    )
+    let malformedToken = TokenResource(jwt: "malformed")
+    await SessionTokensCache.shared.insertToken(
+      canonicalToken,
+      cacheKey: cacheKey
+    )
+
+    let storeResult = await SessionTokensCache.shared.storeIfFresher(
+      malformedToken,
+      cacheKey: cacheKey
+    )
+    let cachedToken = await SessionTokensCache.shared.getToken(cacheKey: cacheKey)
+
+    #expect(storeResult.canonicalToken == canonicalToken)
+    #expect(storeResult.didChangeCanonicalToken == false)
+    #expect(cachedToken == canonicalToken)
+  }
+
+  @Test
   func hydrationDoesNotReplaceCanonicalTokenOnTimestampTie() async throws {
     await SessionTokenFetcher.shared.reset()
     await SessionTokensCache.shared.clear()
@@ -417,6 +444,121 @@ struct SessionTokenFetcherTests {
   }
 
   @Test
+  func resetCancelsConcurrentForcedRefreshes() async throws {
+    await SessionTokenFetcher.shared.reset()
+    await SessionTokensCache.shared.clear()
+
+    let session = Session.mock
+    configureCurrentState(session: session, sessionMinterEnabled: false)
+
+    let callCount = LockIsolated(0)
+    let callsStarted = AsyncStream<Void>.makeStream(
+      bufferingPolicy: .bufferingNewest(2)
+    )
+    let requestGate = SessionTokenFetchGate()
+    defer { callsStarted.continuation.finish() }
+    let service = MockSessionService(fetchToken: { _, _, _ in
+      callCount.withValue { $0 += 1 }
+      callsStarted.continuation.yield()
+      await requestGate.suspend()
+      try Task.checkCancellation()
+      return .mock
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let first = Task {
+      try await SessionTokenFetcher.shared.getToken(
+        session,
+        options: .init(skipCache: true)
+      )
+    }
+    let second = Task {
+      try await SessionTokenFetcher.shared.getToken(
+        session,
+        options: .init(skipCache: true)
+      )
+    }
+    defer {
+      first.cancel()
+      second.cancel()
+      Task { await requestGate.resume() }
+    }
+
+    try await waitForSignal(
+      callsStarted.stream,
+      message: "Timed out waiting for forced token request A to start."
+    )
+    try await waitForSignal(
+      callsStarted.stream,
+      message: "Timed out waiting for forced token request B to start."
+    )
+    #expect(callCount.value == 2)
+    #expect(await SessionTokenFetcher.shared.forcedTokenTasks.count == 2)
+
+    await SessionTokenFetcher.shared.reset()
+    await requestGate.resume()
+
+    await #expect(throws: CancellationError.self) {
+      try await first.value
+    }
+    await #expect(throws: CancellationError.self) {
+      try await second.value
+    }
+    #expect(await SessionTokenFetcher.shared.forcedTokenTasks.isEmpty)
+  }
+
+  @Test
+  func cancellingCallerCancelsForcedRefresh() async throws {
+    await SessionTokenFetcher.shared.reset()
+    await SessionTokensCache.shared.clear()
+
+    let session = Session.mock
+    configureCurrentState(session: session, sessionMinterEnabled: false)
+
+    let callStarted = AsyncStream<Void>.makeStream(
+      bufferingPolicy: .bufferingNewest(1)
+    )
+    let requestGate = SessionTokenFetchGate()
+    defer { callStarted.continuation.finish() }
+    let service = MockSessionService(fetchToken: { _, _, _ in
+      callStarted.continuation.yield()
+      await requestGate.suspend()
+      try Task.checkCancellation()
+      return .mock
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let request = Task {
+      try await SessionTokenFetcher.shared.getToken(
+        session,
+        options: .init(skipCache: true)
+      )
+    }
+    defer {
+      request.cancel()
+      Task { await requestGate.resume() }
+    }
+    try await waitForSignal(
+      callStarted.stream,
+      message: "Timed out waiting for the forced token request to start."
+    )
+
+    request.cancel()
+    await requestGate.resume()
+
+    await #expect(throws: CancellationError.self) {
+      try await request.value
+    }
+    #expect(await SessionTokenFetcher.shared.forcedTokenTasks.isEmpty)
+  }
+
+  @Test
   func completedRequestDoesNotClearReplacementTaskAfterReset() async throws {
     await SessionTokenFetcher.shared.reset()
     await SessionTokensCache.shared.clear()
@@ -553,22 +695,20 @@ struct SessionTokenFetcherTests {
 
 private actor SessionTokenFetchGate {
   private var isOpen = false
-  private var continuation: CheckedContinuation<Void, Never>?
+  private var continuations: [CheckedContinuation<Void, Never>] = []
 
   func suspend() async {
     if isOpen {
       return
     }
-    await withCheckedContinuation { continuation = $0 }
+    await withCheckedContinuation { continuations.append($0) }
   }
 
   func resume() {
-    if let continuation {
-      continuation.resume()
-      self.continuation = nil
-    } else {
-      isOpen = true
-    }
+    isOpen = true
+    let continuations = continuations
+    self.continuations.removeAll()
+    continuations.forEach { $0.resume() }
   }
 }
 

--- a/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
+++ b/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
@@ -24,10 +24,15 @@ struct SessionTokenFetcherTests {
   func fetchTokenUsesSessionServiceFetchToken(
     scenario: FetchTokenScenario
   ) async throws {
+    await SessionTokensCache.shared.clear()
     let session = Session.mock
-    let captured = LockIsolated<(sessionId: String, template: String?)?>(nil)
-    let service = MockSessionService(fetchToken: { sessionId, template in
-      captured.setValue((sessionId: sessionId, template: template))
+    let captured = LockIsolated<(
+      sessionId: String,
+      template: String?,
+      params: SessionTokenRequestParams?
+    )?>(nil)
+    let service = MockSessionService(fetchToken: { sessionId, template, params in
+      captured.setValue((sessionId: sessionId, template: template, params: params))
       return .mock
     })
 
@@ -44,14 +49,22 @@ struct SessionTokenFetcherTests {
     let values = try #require(captured.value)
     #expect(values.sessionId == session.id)
     #expect(values.template == scenario.template)
+    if scenario.template == nil {
+      #expect(values.params?.organizationId == "")
+      #expect(values.params?.token == nil)
+      #expect(values.params?.forceOrigin == nil)
+    } else {
+      #expect(values.params == nil)
+    }
   }
 
   @Test
   func fetchTokenCachesFetchedToken() async throws {
+    await SessionTokensCache.shared.clear()
     let session = Session.mock
     let template = UUID().uuidString
     let tokenResource = TokenResource(jwt: "jwt_123")
-    let service = MockSessionService(fetchToken: { _, _ in
+    let service = MockSessionService(fetchToken: { _, _, _ in
       tokenResource
     })
 
@@ -69,5 +82,218 @@ struct SessionTokenFetcherTests {
       cacheKey: session.tokenCacheKey(template: template)
     )
     #expect(cachedToken == tokenResource)
+  }
+
+  @Test
+  func sessionMinterUsesLatestSessionTokenAndForcesOrigin() async throws {
+    await SessionTokensCache.shared.clear()
+    let staleSession = Session.mock
+    var currentSession = staleSession
+    currentSession.lastActiveOrganizationId = "org_test"
+    currentSession.lastActiveToken = try token(
+      sessionId: currentSession.id,
+      organizationId: currentSession.lastActiveOrganizationId,
+      originIssuedAt: 100,
+      issuedAt: 100,
+      signature: "previous"
+    )
+    configureCurrentState(session: currentSession, sessionMinterEnabled: true)
+
+    let captured = LockIsolated<SessionTokenRequestParams?>(nil)
+    let service = MockSessionService(fetchToken: { _, _, params in
+      captured.setValue(params)
+      return try token(
+        sessionId: currentSession.id,
+        organizationId: currentSession.lastActiveOrganizationId,
+        originIssuedAt: 200,
+        issuedAt: 200,
+        signature: "response"
+      )
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    _ = try await SessionTokenFetcher.shared.fetchToken(
+      staleSession,
+      options: .init(skipCache: true)
+    )
+
+    let params = try #require(captured.value)
+    #expect(params.organizationId == "org_test")
+    #expect(params.token == currentSession.lastActiveToken?.jwt)
+    #expect(params.forceOrigin == "true")
+  }
+
+  @Test
+  func sessionMinterOmitsPreviousTokenOnFirstMint() async throws {
+    await SessionTokensCache.shared.clear()
+    let session = Session.mock
+    configureCurrentState(session: session, sessionMinterEnabled: true)
+
+    let captured = LockIsolated<SessionTokenRequestParams?>(nil)
+    let service = MockSessionService(fetchToken: { _, _, params in
+      captured.setValue(params)
+      return .mock
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    _ = try await SessionTokenFetcher.shared.fetchToken(session)
+
+    let params = try #require(captured.value)
+    #expect(params.token == nil)
+    #expect(params.forceOrigin == nil)
+  }
+
+  @Test
+  func disabledSessionMinterDoesNotPassTokenOrForceOrigin() async throws {
+    await SessionTokensCache.shared.clear()
+    var session = Session.mock
+    session.lastActiveOrganizationId = "org_test"
+    session.lastActiveToken = try token(
+      sessionId: session.id,
+      organizationId: session.lastActiveOrganizationId,
+      originIssuedAt: 100,
+      issuedAt: 100
+    )
+    configureCurrentState(session: session, sessionMinterEnabled: false)
+
+    let captured = LockIsolated<SessionTokenRequestParams?>(nil)
+    let service = MockSessionService(fetchToken: { _, _, params in
+      captured.setValue(params)
+      return .mock
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    _ = try await SessionTokenFetcher.shared.fetchToken(
+      session,
+      options: .init(skipCache: true)
+    )
+
+    let params = try #require(captured.value)
+    #expect(params.organizationId == "org_test")
+    #expect(params.token == nil)
+    #expect(params.forceOrigin == nil)
+  }
+
+  @Test
+  func concurrentForcedRefreshesCannotRollBackCanonicalToken() async throws {
+    await SessionTokenFetcher.shared.reset()
+    await SessionTokensCache.shared.clear()
+
+    var session = Session.mock
+    session.lastActiveToken = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 50,
+      issuedAt: 50,
+      signature: "previous"
+    )
+    let staleResponse = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 100,
+      issuedAt: 100,
+      signature: "stale"
+    )
+    let freshResponse = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 200,
+      issuedAt: 200,
+      signature: "fresh"
+    )
+    configureCurrentState(session: session, sessionMinterEnabled: true)
+
+    let callCount = LockIsolated(0)
+    let service = MockSessionService(fetchToken: { _, _, _ in
+      let callIndex = callCount.withValue { count in
+        defer { count += 1 }
+        return count
+      }
+      if callIndex == 0 {
+        try await Task.sleep(for: .milliseconds(100))
+        return staleResponse
+      }
+      return freshResponse
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let first = Task {
+      try await SessionTokenFetcher.shared.getToken(
+        session,
+        options: .init(skipCache: true)
+      )
+    }
+    let deadline = ContinuousClock.now + .seconds(1)
+    while callCount.value == 0, ContinuousClock.now < deadline {
+      await Task.yield()
+    }
+    let second = Task {
+      try await SessionTokenFetcher.shared.getToken(
+        session,
+        options: .init(skipCache: true)
+      )
+    }
+
+    let firstResult = try await first.value
+    let secondResult = try await second.value
+    let cachedToken = await SessionTokensCache.shared.getToken(
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+
+    #expect(callCount.value == 2)
+    #expect(firstResult == staleResponse)
+    #expect(secondResult == freshResponse)
+    #expect(cachedToken == freshResponse)
+  }
+
+  private func configureCurrentState(
+    session: Session,
+    sessionMinterEnabled: Bool
+  ) {
+    var environment = Clerk.Environment.mock
+    environment.authConfig.sessionMinter = sessionMinterEnabled
+    Clerk.shared.environment = environment
+
+    var client = Client.mock
+    client.sessions = [session]
+    client.lastActiveSessionId = session.id
+    Clerk.shared.client = client
+  }
+
+  private func token(
+    sessionId: String,
+    organizationId: String?,
+    originIssuedAt: Int,
+    issuedAt: Int,
+    signature: String = "signature"
+  ) throws -> TokenResource {
+    let header: [String: Any] = [
+      "alg": "none",
+      "typ": "JWT",
+      "oiat": originIssuedAt,
+    ]
+    var claims: [String: Any] = [
+      "sid": sessionId,
+      "iat": issuedAt,
+      "exp": 4_000_000_000,
+    ]
+    if let organizationId {
+      claims["org_id"] = organizationId
+    }
+    return try TokenResource(
+      jwt: testJWT(header: header, claims: claims, signature: signature)
+    )
   }
 }

--- a/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
+++ b/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
@@ -104,6 +104,82 @@ struct SessionTokenFetcherTests {
   }
 
   @Test
+  func hydrationDoesNotReplaceCanonicalTokenOnTimestampTie() async throws {
+    await SessionTokenFetcher.shared.reset()
+    await SessionTokensCache.shared.clear()
+
+    var session = Session.mock
+    let snapshotToken = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 100,
+      issuedAt: 100,
+      signature: "snapshot"
+    )
+    let mintedToken = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 100,
+      issuedAt: 100,
+      signature: "minted"
+    )
+    session.lastActiveToken = snapshotToken
+    configureCurrentState(session: session, sessionMinterEnabled: true)
+
+    let callCount = LockIsolated(0)
+    let service = MockSessionService(fetchToken: { _, _, _ in
+      callCount.withValue { $0 += 1 }
+      return mintedToken
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let forcedToken = try await SessionTokenFetcher.shared.getToken(
+      session,
+      options: .init(skipCache: true)
+    )
+    let ordinaryToken = try await SessionTokenFetcher.shared.getToken(session)
+    let cachedToken = await SessionTokensCache.shared.getToken(
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+
+    #expect(forcedToken == mintedToken)
+    #expect(ordinaryToken == mintedToken)
+    #expect(cachedToken == mintedToken)
+    #expect(callCount.value == 1)
+  }
+
+  @Test
+  func hydrationAcceptsStrictlyFresherSessionSnapshot() async throws {
+    await SessionTokensCache.shared.clear()
+
+    let session = Session.mock
+    let cacheKey = session.tokenCacheKey(template: nil)
+    let cachedToken = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 100,
+      issuedAt: 100,
+      signature: "cached"
+    )
+    let snapshotToken = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 200,
+      issuedAt: 200,
+      signature: "snapshot"
+    )
+    await SessionTokensCache.shared.insertToken(cachedToken, cacheKey: cacheKey)
+
+    await SessionTokensCache.shared.hydrate(snapshotToken, cacheKey: cacheKey)
+
+    let canonicalToken = await SessionTokensCache.shared.getToken(cacheKey: cacheKey)
+    #expect(canonicalToken == snapshotToken)
+  }
+
+  @Test
   func sessionMinterUsesLatestSessionTokenAndForcesOrigin() async throws {
     await SessionTokensCache.shared.clear()
     let staleSession = Session.mock

--- a/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
+++ b/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
@@ -180,6 +180,57 @@ struct SessionTokenFetcherTests {
   }
 
   @Test
+  func hydrationPreservesFresherExpiredTokenForNextMint() async throws {
+    await SessionTokenFetcher.shared.reset()
+    await SessionTokensCache.shared.clear()
+
+    var session = Session.mock
+    let snapshotToken = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 100,
+      issuedAt: 100,
+      expiresAt: 200,
+      signature: "snapshot"
+    )
+    let cachedToken = try token(
+      sessionId: session.id,
+      organizationId: nil,
+      originIssuedAt: 200,
+      issuedAt: 200,
+      expiresAt: 300,
+      signature: "cached"
+    )
+    session.lastActiveToken = snapshotToken
+    configureCurrentState(session: session, sessionMinterEnabled: true)
+    await SessionTokensCache.shared.insertToken(
+      cachedToken,
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+
+    let captured = LockIsolated<SessionTokenRequestParams?>(nil)
+    let service = MockSessionService(fetchToken: { _, _, params in
+      captured.setValue(params)
+      return try token(
+        sessionId: session.id,
+        organizationId: nil,
+        originIssuedAt: 300,
+        issuedAt: 300,
+        signature: "response"
+      )
+    })
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    _ = try await SessionTokenFetcher.shared.getToken(session)
+
+    let params = try #require(captured.value)
+    #expect(params.token == cachedToken.jwt)
+  }
+
+  @Test
   func sessionMinterUsesLatestSessionTokenAndForcesOrigin() async throws {
     await SessionTokensCache.shared.clear()
     let staleSession = Session.mock
@@ -478,6 +529,7 @@ struct SessionTokenFetcherTests {
     organizationId: String?,
     originIssuedAt: Int,
     issuedAt: Int,
+    expiresAt: Int = 4_000_000_000,
     signature: String = "signature"
   ) throws -> TokenResource {
     let header: [String: Any] = [
@@ -488,7 +540,7 @@ struct SessionTokenFetcherTests {
     var claims: [String: Any] = [
       "sid": sessionId,
       "iat": issuedAt,
-      "exp": 4_000_000_000,
+      "exp": expiresAt,
     ]
     if let organizationId {
       claims["org_id"] = organizationId

--- a/Tests/Domains/Auth/TokenFreshnessTests.swift
+++ b/Tests/Domains/Auth/TokenFreshnessTests.swift
@@ -179,6 +179,36 @@ struct TokenFreshnessTests {
     #expect(result == incoming)
   }
 
+  @Test
+  func keepsDecodableExistingTokenWhenIncomingCannotBeDecoded() throws {
+    let existing = try token(originIssuedAt: 100, issuedAt: 100)
+    let incoming = TokenResource(jwt: "malformed")
+
+    let result = TokenFreshness.pickFreshest(existing: existing, incoming: incoming)
+
+    #expect(result == existing)
+  }
+
+  @Test
+  func acceptsDecodableIncomingTokenWhenExistingCannotBeDecoded() throws {
+    let existing = TokenResource(jwt: "malformed")
+    let incoming = try token(originIssuedAt: 100, issuedAt: 100)
+
+    let result = TokenFreshness.pickFreshest(existing: existing, incoming: incoming)
+
+    #expect(result == incoming)
+  }
+
+  @Test
+  func acceptsIncomingTokenWhenNeitherTokenCanBeDecoded() {
+    let existing = TokenResource(jwt: "malformed-existing")
+    let incoming = TokenResource(jwt: "malformed-incoming")
+
+    let result = TokenFreshness.pickFreshest(existing: existing, incoming: incoming)
+
+    #expect(result == incoming)
+  }
+
   private func token(
     sessionId: String = "sess_test",
     organizationId: String? = nil,

--- a/Tests/Domains/Auth/TokenFreshnessTests.swift
+++ b/Tests/Domains/Auth/TokenFreshnessTests.swift
@@ -108,6 +108,77 @@ struct TokenFreshnessTests {
     #expect(result == incoming)
   }
 
+  @Test
+  func keepsUnexpiredExistingToken() throws {
+    let now = Date(timeIntervalSince1970: 1000)
+    let existing = try token(
+      originIssuedAt: 100,
+      issuedAt: 100,
+      expiresAt: 2000
+    )
+    let incoming = try token(
+      originIssuedAt: 300,
+      issuedAt: 300,
+      expiresAt: 900
+    )
+
+    let result = TokenFreshness.pickFreshest(
+      existing: existing,
+      incoming: incoming,
+      now: now
+    )
+
+    #expect(result == existing)
+  }
+
+  @Test
+  func comparesFreshnessWhenBothTokensAreExpired() throws {
+    let now = Date(timeIntervalSince1970: 1000)
+    let existing = try token(
+      originIssuedAt: 300,
+      issuedAt: 300,
+      expiresAt: 900
+    )
+    let incoming = try token(
+      originIssuedAt: 100,
+      issuedAt: 100,
+      expiresAt: 800
+    )
+
+    let result = TokenFreshness.pickFreshest(
+      existing: existing,
+      incoming: incoming,
+      now: now
+    )
+
+    #expect(result == existing)
+  }
+
+  @Test
+  func acceptsOrganizationChangeBeforeComparingExpiration() throws {
+    let now = Date(timeIntervalSince1970: 1000)
+    let existing = try token(
+      organizationId: "org_one",
+      originIssuedAt: 300,
+      issuedAt: 300,
+      expiresAt: 2000
+    )
+    let incoming = try token(
+      organizationId: "org_two",
+      originIssuedAt: 100,
+      issuedAt: 100,
+      expiresAt: 900
+    )
+
+    let result = TokenFreshness.pickFreshest(
+      existing: existing,
+      incoming: incoming,
+      now: now
+    )
+
+    #expect(result == incoming)
+  }
+
   private func token(
     sessionId: String = "sess_test",
     organizationId: String? = nil,

--- a/Tests/Domains/Auth/TokenFreshnessTests.swift
+++ b/Tests/Domains/Auth/TokenFreshnessTests.swift
@@ -1,0 +1,113 @@
+@testable import ClerkKit
+import Foundation
+import Testing
+
+struct TokenFreshnessTests {
+  @Test
+  func keepsTokenWithHigherOriginIssuedAt() throws {
+    let existing = try token(originIssuedAt: 200, issuedAt: 200)
+    let incoming = try token(originIssuedAt: 100, issuedAt: 300)
+
+    let result = TokenFreshness.pickFreshest(existing: existing, incoming: incoming)
+
+    #expect(result == existing)
+  }
+
+  @Test
+  func usesIssuedAtToBreakEqualOriginIssuedAt() throws {
+    let existing = try token(originIssuedAt: 200, issuedAt: 300)
+    let incoming = try token(originIssuedAt: 200, issuedAt: 400)
+
+    let result = TokenFreshness.pickFreshest(existing: existing, incoming: incoming)
+
+    #expect(result == incoming)
+  }
+
+  @Test
+  func acceptsIncomingTokenOnFullTimestampTie() throws {
+    let existing = try token(originIssuedAt: 200, issuedAt: 300, signature: "existing")
+    let incoming = try token(originIssuedAt: 200, issuedAt: 300, signature: "incoming")
+
+    let result = TokenFreshness.pickFreshest(existing: existing, incoming: incoming)
+
+    #expect(result == incoming)
+  }
+
+  @Test
+  func acceptsIncomingTokenWhenOrganizationChanges() throws {
+    let existing = try token(
+      organizationId: "org_one",
+      originIssuedAt: 300,
+      issuedAt: 300
+    )
+    let incoming = try token(
+      organizationId: "org_two",
+      originIssuedAt: 100,
+      issuedAt: 100
+    )
+
+    let result = TokenFreshness.pickFreshest(existing: existing, incoming: incoming)
+
+    #expect(result == incoming)
+  }
+
+  @Test
+  func treatsTokenWithoutOriginIssuedAtAsOlder() throws {
+    let existing = try token(originIssuedAt: 200, issuedAt: 200)
+    let incoming = try token(originIssuedAt: nil, issuedAt: 300)
+
+    let result = TokenFreshness.pickFreshest(existing: existing, incoming: incoming)
+
+    #expect(result == existing)
+  }
+
+  @Test
+  func replacesExpiredExistingToken() throws {
+    let now = Date(timeIntervalSince1970: 1000)
+    let existing = try token(
+      originIssuedAt: 300,
+      issuedAt: 300,
+      expiresAt: 900
+    )
+    let incoming = try token(
+      originIssuedAt: 100,
+      issuedAt: 100,
+      expiresAt: 2000
+    )
+
+    let result = TokenFreshness.pickFreshest(
+      existing: existing,
+      incoming: incoming,
+      now: now
+    )
+
+    #expect(result == incoming)
+  }
+
+  private func token(
+    sessionId: String = "sess_test",
+    organizationId: String? = nil,
+    originIssuedAt: Int?,
+    issuedAt: Int,
+    expiresAt: Int = 4_000_000_000,
+    signature: String = "signature"
+  ) throws -> TokenResource {
+    var header: [String: Any] = ["alg": "none", "typ": "JWT"]
+    if let originIssuedAt {
+      header["oiat"] = originIssuedAt
+    }
+
+    var claims: [String: Any] = [
+      "sid": sessionId,
+      "iat": issuedAt,
+      "exp": expiresAt,
+    ]
+    if let organizationId {
+      claims["org_id"] = organizationId
+    }
+
+    return try TokenResource(
+      jwt: testJWT(header: header, claims: claims, signature: signature)
+    )
+  }
+}

--- a/Tests/Domains/Auth/TokenFreshnessTests.swift
+++ b/Tests/Domains/Auth/TokenFreshnessTests.swift
@@ -24,6 +24,16 @@ struct TokenFreshnessTests {
   }
 
   @Test
+  func usesIssuedAtWhenBothTokensLackOriginIssuedAt() throws {
+    let existing = try token(originIssuedAt: nil, issuedAt: 300)
+    let incoming = try token(originIssuedAt: nil, issuedAt: 200)
+
+    let result = TokenFreshness.pickFreshest(existing: existing, incoming: incoming)
+
+    #expect(result == existing)
+  }
+
+  @Test
   func acceptsIncomingTokenOnFullTimestampTie() throws {
     let existing = try token(originIssuedAt: 200, issuedAt: 300, signature: "existing")
     let incoming = try token(originIssuedAt: 200, issuedAt: 300, signature: "incoming")
@@ -31,6 +41,20 @@ struct TokenFreshnessTests {
     let result = TokenFreshness.pickFreshest(existing: existing, incoming: incoming)
 
     #expect(result == incoming)
+  }
+
+  @Test
+  func keepsExistingTokenOnFullTimestampTieWhenRequested() throws {
+    let existing = try token(originIssuedAt: 200, issuedAt: 300, signature: "existing")
+    let incoming = try token(originIssuedAt: 200, issuedAt: 300, signature: "incoming")
+
+    let result = TokenFreshness.pickFreshest(
+      existing: existing,
+      incoming: incoming,
+      tieBreaker: .existing
+    )
+
+    #expect(result == existing)
   }
 
   @Test

--- a/Tests/Domains/Environment/AuthConfigTests.swift
+++ b/Tests/Domains/Environment/AuthConfigTests.swift
@@ -1,0 +1,31 @@
+@testable import ClerkKit
+import Foundation
+import Testing
+
+struct AuthConfigTests {
+  @Test
+  func decodesSessionMinter() throws {
+    let data = Data(
+      #"{"single_session_mode":false,"session_minter":true}"#.utf8
+    )
+
+    let authConfig = try JSONDecoder.clerkDecoder.decode(
+      Clerk.Environment.AuthConfig.self,
+      from: data
+    )
+
+    #expect(authConfig.sessionMinter)
+  }
+
+  @Test
+  func defaultsSessionMinterToFalseWhenMissing() throws {
+    let data = Data(#"{"single_session_mode":false}"#.utf8)
+
+    let authConfig = try JSONDecoder.clerkDecoder.decode(
+      Clerk.Environment.AuthConfig.self,
+      from: data
+    )
+
+    #expect(authConfig.sessionMinter == false)
+  }
+}

--- a/Tests/TestSupport/JWTTestHelpers.swift
+++ b/Tests/TestSupport/JWTTestHelpers.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+func testJWT(
+  header: [String: Any] = ["alg": "none", "typ": "JWT"],
+  claims: [String: Any],
+  signature: String = "signature"
+) throws -> String {
+  try [
+    base64URLEncodedJSON(header),
+    base64URLEncodedJSON(claims),
+    signature,
+  ].joined(separator: ".")
+}
+
+private func base64URLEncodedJSON(_ object: [String: Any]) throws -> String {
+  try JSONSerialization.data(withJSONObject: object)
+    .base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add session minter token freshness handling with organization-scoped caching
- Introduces `TokenFreshness` logic to select the freshest session token by comparing `originIssuedAt`, `issuedAt`, expiration, and organization/session context between existing and incoming tokens.
- Adds `SessionTokenRequestParams` to pass previous token and `forceOrigin` in default (non-template) token fetch requests when the session minter feature is enabled.
- Partitions `SessionTokensCache` keys by active organization ID so tokens are cached separately per organization; adds generation counters to invalidate stale in-flight writes after `removeTokens` or `clear`.
- Rewrites `SessionTokenFetcher` to deduplicate concurrent requests only when cache generation and active-session status match, isolate forced (`skipCache`) fetches in a separate task map, and fire `tokenRefreshed` only when the canonical token changes.
- Adds `sessionMinter` boolean to `Clerk.Environment.AuthConfig`, decoded from the `session_minter` field and defaulting to `false`.
- `SessionService.signOut` and `setActive` now proactively clear cached tokens for the affected session.
- Risk: `Session.tokenCacheKey` format has changed to include organization ID, so all existing cached token entries will be treated as cache misses after this update.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized df197f6.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->