### PR TITLE
Add Session Minter support to the token fetch path

### DIFF
--- a/Sources/ClerkKit/Domains/Auth/Session/Session.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/Session.swift
@@ -296,7 +296,12 @@ extension Session {
   /// - If the template is null, the key will be 'sess_abc12345'
   /// - If the template is 'supabase', the key will be 'sess_abc12345-supabase'
   func tokenCacheKey(template: String?) -> String {
-    var tokenCacheKey = id
+    Self.tokenCacheKey(sessionId: id, template: template)
+  }
+
+  /// Format for the session token cache key, for callers that only hold a session id.
+  static func tokenCacheKey(sessionId: String, template: String?) -> String {
+    var tokenCacheKey = sessionId
     if let template {
       tokenCacheKey += "-\(template)"
     }

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionService.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionService.swift
@@ -22,7 +22,8 @@ protocol SessionServiceProtocol: Sendable {
   /// - Parameters:
   ///   - sessionId: The session ID to generate a token for.
   ///   - template: Optional JWT template name.
-  @MainActor func fetchToken(sessionId: String, template: String?) async throws -> TokenResource?
+  ///   - skipCache: Whether the caller asked to bypass caches for this token.
+  @MainActor func fetchToken(sessionId: String, template: String?, skipCache: Bool) async throws -> TokenResource?
 
   /// Starts an in-session reverification (step-up) flow.
   @MainActor func startVerification(
@@ -81,15 +82,31 @@ final class SessionService: SessionServiceProtocol {
         method: .post
       )
 
-      try await apiClient.send(request)
-    } else {
-      let request = Request<EmptyResponse>(
-        path: "/v1/client/sessions",
-        method: .delete
-      )
+      do {
+        try await apiClient.send(request)
+      } catch {
+        // The server can accept the sign-out and the response pipeline still throw.
+        await SessionTokensCache.shared.removeTokens(sessionId: sessionId)
+        throw error
+      }
 
-      try await apiClient.send(request)
+      await SessionTokensCache.shared.removeTokens(sessionId: sessionId)
+      return
     }
+
+    let request = Request<EmptyResponse>(
+      path: "/v1/client/sessions",
+      method: .delete
+    )
+
+    do {
+      try await apiClient.send(request)
+    } catch {
+      await SessionTokensCache.shared.clear()
+      throw error
+    }
+
+    await SessionTokensCache.shared.clear()
   }
 
   @MainActor
@@ -104,22 +121,75 @@ final class SessionService: SessionServiceProtocol {
     )
 
     try await apiClient.send(request)
+    await SessionTokensCache.shared.removeTokens(sessionId: sessionId)
   }
 
   @MainActor
-  func fetchToken(sessionId: String, template: String?) async throws -> TokenResource? {
-    let path = if let template {
-      "/v1/client/sessions/\(sessionId)/tokens/\(template)"
-    } else {
-      "/v1/client/sessions/\(sessionId)/tokens"
+  func fetchToken(sessionId: String, template: String?, skipCache: Bool) async throws -> TokenResource? {
+    if let template {
+      let request = Request<TokenResource?>(
+        path: "/v1/client/sessions/\(sessionId)/tokens/\(template)",
+        method: .post
+      )
+
+      return try await apiClient.send(request).value
     }
 
+    let body = await sessionMinterBody(sessionId: sessionId, skipCache: skipCache)
     let request = Request<TokenResource?>(
-      path: path,
-      method: .post
+      path: "/v1/client/sessions/\(sessionId)/tokens",
+      method: .post,
+      body: body,
+      // The seed is a replayable session credential; keep it out of device logs.
+      logBodies: body?["token"] == nil
     )
 
     return try await apiClient.send(request).value
+  }
+
+  /// Body params the session minter needs on the non-template tokens route.
+  ///
+  /// Returns `nil` when the instance is not on the session minter, or when there is
+  /// nothing to send, so the request stays byte-identical to a minter-less one.
+  @MainActor
+  private func sessionMinterBody(sessionId: String, skipCache: Bool) async -> [String: String]? {
+    guard Clerk.shared.environment?.authConfig.sessionMinter == true else {
+      return nil
+    }
+
+    var body: [String: String] = [:]
+
+    if let seedToken = await sessionMinterSeedToken(sessionId: sessionId) {
+      body["token"] = seedToken
+    }
+
+    if skipCache {
+      body["force_origin"] = "true"
+    }
+
+    return body.isEmpty ? nil : body
+  }
+
+  /// The previous session token the minter mints from. Never a template token.
+  @MainActor
+  private func sessionMinterSeedToken(sessionId: String) async -> String? {
+    let cacheKey = Session.tokenCacheKey(sessionId: sessionId, template: nil)
+
+    if let cachedToken = await SessionTokensCache.shared.getToken(cacheKey: cacheKey)?.jwt, !cachedToken.isEmpty {
+      return cachedToken
+    }
+
+    let lastActiveToken = Clerk.shared.client?
+      .sessions
+      .first { $0.id == sessionId }?
+      .lastActiveToken?
+      .jwt
+
+    guard let lastActiveToken, !lastActiveToken.isEmpty else {
+      return nil
+    }
+
+    return lastActiveToken
   }
 
   @MainActor

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionTokenFetcher.swift
@@ -10,8 +10,15 @@ import Foundation
 actor SessionTokenFetcher {
   static let shared = SessionTokenFetcher()
 
-  /// Key is `tokenCacheKey` property of a `session`
-  var tokenTasks: [String: Task<TokenResource?, Error>] = [:]
+  /// A forced request gets its own key so a `skipCache` caller never joins a task that
+  /// is allowed to answer from a cache. Typed rather than a delimited string so no
+  /// template name can collide with the force marker.
+  private struct TokenTaskKey: Hashable {
+    let cacheKey: String
+    let force: Bool
+  }
+
+  private var tokenTasks: [TokenTaskKey: Task<TokenResource?, Error>] = [:]
 
   func reset() {
     for task in tokenTasks.values {
@@ -20,11 +27,15 @@ actor SessionTokenFetcher {
     tokenTasks.removeAll()
   }
 
+  private func taskKey(_ session: Session, options: Session.GetTokenOptions) -> TokenTaskKey {
+    TokenTaskKey(cacheKey: session.tokenCacheKey(template: options.template), force: options.skipCache)
+  }
+
   func getToken(_ session: Session, options: Session.GetTokenOptions = .init()) async throws -> TokenResource? {
     let runtime = try await Clerk.requireStableRuntime()
-    let cacheKey = session.tokenCacheKey(template: options.template)
+    let taskKey = taskKey(session, options: options)
 
-    if let inProgressTask = tokenTasks[cacheKey] {
+    if let inProgressTask = tokenTasks[taskKey] {
       let result = await inProgressTask.result
       try runtime.validateStableRuntime()
       return try result.get()
@@ -35,12 +46,12 @@ actor SessionTokenFetcher {
       return try await fetchToken(session, options: options, runtime: runtime)
     }
 
-    tokenTasks[cacheKey] = task
+    tokenTasks[taskKey] = task
 
     let result = await task.result
 
     // clear the inProgressTask on success AND failure
-    tokenTasks[cacheKey] = nil
+    tokenTasks[taskKey] = nil
 
     try runtime.validateStableRuntime()
     return try result.get()
@@ -79,9 +90,12 @@ actor SessionTokenFetcher {
     try Task.checkCancellation()
     try runtime.validateStableRuntime()
 
+    let cacheGeneration = await SessionTokensCache.shared.generation(sessionId: session.id)
+
     let token = try await Clerk.shared.dependencies.sessionService.fetchToken(
       sessionId: session.id,
-      template: options.template
+      template: options.template,
+      skipCache: options.skipCache
     )
 
     try Task.checkCancellation()
@@ -90,7 +104,7 @@ actor SessionTokenFetcher {
     if let token {
       try Task.checkCancellation()
       try runtime.validateStableRuntime()
-      await SessionTokensCache.shared.insertToken(token, cacheKey: cacheKey)
+      await SessionTokensCache.shared.insertToken(token, cacheKey: cacheKey, generation: cacheGeneration)
       try Task.checkCancellation()
       try runtime.validateStableRuntime()
       Clerk.shared.auth.send(.tokenRefreshed(token: token.jwt))
@@ -100,10 +114,18 @@ actor SessionTokenFetcher {
   }
 }
 
+/// Fence taken before a token request so a request that started before an invalidation
+/// cannot write its result back afterwards.
+struct SessionTokensCacheGeneration: Equatable {
+  let sessionId: String
+  let value: Int
+}
+
 actor SessionTokensCache {
   static let shared = SessionTokensCache()
 
   private var cache: [String: TokenResource] = [:]
+  private var generations: [String: Int] = [:]
 
   /// Returns a session token from the cache.
   /// - Parameter cacheKey: cacheKey is the session id + template name if there is one.
@@ -113,16 +135,95 @@ actor SessionTokensCache {
     cache[cacheKey]
   }
 
-  /// Inserts a session token into the cache.
+  /// The current cache generation for a session. Capture it before a token request and
+  /// pass it back to ``insertToken(_:cacheKey:generation:)``.
+  func generation(sessionId: String) -> SessionTokensCacheGeneration {
+    let value = generations[sessionId] ?? 0
+    generations[sessionId] = value
+    return .init(sessionId: sessionId, value: value)
+  }
+
+  /// Inserts a session token into the cache, keeping whichever token is fresher.
   /// - Parameters:
   ///   - token: ``TokenResource``
   ///   - cacheKey: cacheKey is the session id + template name if there is one.
   ///               For example, `sess_abc12345` or `sess_abc12345-supabase`.
-  func insertToken(_ token: TokenResource, cacheKey: String) {
-    cache[cacheKey] = token
+  ///   - generation: The generation captured before the request. The write is dropped when
+  ///                 the session's tokens were invalidated while the request was in flight.
+  func insertToken(_ token: TokenResource, cacheKey: String, generation: SessionTokensCacheGeneration? = nil) {
+    if let generation, generations[generation.sessionId] ?? 0 != generation.value {
+      return
+    }
+
+    cache[cacheKey] = freshestToken(existing: cache[cacheKey], incoming: token)
+  }
+
+  /// Removes every cached token for a session, including its template tokens.
+  /// - Parameter sessionId: The session whose tokens are no longer valid.
+  func removeTokens(sessionId: String) {
+    let defaultCacheKey = Session.tokenCacheKey(sessionId: sessionId, template: nil)
+    cache = cache.filter { key, _ in
+      key != defaultCacheKey && !key.hasPrefix("\(defaultCacheKey)-")
+    }
+    generations[sessionId] = (generations[sessionId] ?? 0) + 1
   }
 
   func clear() {
     cache.removeAll()
+    for sessionId in generations.keys {
+      generations[sessionId] = (generations[sessionId] ?? 0) + 1
+    }
+  }
+}
+
+/// Picks the fresher of two tokens.
+///
+/// Origin-minted tokens carry an `oiat` (origin-issued-at) JWT header, the time the claims
+/// were last assembled. Minted tokens inherit the `oiat` of the token they were minted from,
+/// so an equal `oiat` is broken by `iat`. A token without an `oiat` predates the feature and
+/// loses to one that has it. Ties return the incoming token: identical timestamps can still
+/// mean different claims.
+func freshestToken(existing: TokenResource?, incoming: TokenResource) -> TokenResource {
+  guard let existing else {
+    return incoming
+  }
+
+  let existingOiat = existing.decodedJWT?.originIssuedAt
+  let incomingOiat = incoming.decodedJWT?.originIssuedAt
+
+  switch (existingOiat, incomingOiat) {
+  case (nil, nil):
+    return incoming
+  case (.some, nil):
+    return existing
+  case (nil, .some):
+    return incoming
+  case let (.some(existingOiat), .some(incomingOiat)):
+    if existingOiat > incomingOiat {
+      return existing
+    }
+    if existingOiat < incomingOiat {
+      return incoming
+    }
+
+    let existingIssuedAt = existing.decodedJWT?.issuedAt ?? .distantPast
+    let incomingIssuedAt = incoming.decodedJWT?.issuedAt ?? .distantPast
+    return existingIssuedAt > incomingIssuedAt ? existing : incoming
+  }
+}
+
+extension DecodedJWT {
+  /// Value of the `oiat` protected header, if available.
+  var originIssuedAt: Double? {
+    switch header["oiat"] {
+    case let value as Double:
+      value
+    case let value as Int:
+      Double(value)
+    case let value as String:
+      Double(value)
+    default:
+      nil
+    }
   }
 }

--- a/Sources/ClerkKit/Domains/Environment/AuthConfig.swift
+++ b/Sources/ClerkKit/Domains/Environment/AuthConfig.swift
@@ -8,5 +8,19 @@ import Foundation
 extension Clerk.Environment {
   public struct AuthConfig: Codable, Sendable, Equatable {
     public var singleSessionMode: Bool
+
+    /// Whether the instance serves session tokens through the session minter.
+    public var sessionMinter: Bool
+
+    init(singleSessionMode: Bool, sessionMinter: Bool = false) {
+      self.singleSessionMode = singleSessionMode
+      self.sessionMinter = sessionMinter
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      singleSessionMode = try container.decode(Bool.self, forKey: .singleSessionMode)
+      sessionMinter = try container.decodeIfPresent(Bool.self, forKey: .sessionMinter) ?? false
+    }
   }
 }

--- a/Sources/ClerkKit/Mocks/MockServices/MockSessionService.swift
+++ b/Sources/ClerkKit/Mocks/MockServices/MockSessionService.swift
@@ -21,8 +21,8 @@ package final class MockSessionService: SessionServiceProtocol {
   /// Custom handler for the `setActive(sessionId:organizationId:)` method.
   package nonisolated(unsafe) var setActiveHandler: ((String, String?) async throws -> Void)?
 
-  /// Custom handler for the `fetchToken(sessionId:template:)` method.
-  package nonisolated(unsafe) var fetchTokenHandler: ((String, String?) async throws -> TokenResource?)?
+  /// Custom handler for the `fetchToken(sessionId:template:skipCache:)` method.
+  package nonisolated(unsafe) var fetchTokenHandler: ((String, String?, Bool) async throws -> TokenResource?)?
 
   /// Custom handler for the `startVerification(sessionId:params:)` method.
   nonisolated(unsafe) var startVerificationHandler: ((String, Session.StartVerificationParams) async throws -> SessionVerification)?
@@ -43,7 +43,7 @@ package final class MockSessionService: SessionServiceProtocol {
     revoke: ((String) async throws -> Session)? = nil,
     signOut: ((String?) async throws -> Void)? = nil,
     setActive: ((String, String?) async throws -> Void)? = nil,
-    fetchToken: ((String, String?) async throws -> TokenResource?)? = nil
+    fetchToken: ((String, String?, Bool) async throws -> TokenResource?)? = nil
   ) {
     self.init(
       revoke: revoke,
@@ -62,7 +62,7 @@ package final class MockSessionService: SessionServiceProtocol {
     revoke: ((String) async throws -> Session)? = nil,
     signOut: ((String?) async throws -> Void)? = nil,
     setActive: ((String, String?) async throws -> Void)? = nil,
-    fetchToken: ((String, String?) async throws -> TokenResource?)? = nil,
+    fetchToken: ((String, String?, Bool) async throws -> TokenResource?)? = nil,
     startVerification: ((String, Session.StartVerificationParams) async throws -> SessionVerification)? = nil,
     prepareFirstFactorVerification: ((String, Session.PrepareFirstFactorVerificationParams) async throws -> SessionVerification)? = nil,
     attemptFirstFactorVerification: ((String, Session.AttemptFirstFactorVerificationParams) async throws -> SessionVerification)? = nil,
@@ -104,9 +104,9 @@ package final class MockSessionService: SessionServiceProtocol {
   }
 
   @MainActor
-  package func fetchToken(sessionId: String, template: String?) async throws -> TokenResource? {
+  package func fetchToken(sessionId: String, template: String?, skipCache: Bool) async throws -> TokenResource? {
     if let handler = fetchTokenHandler {
-      return try await handler(sessionId, template)
+      return try await handler(sessionId, template, skipCache)
     }
 
     return .mock

--- a/Tests/Core/ClerkReconfigureTests.swift
+++ b/Tests/Core/ClerkReconfigureTests.swift
@@ -545,7 +545,7 @@ struct ClerkReconfigureTests {
   @Test
   func reconfigureClearsTokensBeforeSessionChangedEvent() async throws {
     let cachedJWT = try unexpiredJWT()
-    let sessionService = MockSessionService(fetchToken: { _, _ in
+    let sessionService = MockSessionService(fetchToken: { _, _, _ in
       throw CancellationError()
     })
     let dependencies = MockDependencyContainer(

--- a/Tests/Domains/Auth/Session/SessionServiceTests.swift
+++ b/Tests/Domains/Auth/Session/SessionServiceTests.swift
@@ -268,7 +268,11 @@ struct SessionServiceTests {
     }
     mock.register()
 
-    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(sessionId: session.id, template: nil)
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: nil,
+      skipCache: false
+    )
     #expect(requestHandled.value)
   }
 
@@ -292,8 +296,515 @@ struct SessionServiceTests {
     }
     mock.register()
 
-    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(sessionId: session.id, template: template)
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: template,
+      skipCache: false
+    )
     #expect(requestHandled.value)
+  }
+
+  // MARK: - Session minter
+
+  private func setEnvironment(sessionMinter: Bool) {
+    Clerk.shared.environment = .init(
+      authConfig: .init(singleSessionMode: false, sessionMinter: sessionMinter),
+      userSettings: .mock,
+      displayConfig: .mock
+    )
+  }
+
+  private func registerTokensMock(
+    sessionId: String,
+    template: String? = nil,
+    capturedBody: LockIsolated<[String: String]?>,
+    capturedBodyLogging: LockIsolated<Bool?> = .init(nil),
+    requestHandled: LockIsolated<Bool>
+  ) throws {
+    let path = if let template {
+      "/v1/client/sessions/\(sessionId)/tokens/\(template)"
+    } else {
+      "/v1/client/sessions/\(sessionId)/tokens"
+    }
+    let originalURL = URL(string: mockBaseUrl.absoluteString + path)!
+
+    var mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(TokenResource.mock),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { @Sendable request in
+      capturedBody.setValue(request.urlEncodedFormBody)
+      capturedBodyLogging.setValue(request.shouldLogClerkBodies)
+      requestHandled.setValue(true)
+    }
+    mock.register()
+  }
+
+  @Test
+  func fetchTokenDisablesBodyLoggingWhenASeedIsAttached() async throws {
+    let session = Session.mock
+    setEnvironment(sessionMinter: true)
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "seed_jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+
+    let capturedBody = LockIsolated<[String: String]?>(nil)
+    let capturedBodyLogging = LockIsolated<Bool?>(nil)
+    let requestHandled = LockIsolated(false)
+    try registerTokensMock(
+      sessionId: session.id,
+      capturedBody: capturedBody,
+      capturedBodyLogging: capturedBodyLogging,
+      requestHandled: requestHandled
+    )
+
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: nil,
+      skipCache: true
+    )
+
+    #expect(requestHandled.value)
+    #expect(capturedBody.value?["token"] == "seed_jwt")
+    #expect(capturedBodyLogging.value == false)
+  }
+
+  @Test
+  func fetchTokenKeepsBodyLoggingWhenNoSeedIsAttached() async throws {
+    let session = Session.mock
+    setEnvironment(sessionMinter: true)
+    Clerk.shared.client = .mock
+    await SessionTokensCache.shared.clear()
+
+    let capturedBody = LockIsolated<[String: String]?>(nil)
+    let capturedBodyLogging = LockIsolated<Bool?>(nil)
+    let requestHandled = LockIsolated(false)
+    try registerTokensMock(
+      sessionId: session.id,
+      capturedBody: capturedBody,
+      capturedBodyLogging: capturedBodyLogging,
+      requestHandled: requestHandled
+    )
+
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: nil,
+      skipCache: true
+    )
+
+    #expect(requestHandled.value)
+    #expect(capturedBody.value?["token"] == nil)
+    #expect(capturedBodyLogging.value == true)
+  }
+
+  @Test
+  func fetchTokenSendsNoBodyWhenSessionMinterIsDisabled() async throws {
+    let session = Session.mock
+    setEnvironment(sessionMinter: false)
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "seed_jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+
+    let capturedBody = LockIsolated<[String: String]?>(nil)
+    let requestHandled = LockIsolated(false)
+    try registerTokensMock(sessionId: session.id, capturedBody: capturedBody, requestHandled: requestHandled)
+
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: nil,
+      skipCache: true
+    )
+
+    #expect(requestHandled.value)
+    #expect(capturedBody.value == nil)
+  }
+
+  @Test
+  func fetchTokenSendsCachedTokenAsSeedWhenSessionMinterIsEnabled() async throws {
+    let session = Session.mock
+    setEnvironment(sessionMinter: true)
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "seed_jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+
+    let capturedBody = LockIsolated<[String: String]?>(nil)
+    let requestHandled = LockIsolated(false)
+    try registerTokensMock(sessionId: session.id, capturedBody: capturedBody, requestHandled: requestHandled)
+
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: nil,
+      skipCache: false
+    )
+
+    #expect(requestHandled.value)
+    let body = try #require(capturedBody.value)
+    #expect(body["token"] == "seed_jwt")
+    #expect(body["force_origin"] == nil)
+  }
+
+  @Test
+  func fetchTokenSendsNoBodyWhenSessionMinterIsEnabledAndNoSeedExists() async throws {
+    let session = Session.mock
+    setEnvironment(sessionMinter: true)
+    Clerk.shared.client = .mock
+    await SessionTokensCache.shared.clear()
+
+    let capturedBody = LockIsolated<[String: String]?>(nil)
+    let requestHandled = LockIsolated(false)
+    try registerTokensMock(sessionId: session.id, capturedBody: capturedBody, requestHandled: requestHandled)
+
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: nil,
+      skipCache: false
+    )
+
+    #expect(requestHandled.value)
+    #expect(capturedBody.value == nil)
+  }
+
+  @Test
+  func fetchTokenFallsBackToLastActiveTokenWhenCacheIsCold() async throws {
+    var session = Session.mock
+    session.lastActiveToken = .init(jwt: "last_active_jwt")
+    var client = Client.mock
+    client.sessions = [session]
+    setEnvironment(sessionMinter: true)
+    Clerk.shared.client = client
+    await SessionTokensCache.shared.clear()
+
+    let capturedBody = LockIsolated<[String: String]?>(nil)
+    let requestHandled = LockIsolated(false)
+    try registerTokensMock(sessionId: session.id, capturedBody: capturedBody, requestHandled: requestHandled)
+
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: nil,
+      skipCache: false
+    )
+
+    #expect(requestHandled.value)
+    let body = try #require(capturedBody.value)
+    #expect(body["token"] == "last_active_jwt")
+  }
+
+  @Test
+  func fetchTokenPrefersCachedTokenOverLastActiveToken() async throws {
+    var session = Session.mock
+    session.lastActiveToken = .init(jwt: "last_active_jwt")
+    var client = Client.mock
+    client.sessions = [session]
+    setEnvironment(sessionMinter: true)
+    Clerk.shared.client = client
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "seed_jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+
+    let capturedBody = LockIsolated<[String: String]?>(nil)
+    let requestHandled = LockIsolated(false)
+    try registerTokensMock(sessionId: session.id, capturedBody: capturedBody, requestHandled: requestHandled)
+
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: nil,
+      skipCache: false
+    )
+
+    #expect(requestHandled.value)
+    let body = try #require(capturedBody.value)
+    #expect(body["token"] == "seed_jwt")
+  }
+
+  @Test
+  func fetchTokenMapsSkipCacheToForceOrigin() async throws {
+    let session = Session.mock
+    setEnvironment(sessionMinter: true)
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "seed_jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+
+    let capturedBody = LockIsolated<[String: String]?>(nil)
+    let requestHandled = LockIsolated(false)
+    try registerTokensMock(sessionId: session.id, capturedBody: capturedBody, requestHandled: requestHandled)
+
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: nil,
+      skipCache: true
+    )
+
+    #expect(requestHandled.value)
+    let body = try #require(capturedBody.value)
+    #expect(body["token"] == "seed_jwt")
+    #expect(body["force_origin"] == "true")
+  }
+
+  @Test
+  func fetchTokenWithTemplateNeverSendsMinterBody() async throws {
+    let session = Session.mock
+    let template = "firebase"
+    setEnvironment(sessionMinter: true)
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "seed_jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+
+    let capturedBody = LockIsolated<[String: String]?>(nil)
+    let requestHandled = LockIsolated(false)
+    try registerTokensMock(
+      sessionId: session.id,
+      template: template,
+      capturedBody: capturedBody,
+      requestHandled: requestHandled
+    )
+
+    _ = try await Clerk.shared.dependencies.sessionService.fetchToken(
+      sessionId: session.id,
+      template: template,
+      skipCache: true
+    )
+
+    #expect(requestHandled.value)
+    #expect(capturedBody.value == nil)
+  }
+
+  // MARK: - Cached token invalidation
+
+  @Test
+  func signOutWithSessionIdClearsThatSessionsCachedTokens() async throws {
+    let sessionId = "sess_signed_out"
+    let otherSessionId = "sess_other"
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "seed_jwt"),
+      cacheKey: Session.tokenCacheKey(sessionId: sessionId, template: nil)
+    )
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "template_jwt"),
+      cacheKey: Session.tokenCacheKey(sessionId: sessionId, template: "firebase")
+    )
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "other_jwt"),
+      cacheKey: Session.tokenCacheKey(sessionId: otherSessionId, template: nil)
+    )
+
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(sessionId)/remove")!
+    let mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(EmptyResponse()),
+      ]
+    )
+    mock.register()
+
+    try await Clerk.shared.dependencies.sessionService.signOut(sessionId: sessionId)
+
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: Session.tokenCacheKey(sessionId: sessionId, template: nil)
+    ) == nil)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: Session.tokenCacheKey(sessionId: sessionId, template: "firebase")
+    ) == nil)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: Session.tokenCacheKey(sessionId: otherSessionId, template: nil)
+    )?.jwt == "other_jwt")
+  }
+
+  @Test
+  func signOutWithoutSessionIdClearsEveryCachedToken() async throws {
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "seed_jwt"),
+      cacheKey: Session.tokenCacheKey(sessionId: "sess_one", template: nil)
+    )
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "other_jwt"),
+      cacheKey: Session.tokenCacheKey(sessionId: "sess_two", template: nil)
+    )
+
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions")!
+    let mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .delete: JSONEncoder.clerkEncoder.encode(EmptyResponse()),
+      ]
+    )
+    mock.register()
+
+    try await Clerk.shared.dependencies.sessionService.signOut(sessionId: nil)
+
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: Session.tokenCacheKey(sessionId: "sess_one", template: nil)
+    ) == nil)
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: Session.tokenCacheKey(sessionId: "sess_two", template: nil)
+    ) == nil)
+  }
+
+  @Test
+  func signOutWithSessionIdClearsCachedTokensWhenTheResponseThrows() async throws {
+    let sessionId = "sess_signed_out_failing"
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "seed_jwt"),
+      cacheKey: Session.tokenCacheKey(sessionId: sessionId, template: nil)
+    )
+
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(sessionId)/remove")!
+    let mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 500,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(
+          ClerkErrorResponse(
+            errors: [
+              ClerkAPIError(
+                code: "internal_server_error",
+                message: "Something went wrong",
+                longMessage: nil,
+                meta: nil,
+                clerkTraceId: nil
+              ),
+            ],
+            clerkTraceId: nil
+          )
+        ),
+      ]
+    )
+    mock.register()
+
+    await #expect(throws: (any Error).self) {
+      try await Clerk.shared.dependencies.sessionService.signOut(sessionId: sessionId)
+    }
+
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: Session.tokenCacheKey(sessionId: sessionId, template: nil)
+    ) == nil)
+  }
+
+  @Test
+  func signOutWithoutSessionIdClearsCachedTokensWhenTheResponseThrows() async throws {
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "seed_jwt"),
+      cacheKey: Session.tokenCacheKey(sessionId: "sess_one", template: nil)
+    )
+
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions")!
+    let mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 500,
+      data: [
+        .delete: JSONEncoder.clerkEncoder.encode(
+          ClerkErrorResponse(
+            errors: [
+              ClerkAPIError(
+                code: "internal_server_error",
+                message: "Something went wrong",
+                longMessage: nil,
+                meta: nil,
+                clerkTraceId: nil
+              ),
+            ],
+            clerkTraceId: nil
+          )
+        ),
+      ]
+    )
+    mock.register()
+
+    await #expect(throws: (any Error).self) {
+      try await Clerk.shared.dependencies.sessionService.signOut(sessionId: nil)
+    }
+
+    #expect(await SessionTokensCache.shared.getToken(
+      cacheKey: Session.tokenCacheKey(sessionId: "sess_one", template: nil)
+    ) == nil)
+  }
+
+  @Test
+  func setActiveClearsThatSessionsCachedTokens() async throws {
+    let session = Session.mock
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "seed_jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "template_jwt"),
+      cacheKey: session.tokenCacheKey(template: "firebase")
+    )
+
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/touch")!
+    let mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(ClientResponse<Session>(response: session, client: .mock)),
+      ]
+    )
+    mock.register()
+
+    try await Clerk.shared.dependencies.sessionService.setActive(
+      sessionId: session.id,
+      organizationId: "org_test456"
+    )
+
+    #expect(await SessionTokensCache.shared.getToken(cacheKey: session.tokenCacheKey(template: nil)) == nil)
+    #expect(await SessionTokensCache.shared.getToken(cacheKey: session.tokenCacheKey(template: "firebase")) == nil)
+  }
+
+  @Test
+  func setActiveFailureKeepsCachedTokens() async throws {
+    let session = Session.mock
+    await SessionTokensCache.shared.clear()
+    await SessionTokensCache.shared.insertToken(
+      .init(jwt: "seed_jwt"),
+      cacheKey: session.tokenCacheKey(template: nil)
+    )
+
+    let originalURL = URL(string: mockBaseUrl.absoluteString + "/v1/client/sessions/\(session.id)/touch")!
+    let mock = try Mock(
+      url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 403,
+      data: [
+        .post: JSONEncoder.clerkEncoder.encode(
+          ClerkErrorResponse(
+            errors: [
+              ClerkAPIError(
+                code: "not_a_member_in_organization",
+                message: "Unable to switch organization",
+                longMessage: nil,
+                meta: nil,
+                clerkTraceId: nil
+              ),
+            ],
+            clerkTraceId: nil
+          )
+        ),
+      ]
+    )
+    mock.register()
+
+    await #expect(throws: ClerkAPIError.self) {
+      try await Clerk.shared.dependencies.sessionService.setActive(
+        sessionId: session.id,
+        organizationId: "org_unauthorized"
+      )
+    }
+
+    #expect(await SessionTokensCache.shared.getToken(cacheKey: session.tokenCacheKey(template: nil))?.jwt == "seed_jwt")
   }
 
   @Test

--- a/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
+++ b/Tests/Domains/Auth/Session/SessionTokenFetcherTests.swift
@@ -25,9 +25,9 @@ struct SessionTokenFetcherTests {
     scenario: FetchTokenScenario
   ) async throws {
     let session = Session.mock
-    let captured = LockIsolated<(sessionId: String, template: String?)?>(nil)
-    let service = MockSessionService(fetchToken: { sessionId, template in
-      captured.setValue((sessionId: sessionId, template: template))
+    let captured = LockIsolated<(sessionId: String, template: String?, skipCache: Bool)?>(nil)
+    let service = MockSessionService(fetchToken: { sessionId, template, skipCache in
+      captured.setValue((sessionId: sessionId, template: template, skipCache: skipCache))
       return .mock
     })
 
@@ -44,6 +44,31 @@ struct SessionTokenFetcherTests {
     let values = try #require(captured.value)
     #expect(values.sessionId == session.id)
     #expect(values.template == scenario.template)
+    #expect(values.skipCache)
+  }
+
+  @Test
+  func fetchTokenForwardsSkipCacheFalse() async throws {
+    let session = Session.mock
+    let captured = LockIsolated<Bool?>(nil)
+    let service = MockSessionService(fetchToken: { _, _, skipCache in
+      captured.setValue(skipCache)
+      return .mock
+    })
+
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    await SessionTokensCache.shared.clear()
+
+    _ = try await SessionTokenFetcher.shared.fetchToken(
+      session,
+      options: .init(template: UUID().uuidString, skipCache: false)
+    )
+
+    #expect(captured.value == false)
   }
 
   @Test
@@ -51,7 +76,7 @@ struct SessionTokenFetcherTests {
     let session = Session.mock
     let template = UUID().uuidString
     let tokenResource = TokenResource(jwt: "jwt_123")
-    let service = MockSessionService(fetchToken: { _, _ in
+    let service = MockSessionService(fetchToken: { _, _, _ in
       tokenResource
     })
 
@@ -69,5 +94,288 @@ struct SessionTokenFetcherTests {
       cacheKey: session.tokenCacheKey(template: template)
     )
     #expect(cachedToken == tokenResource)
+  }
+
+  @Test
+  func fetchTokenDropsCacheWriteWhenSessionIsInvalidatedMidFlight() async throws {
+    let session = Session.mock
+    await SessionTokensCache.shared.clear()
+
+    let service = MockSessionService(fetchToken: { sessionId, _, _ in
+      // Stands in for a sign-out or org switch landing while the request is in flight.
+      await SessionTokensCache.shared.removeTokens(sessionId: sessionId)
+      return .init(jwt: "stale_jwt")
+    })
+
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    _ = try await SessionTokenFetcher.shared.fetchToken(session, options: .init(skipCache: true))
+
+    #expect(await SessionTokensCache.shared.getToken(cacheKey: session.tokenCacheKey(template: nil)) == nil)
+  }
+
+  @Test
+  func skipCacheRequestDoesNotJoinAnInFlightNormalRequest() async throws {
+    let session = Session.mock
+    await SessionTokensCache.shared.clear()
+
+    let observedSkipCache = LockIsolated<[Bool]>([])
+    let release = LockIsolated(false)
+    let service = MockSessionService(fetchToken: { _, _, skipCache in
+      observedSkipCache.withValue { $0.append(skipCache) }
+      while !release.value {
+        try? await Task.sleep(for: .milliseconds(5))
+      }
+      return .mock
+    })
+
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let normalRequest = Task { @MainActor in
+      try await SessionTokenFetcher.shared.getToken(session, options: .init(skipCache: false))
+    }
+    try await waitUntil { observedSkipCache.value.count == 1 }
+
+    let forcedRequest = Task { @MainActor in
+      try await SessionTokenFetcher.shared.getToken(session, options: .init(skipCache: true))
+    }
+
+    do {
+      try await waitUntil { observedSkipCache.value.count == 2 }
+    } catch {
+      release.setValue(true)
+      _ = try? await normalRequest.value
+      _ = try? await forcedRequest.value
+      Issue.record("skipCache request joined the in-flight request instead of forcing origin")
+      return
+    }
+
+    release.setValue(true)
+    _ = try await normalRequest.value
+    _ = try await forcedRequest.value
+
+    #expect(observedSkipCache.value.contains(false))
+    #expect(observedSkipCache.value.contains(true))
+  }
+
+  @Test
+  func normalRequestForDelimiterTemplateDoesNotJoinAForcedRequestForAnotherTemplate() async throws {
+    let session = Session.mock
+    await SessionTokensCache.shared.clear()
+
+    // A forced request for template "foo" and a normal request for a template literally
+    // named "foo|force" would collide if the dedupe key concatenated a "|force" delimiter.
+    let observed = LockIsolated<[(template: String?, skipCache: Bool)]>([])
+    let release = LockIsolated(false)
+    let service = MockSessionService(fetchToken: { _, template, skipCache in
+      observed.withValue { $0.append((template: template, skipCache: skipCache)) }
+      while !release.value {
+        try? await Task.sleep(for: .milliseconds(5))
+      }
+      return .mock
+    })
+
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      sessionService: service
+    )
+
+    let forcedRequest = Task { @MainActor in
+      try await SessionTokenFetcher.shared.getToken(session, options: .init(template: "foo", skipCache: true))
+    }
+    try await waitUntil { observed.value.count == 1 }
+
+    let normalRequest = Task { @MainActor in
+      try await SessionTokenFetcher.shared.getToken(session, options: .init(template: "foo|force", skipCache: false))
+    }
+
+    do {
+      try await waitUntil { observed.value.count == 2 }
+    } catch {
+      release.setValue(true)
+      _ = try? await forcedRequest.value
+      _ = try? await normalRequest.value
+      Issue.record("Requests with colliding delimiter keys joined the same task")
+      return
+    }
+
+    release.setValue(true)
+    _ = try await forcedRequest.value
+    _ = try await normalRequest.value
+
+    #expect(observed.value.contains { $0.template == "foo" && $0.skipCache })
+    #expect(observed.value.contains { $0.template == "foo|force" && !$0.skipCache })
+  }
+
+  private func waitUntil(
+    timeout: Duration = .seconds(2),
+    _ condition: () -> Bool
+  ) async throws {
+    enum TimeoutError: Error {
+      case timedOut
+    }
+
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+      if condition() {
+        return
+      }
+      try await Task.sleep(for: .milliseconds(10))
+    }
+
+    if !condition() {
+      throw TimeoutError.timedOut
+    }
+  }
+}
+
+struct SessionTokensCacheTests {
+  private func jwt(oiat: Int?, iat: Int?) -> TokenResource {
+    var header: [String: Any] = ["alg": "RS256", "typ": "JWT"]
+    if let oiat {
+      header["oiat"] = oiat
+    }
+    var payload: [String: Any] = ["sid": "sess_1"]
+    if let iat {
+      payload["iat"] = iat
+    }
+
+    return .init(jwt: [base64URLEncodedJSON(header), base64URLEncodedJSON(payload), "signature"].joined(separator: "."))
+  }
+
+  private func base64URLEncodedJSON(_ object: [String: Any]) -> String {
+    let data = (try? JSONSerialization.data(withJSONObject: object)) ?? Data()
+    return data
+      .base64EncodedString()
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "=", with: "")
+  }
+
+  @Test
+  func insertTokenKeepsExistingTokenWhenIncomingOiatIsOlder() async {
+    let cache = SessionTokensCache()
+    let existing = jwt(oiat: 2000, iat: 2000)
+    let incoming = jwt(oiat: 1000, iat: 3000)
+
+    await cache.insertToken(existing, cacheKey: "sess_1")
+    await cache.insertToken(incoming, cacheKey: "sess_1")
+
+    #expect(await cache.getToken(cacheKey: "sess_1") == existing)
+  }
+
+  @Test
+  func insertTokenReplacesExistingTokenWhenIncomingOiatIsNewer() async {
+    let cache = SessionTokensCache()
+    let existing = jwt(oiat: 1000, iat: 1000)
+    let incoming = jwt(oiat: 2000, iat: 2000)
+
+    await cache.insertToken(existing, cacheKey: "sess_1")
+    await cache.insertToken(incoming, cacheKey: "sess_1")
+
+    #expect(await cache.getToken(cacheKey: "sess_1") == incoming)
+  }
+
+  @Test
+  func insertTokenBreaksEqualOiatTiesWithIssuedAt() async {
+    let cache = SessionTokensCache()
+    let existing = jwt(oiat: 1000, iat: 2000)
+    let stale = jwt(oiat: 1000, iat: 1000)
+    let fresh = jwt(oiat: 1000, iat: 3000)
+
+    await cache.insertToken(existing, cacheKey: "sess_1")
+    await cache.insertToken(stale, cacheKey: "sess_1")
+    #expect(await cache.getToken(cacheKey: "sess_1") == existing)
+
+    await cache.insertToken(fresh, cacheKey: "sess_1")
+    #expect(await cache.getToken(cacheKey: "sess_1") == fresh)
+  }
+
+  @Test
+  func insertTokenKeepsExistingTokenWhenIncomingHasNoOiat() async {
+    let cache = SessionTokensCache()
+    let existing = jwt(oiat: 1000, iat: 1000)
+    let incoming = jwt(oiat: nil, iat: 3000)
+
+    await cache.insertToken(existing, cacheKey: "sess_1")
+    await cache.insertToken(incoming, cacheKey: "sess_1")
+
+    #expect(await cache.getToken(cacheKey: "sess_1") == existing)
+  }
+
+  @Test
+  func insertTokenOverwritesWhenNeitherTokenHasOiat() async {
+    let cache = SessionTokensCache()
+    let existing = TokenResource(jwt: "jwt_123")
+    let incoming = TokenResource(jwt: "jwt_456")
+
+    await cache.insertToken(existing, cacheKey: "sess_1")
+    await cache.insertToken(incoming, cacheKey: "sess_1")
+
+    #expect(await cache.getToken(cacheKey: "sess_1") == incoming)
+  }
+
+  @Test
+  func insertTokenDropsWritesFromBeforeRemoveTokens() async {
+    let cache = SessionTokensCache()
+    let generation = await cache.generation(sessionId: "sess_1")
+
+    await cache.removeTokens(sessionId: "sess_1")
+    await cache.insertToken(.init(jwt: "stale"), cacheKey: "sess_1", generation: generation)
+
+    #expect(await cache.getToken(cacheKey: "sess_1") == nil)
+  }
+
+  @Test
+  func insertTokenDropsWritesFromBeforeClear() async {
+    let cache = SessionTokensCache()
+    let generation = await cache.generation(sessionId: "sess_1")
+
+    await cache.clear()
+    await cache.insertToken(.init(jwt: "stale"), cacheKey: "sess_1", generation: generation)
+
+    #expect(await cache.getToken(cacheKey: "sess_1") == nil)
+  }
+
+  @Test
+  func insertTokenKeepsWritesFromTheCurrentGeneration() async {
+    let cache = SessionTokensCache()
+    await cache.removeTokens(sessionId: "sess_1")
+    let generation = await cache.generation(sessionId: "sess_1")
+
+    await cache.insertToken(.init(jwt: "fresh"), cacheKey: "sess_1", generation: generation)
+
+    #expect(await cache.getToken(cacheKey: "sess_1")?.jwt == "fresh")
+  }
+
+  @Test
+  func insertTokenIsNotFencedByAnotherSessionsInvalidation() async {
+    let cache = SessionTokensCache()
+    let generation = await cache.generation(sessionId: "sess_1")
+
+    await cache.removeTokens(sessionId: "sess_2")
+    await cache.insertToken(.init(jwt: "fresh"), cacheKey: "sess_1", generation: generation)
+
+    #expect(await cache.getToken(cacheKey: "sess_1")?.jwt == "fresh")
+  }
+
+  @Test
+  func removeTokensClearsEveryTokenForTheSession() async {
+    let cache = SessionTokensCache()
+    await cache.insertToken(.init(jwt: "default"), cacheKey: "sess_1")
+    await cache.insertToken(.init(jwt: "template"), cacheKey: "sess_1-firebase")
+    await cache.insertToken(.init(jwt: "other"), cacheKey: "sess_12")
+
+    await cache.removeTokens(sessionId: "sess_1")
+
+    #expect(await cache.getToken(cacheKey: "sess_1") == nil)
+    #expect(await cache.getToken(cacheKey: "sess_1-firebase") == nil)
+    #expect(await cache.getToken(cacheKey: "sess_12")?.jwt == "other")
   }
 }

--- a/Tests/Domains/Environment/AuthConfigDecodingTests.swift
+++ b/Tests/Domains/Environment/AuthConfigDecodingTests.swift
@@ -1,0 +1,23 @@
+@testable import ClerkKit
+import Foundation
+import Testing
+
+struct AuthConfigDecodingTests {
+  private let decoder = JSONDecoder.clerkDecoder
+
+  @Test
+  func sessionMinterDefaultsToFalseWhenKeyIsMissing() throws {
+    let data = Data("{ \"single_session_mode\": false }".utf8)
+    let authConfig = try decoder.decode(Clerk.Environment.AuthConfig.self, from: data)
+
+    #expect(authConfig.sessionMinter == false)
+  }
+
+  @Test
+  func sessionMinterDecodesFromSnakeCaseKey() throws {
+    let data = Data("{ \"single_session_mode\": false, \"session_minter\": true }".utf8)
+    let authConfig = try decoder.decode(Clerk.Environment.AuthConfig.self, from: data)
+
+    #expect(authConfig.sessionMinter == true)
+  }
+}


### PR DESCRIPTION
Why

Native apps will feed their previous session token to Clerk's edge Session Minter, which mints the next token from it instead of reading the origin database. For the edge to mint, the SDK has to send that previous token, and today the tokens request is a bodyless POST that sends nothing the edge can use. This is the iOS side of adding native Session Minter support.

What changed

The tokens request attaches the previous session token as a token form field and maps skipCache to force_origin=true, both only when the environment's auth_config.session_minter flag is on, so the request is unchanged for instances that are not enrolled and for the templated route. The seed is the cached token for the session, falling back to the persisted lastActiveToken on a cold launch, and is never sent empty.

Because the previous token is now the input to the next mint, a stale local token no longer self-corrects. The token cache is made monotonic (an older oiat, or an unreadable JWT, never overwrites a newer entry, matching clerk-js pickFreshestJwt), the cached token is invalidated on sign-out and org switch so a stale seed cannot carry the old scope forward, and a per-session generation fence drops a late in-flight write that lands after an invalidation. Concurrent getToken dedupe keys on whether the caller forced origin, so a skipCache call can no longer be answered from cache. The seed is kept out of verbose body logs.

Related

Part of a four-PR set adding native Session Minter support: the edge worker is [clerk/cloudflare-workers#2509](https://github.com/clerk/cloudflare-workers/pull/2509), the web/Expo SDK is [clerk/javascript#9284](https://github.com/clerk/javascript/pull/9284), and clerk-android lands alongside.

Local lint (SwiftLint) and the ClerkKitUI targets could not run in this environment (no Xcode); ClerkKit builds and the full unit suite is green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Session Minter support to the token fetch path
> - Non-template token requests now include a minter body with a seed token (`lastActiveToken.jwt` or cached default token) and a `force_origin` flag when `authConfig.sessionMinter` is true; body logging is suppressed when a seed token is present.
> - `SessionTokensCache` gains session-scoped invalidation via generation fencing: stale writes (from requests started before a `removeTokens` or `clear`) are dropped, and concurrent writes prefer the fresher token using `oiat`/`iat` JWT headers.
> - `skipCache` requests use a separate deduplication key in `SessionTokenFetcher` so they never coalesce with in-flight non-forced requests for the same cache key.
> - Sign-out and set-active now invalidate cached tokens for the affected session(s), including in error paths.
> - `Clerk.Environment.AuthConfig` gains a `sessionMinter` Bool decoded from `session_minter`, defaulting to `false`.
> - Behavioral Change: `SessionServiceProtocol.fetchToken` now requires a `skipCache: Bool` parameter; all callers including mocks must be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5fb4104. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->