### PR TITLE
Fix passkey authorization error handling

### DIFF
--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfilePasskeySection.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfilePasskeySection.swift
@@ -6,6 +6,7 @@
 #if os(iOS) || os(macOS)
 
 import ClerkKit
+import Foundation
 import SwiftUI
 
 struct UserProfilePasskeySection: View {
@@ -53,7 +54,11 @@ extension UserProfilePasskeySection {
     } catch {
       if error.isUserCancelledError { return }
       self.error = error
-      ClerkLogger.error("Failed to create passkey", error: error)
+      let nsError = error as NSError
+      ClerkLogger.error(
+        "Failed to create passkey (phase: passkey_registration, domain: \(nsError.domain), code: \(nsError.code))",
+        error: error
+      )
     }
   }
 }

--- a/Sources/ClerkKitUI/Extensions/Error+Ext.swift
+++ b/Sources/ClerkKitUI/Extensions/Error+Ext.swift
@@ -12,8 +12,9 @@ extension Error {
   var isUserCancelledError: Bool {
     if case ASWebAuthenticationSessionError.canceledLogin = self { return true }
 
-    if let authError = self as? ASAuthorizationError, authError.errorUserInfo["NSLocalizedFailureReason"] == nil {
-      return true
+    let nsError = self as NSError
+    if nsError.domain == ASAuthorizationError.errorDomain {
+      return nsError.code == ASAuthorizationError.Code.canceled.rawValue
     }
 
     return false

--- a/Tests/UI/UserCancellationErrorTests.swift
+++ b/Tests/UI/UserCancellationErrorTests.swift
@@ -1,0 +1,120 @@
+#if os(iOS) || os(macOS)
+
+import AuthenticationServices
+@testable import ClerkKitUI
+import Foundation
+import Testing
+
+struct UserCancellationErrorTests {
+  @Test(arguments: AuthorizationErrorInput.all)
+  func canceledAuthorizationErrorIsUserCancellation(
+    input: AuthorizationErrorInput
+  ) {
+    let error = authorizationError(
+      code: ASAuthorizationError.Code.canceled.rawValue,
+      input: input
+    )
+
+    #expect(error.isUserCancelledError)
+  }
+
+  @Test(
+    arguments: AuthorizationErrorScenario.nonCancellationErrors,
+    AuthorizationErrorInput.all
+  )
+  func nonCanceledAuthorizationErrorIsNotUserCancellation(
+    scenario: AuthorizationErrorScenario,
+    input: AuthorizationErrorInput
+  ) {
+    let error = authorizationError(
+      code: scenario.code,
+      input: input
+    )
+
+    #expect(!error.isUserCancelledError)
+  }
+
+  @Test
+  func canceledWebAuthenticationSessionIsUserCancellation() {
+    let error = ASWebAuthenticationSessionError(.canceledLogin)
+
+    #expect(error.isUserCancelledError)
+  }
+
+  @Test
+  func taskCancellationIsNotUserCancellation() {
+    let error = CancellationError()
+
+    #expect(!error.isUserCancelledError)
+    #expect(error.isCancellationError)
+  }
+
+  private func authorizationError(
+    code: Int,
+    input: AuthorizationErrorInput
+  ) -> any Error {
+    let userInfo: [String: Any] = if input.includesFailureReason {
+      [NSLocalizedFailureReasonErrorKey: "Failure reason"]
+    } else {
+      [:]
+    }
+    let nsError = NSError(
+      domain: ASAuthorizationError.errorDomain,
+      code: code,
+      userInfo: userInfo
+    )
+
+    switch input.representation {
+    case .typed:
+      return ASAuthorizationError(_nsError: nsError)
+    case .nsError:
+      return nsError
+    }
+  }
+}
+
+struct AuthorizationErrorInput: CustomTestStringConvertible {
+  let representation: AuthorizationErrorRepresentation
+  let includesFailureReason: Bool
+
+  var testDescription: String {
+    "\(representation), includesFailureReason: \(includesFailureReason)"
+  }
+
+  static let all = AuthorizationErrorRepresentation.allCases.flatMap { representation in
+    [
+      AuthorizationErrorInput(representation: representation, includesFailureReason: false),
+      AuthorizationErrorInput(representation: representation, includesFailureReason: true),
+    ]
+  }
+}
+
+enum AuthorizationErrorRepresentation: CaseIterable {
+  case typed
+  case nsError
+}
+
+struct AuthorizationErrorScenario: CustomTestStringConvertible {
+  let name: String
+  let code: Int
+
+  var testDescription: String {
+    "\(name) (\(code))"
+  }
+
+  static let nonCancellationErrors = [
+    AuthorizationErrorScenario(name: "unknown", code: 1000),
+    AuthorizationErrorScenario(name: "invalidResponse", code: 1002),
+    AuthorizationErrorScenario(name: "notHandled", code: 1003),
+    AuthorizationErrorScenario(name: "failed", code: 1004),
+    AuthorizationErrorScenario(name: "notInteractive", code: 1005),
+    AuthorizationErrorScenario(name: "matchedExcludedCredential", code: 1006),
+    AuthorizationErrorScenario(name: "credentialImport", code: 1007),
+    AuthorizationErrorScenario(name: "credentialExport", code: 1008),
+    AuthorizationErrorScenario(name: "preferSignInWithApple", code: 1009),
+    AuthorizationErrorScenario(name: "deviceNotConfiguredForPasskeyCreation", code: 1010),
+    AuthorizationErrorScenario(name: "futureError", code: 1099),
+  ]
+}
+
+#endif


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix `Error.isUserCancelledError` to only match `ASAuthorizationError` with canceled code
- Replaces implicit logic in [`Error+Ext.swift`](https://github.com/clerk/clerk-ios/pull/537/files#diff-eeedd8c8528cfe8997ff0c8b1c2b9663163e294c95724acb1aaaa2dd9eb54c6b) that treated any `ASAuthorizationError` without a `NSLocalizedFailureReason` as user-cancelled; now explicitly checks that the `NSError` domain equals `ASAuthorizationError.errorDomain` and the code equals `.canceled`.
- Improves passkey creation error logging in [`UserProfilePasskeySection.swift`](https://github.com/clerk/clerk-ios/pull/537/files#diff-8cbdc676495069a7a786ec985d266238870972c13e3b8ff3b5e78c4a2fa2d351) to include a phase label plus the `NSError` domain and code.
- Adds a new test suite in [`UserCancellationErrorTests.swift`](https://github.com/clerk/clerk-ios/pull/537/files#diff-bcbb031fa2355bc7d3ee264a4ed1710dbb22c39b469802592e129a19fdce3185) covering both typed and `NSError` representations of `ASAuthorizationError` and `ASWebAuthenticationSessionError`.
- Behavioral Change: authorization errors other than `ASAuthorizationError.canceled` that previously silently swallowed failures as user cancellations will now propagate as real errors.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized a981579.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->