### PR TITLE
Add navigationPath support to AuthView

### DIFF
--- a/Sources/ClerkKitUI/Components/Auth/AuthNavigation.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthNavigation.swift
@@ -17,13 +17,49 @@ import SwiftUI
 @Observable
 final class AuthNavigation {
   /// The navigation path for the auth flow.
-  var path: [AuthView.Destination] = []
+  var path: [AuthView.Destination] = [] {
+    didSet { mirrorToExternalPath(previousCount: oldValue.count) }
+  }
 
   /// Set to `true` when a session task flow completes and auth navigation should continue.
   private(set) var allTasksComplete = false
 
+  /// The parent `NavigationPath` the auth flow pushes onto when embedded in a host-owned
+  /// `NavigationStack`, and the number of host entries beneath the auth flow's segment.
+  @ObservationIgnored private var externalPath: Binding<NavigationPath>?
+  @ObservationIgnored private var externalBaseCount = 0
+  @ObservationIgnored private var isSyncingFromExternal = false
+
   /// Creates a new AuthNavigation instance.
   init() {}
+
+  /// Mirrors ``path`` into a host-owned `NavigationPath`, keeping the host's own entries
+  /// beneath the auth flow's segment untouched.
+  func attachExternalPath(_ binding: Binding<NavigationPath>) {
+    externalPath = binding
+    externalBaseCount = binding.wrappedValue.count
+    mirrorToExternalPath(previousCount: 0)
+  }
+
+  /// Trims ``path`` after the host popped entries directly (back button, gesture).
+  func externalPathDidChange() {
+    guard let externalPath else { return }
+    let externalDepth = max(externalPath.wrappedValue.count - externalBaseCount, 0)
+    guard externalDepth < path.count else { return }
+    isSyncingFromExternal = true
+    path.removeLast(path.count - externalDepth)
+    isSyncingFromExternal = false
+  }
+
+  private func mirrorToExternalPath(previousCount: Int) {
+    guard let externalPath, !isSyncingFromExternal else { return }
+    var newValue = externalPath.wrappedValue
+    newValue.removeLast(min(previousCount, max(newValue.count - externalBaseCount, 0)))
+    for destination in path {
+      newValue.append(destination)
+    }
+    externalPath.wrappedValue = newValue
+  }
 
   /// Updates the navigation path based on the current sign-in status.
   ///

--- a/Sources/ClerkKitUI/Components/Auth/AuthView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthView.swift
@@ -99,6 +99,7 @@ public struct AuthView: View {
   }
 
   let isDismissible: Bool
+  private let navigationPath: Binding<NavigationPath>?
 
   /// Creates a new authentication view.
   ///
@@ -110,43 +111,51 @@ public struct AuthView: View {
   ///     dismisses on successful authentication. When `false`, no dismiss
   ///     button is shown. Interactive presentation dismissal is always disabled.
   ///     Defaults to `true`.
-  public init(mode: Mode = .signInOrUp, isDismissible: Bool = true) {
-    self.init(mode: mode, isDismissible: isDismissible, config: AuthConfig())
+  ///   - navigationPath: An optional binding to a parent `NavigationPath`. When provided,
+  ///   the view skips creating its own `NavigationStack` and pushes the auth flow's steps
+  ///   onto the parent's path instead. Use this when embedding `AuthView` inside your own
+  ///   `NavigationStack` to avoid nested navigation stacks; the flow pops its own steps
+  ///   when authentication completes. Defaults to `nil`.
+  public init(
+    mode: Mode = .signInOrUp,
+    isDismissible: Bool = true,
+    navigationPath: Binding<NavigationPath>? = nil
+  ) {
+    self.init(
+      mode: mode,
+      isDismissible: isDismissible,
+      navigationPath: navigationPath,
+      config: AuthConfig()
+    )
   }
 
   init(
     mode: Mode,
     isDismissible: Bool,
+    navigationPath: Binding<NavigationPath>? = nil,
     config: AuthConfig
   ) {
     _authState = State(initialValue: AuthState(mode: mode, config: config))
     self.isDismissible = isDismissible
+    self.navigationPath = navigationPath
     self.config = config
   }
 
   public var body: some View {
-    NavigationStack(path: $navigation.path) {
-      AuthStartView()
-        #if os(iOS)
-        .toolbar {
-          dismissToolbarItem
+    Group {
+      if let navigationPath {
+        authContent
+          .onFirstAppear {
+            navigation.attachExternalPath(navigationPath)
+          }
+          .onChange(of: navigationPath.wrappedValue.count) {
+            navigation.externalPathDidChange()
+          }
+      } else {
+        NavigationStack(path: $navigation.path) {
+          authContent
         }
-        #endif
-        .embeddedNavigationBarHidden()
-        .navigationDestination(for: Destination.self) {
-          $0.view
-            #if os(iOS)
-            .toolbar {
-              dismissToolbarItem
-            }
-            #endif
-            .embeddedNavigationBarHidden()
-            .authFooter(macOSDismissAction: showDismissButton ? { dismiss() } : nil)
-            .environment(navigation)
-            .environment(authState)
-            .environment(codeLimiter)
-        }
-        .authFooter(macOSDismissAction: showDismissButton ? { dismiss() } : nil)
+      }
     }
     .background(theme.colors.background)
     .presentationBackground(theme.colors.background)
@@ -206,8 +215,14 @@ public struct AuthView: View {
           let becameActive = newValue?.status == .active && (oldValue?.status != .active || oldValue?.id != newValue?.id)
           let isHandlingSessionTask = navigation.hasSessionTaskStartInPath
           let sessionSwitched = oldValue?.id != newValue?.id
-          if becameActive, isDismissible, !isHandlingSessionTask || sessionSwitched {
-            dismiss()
+          if becameActive, !isHandlingSessionTask || sessionSwitched {
+            if navigationPath != nil {
+              // Embedded in a host-owned stack: pop the flow's own steps; the host
+              // reacts to the auth state change itself.
+              navigation.path = []
+            } else if isDismissible {
+              dismiss()
+            }
           }
         default:
           break
@@ -216,7 +231,9 @@ public struct AuthView: View {
     }
     .onChange(of: navigation.allTasksComplete) { _, isComplete in
       guard isComplete else { return }
-      if isDismissible {
+      if navigationPath != nil {
+        navigation.path = []
+      } else if isDismissible {
         dismiss()
       }
     }
@@ -258,6 +275,32 @@ public struct AuthView: View {
 }
 
 extension AuthView {
+  /// The auth flow's screens and destination registrations, shared by the self-contained
+  /// `NavigationStack` and host-owned (`navigationPath:`) rendering modes.
+  private var authContent: some View {
+    AuthStartView()
+      #if os(iOS)
+      .toolbar {
+        dismissToolbarItem
+      }
+      #endif
+      .embeddedNavigationBarHidden()
+      .navigationDestination(for: Destination.self) {
+        $0.view
+          #if os(iOS)
+          .toolbar {
+            dismissToolbarItem
+          }
+          #endif
+          .embeddedNavigationBarHidden()
+          .authFooter(macOSDismissAction: showDismissButton ? { dismiss() } : nil)
+          .environment(navigation)
+          .environment(authState)
+          .environment(codeLimiter)
+      }
+      .authFooter(macOSDismissAction: showDismissButton ? { dismiss() } : nil)
+  }
+
   /// Whether the dismiss button should be shown, accounting for required session tasks.
   private var showDismissButton: Bool {
     isDismissible && !navigation.hasSessionTaskStartInPath

--- a/Tests/UI/AuthNavigationExternalPathTests.swift
+++ b/Tests/UI/AuthNavigationExternalPathTests.swift
@@ -1,0 +1,83 @@
+@testable import ClerkKitUI
+import SwiftUI
+import Testing
+
+@MainActor
+struct AuthNavigationExternalPathTests {
+  private final class PathBox {
+    var path = NavigationPath()
+  }
+
+  private func makeBinding(_ box: PathBox) -> Binding<NavigationPath> {
+    Binding(get: { box.path }, set: { box.path = $0 })
+  }
+
+  @Test
+  func pushesMirrorOntoExternalPathAboveHostEntries() {
+    let box = PathBox()
+    box.path.append("host-screen")
+    let navigation = AuthNavigation()
+    navigation.attachExternalPath(makeBinding(box))
+
+    navigation.path.append(.signInForgotPassword)
+    navigation.path.append(.signInSetNewPassword)
+
+    #expect(box.path.count == 3)
+  }
+
+  @Test
+  func popsMirrorOntoExternalPath() {
+    let box = PathBox()
+    box.path.append("host-screen")
+    let navigation = AuthNavigation()
+    navigation.attachExternalPath(makeBinding(box))
+    navigation.path.append(.signInForgotPassword)
+    navigation.path.append(.signInSetNewPassword)
+
+    navigation.path.removeLast()
+
+    #expect(box.path.count == 2)
+  }
+
+  @Test
+  func clearingPathRemovesOnlyTheAuthSegment() {
+    let box = PathBox()
+    box.path.append("host-screen")
+    let navigation = AuthNavigation()
+    navigation.attachExternalPath(makeBinding(box))
+    navigation.path.append(.signInForgotPassword)
+
+    navigation.path = []
+
+    #expect(box.path.count == 1)
+  }
+
+  @Test
+  func externalPopTrimsTypedPath() {
+    let box = PathBox()
+    box.path.append("host-screen")
+    let navigation = AuthNavigation()
+    navigation.attachExternalPath(makeBinding(box))
+    navigation.path.append(.signInForgotPassword)
+    navigation.path.append(.signInSetNewPassword)
+
+    // Host back button pops the top entry directly.
+    box.path.removeLast()
+    navigation.externalPathDidChange()
+
+    #expect(navigation.path == [.signInForgotPassword])
+    #expect(box.path.count == 2)
+  }
+
+  @Test
+  func attachingWithExistingStepsMirrorsThem() {
+    let box = PathBox()
+    box.path.append("host-screen")
+    let navigation = AuthNavigation()
+    navigation.path.append(.signInForgotPassword)
+
+    navigation.attachExternalPath(makeBinding(box))
+
+    #expect(box.path.count == 2)
+  }
+}


### PR DESCRIPTION
## Problem

`UserProfileView` can be embedded in a host-owned `NavigationStack` via its public `navigationPath:` initializer, but `AuthView` has no equivalent — the only embedding option is the framework-integration SPI from #519, which native apps shouldn't use.

## What this adds

The same public option, same shape:

```swift
NavigationStack(path: $path) {
  HomeView()
    .navigationDestination(for: AppRoute.self) { route in
      switch route {
      case .signIn:
        AuthView(isDismissible: false, navigationPath: $path)
      }
    }
}
```

`AuthNavigation.path` stays the typed source of truth (internal reads like `hasSessionTaskStartInPath` keep working) and mirrors into the host's type-erased `NavigationPath`: pushes and pops replace only the flow's own segment above the host's entries, and a host-initiated pop (back button, gesture) trims the typed path to match. When authentication or the last session task completes in this mode, the flow pops its own steps instead of calling `dismiss()`, and the host reacts to the auth state change itself.

Self-contained usage is unchanged: without `navigationPath`, the same content renders inside `AuthView`'s own `NavigationStack` exactly as before.

Based on #519; the mirror logic is covered by the new `AuthNavigationExternalPathTests` (88 tests in the suite pass, `make format-check` and `make lint` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `navigationPath` support to `AuthView` for embedding in an existing `NavigationStack`
> - `AuthView` now accepts an optional `Binding<NavigationPath>` parameter; when provided, it skips creating its own `NavigationStack` and pushes auth steps onto the host's path instead.
> - `AuthNavigation` gains `attachExternalPath`, `externalPathDidChange`, and `mirrorToExternalPath` methods to keep the internal and external paths in sync, preserving host-owned entries.
> - On completion or session activation in embedded mode, the auth steps are cleared from the navigation path rather than triggering a modal dismiss.
> - External back navigations (e.g. swipe-to-pop) trim the internal auth path to stay consistent with the host stack depth.
> - New tests in [AuthNavigationExternalPathTests.swift](https://github.com/clerk/clerk-ios/pull/536/files#diff-b51830f73e49fcb947fc943b4d4a875eab28349be0bff60ecf2c1baae2118222) cover push/pop mirroring, clearing, and attach-with-existing-steps scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b21e90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->