### PR TITLE
Sean/cleanup items

### DIFF
--- a/Examples/AirbnbClone/AirbnbClone/Features/Auth/Views/LoginView.swift
+++ b/Examples/AirbnbClone/AirbnbClone/Features/Auth/Views/LoginView.swift
@@ -45,6 +45,8 @@ struct LoginView: View {
           )
           .disabled(loadingSocialProvider != nil)
 
+          ErrorMessage(message: errorMessage)
+
           Spacer(minLength: 40)
         }
         .padding(.horizontal, 24)
@@ -74,6 +76,7 @@ struct LoginView: View {
       }
     }
     .tint(Color(.label))
+    .animation(.default, value: errorMessage)
     .task {
       for await event in clerk.auth.events {
         switch event {

--- a/Examples/AirbnbClone/AirbnbClone/Features/Profile/Views/HomeView.swift
+++ b/Examples/AirbnbClone/AirbnbClone/Features/Profile/Views/HomeView.swift
@@ -59,37 +59,7 @@ private struct ProfileHeaderView: View {
       Text("Profile")
         .font(.system(size: 34, weight: .bold))
         .foregroundStyle(.primary)
-
-      Spacer()
-
-      NotificationButton()
     }
-  }
-}
-
-// MARK: - NotificationButton
-
-private struct NotificationButton: View {
-  @Environment(\.colorScheme) private var colorScheme
-
-  var body: some View {
-    Button {} label: {
-      Image(systemName: "bell")
-        .font(.system(size: 18, weight: .medium))
-        .foregroundStyle(.primary)
-        .frame(width: 44, height: 44)
-        .background(Color(uiColor: .systemBackground))
-        .clipShape(.circle)
-        .overlay {
-          if colorScheme == .dark {
-            Circle()
-              .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
-          }
-        }
-        .shadow(color: .black.opacity(0.10), radius: 14, x: 0, y: 8)
-        .shadow(color: .black.opacity(0.05), radius: 5, x: 0, y: 2)
-    }
-    .buttonStyle(.plain)
   }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,9 @@ let package = Package(
       name: "ClerkKit",
       dependencies: [],
       path: "Sources/ClerkKit",
+      resources: [
+        .process("Resources"),
+      ],
       swiftSettings: [
         .enableUpcomingFeature("StrictConcurrency"),
       ]
@@ -60,6 +63,9 @@ let package = Package(
       path: "Tests",
       exclude: [
         "UI",
+      ],
+      resources: [
+        .process("Resources"),
       ],
       swiftSettings: [
         .enableUpcomingFeature("StrictConcurrency"),

--- a/Sources/ClerkKit/Core/Auth+Apple.swift
+++ b/Sources/ClerkKit/Core/Auth+Apple.swift
@@ -41,7 +41,7 @@ extension Auth {
     let credential = try await SignInWithAppleHelper.getAppleIdCredential(requestedScopes: requestedScopes)
 
     guard !credential.tokenString.isEmpty else {
-      throw ClerkClientError(message: "Unable to retrieve the Apple identity token.")
+      throw ClerkClientError(message: "Unable to retrieve the Apple identity token.", localizationBundle: .module)
     }
 
     return credential

--- a/Sources/ClerkKit/Core/Auth+HostedAuth.swift
+++ b/Sources/ClerkKit/Core/Auth+HostedAuth.swift
@@ -56,7 +56,7 @@ extension Auth {
     webAuthentication: HostedAuthWebAuthentication
   ) async throws -> Session {
     guard !Self.isHostedAuthInFlight else {
-      throw ClerkClientError(message: "A hosted authentication session is already in progress.")
+      throw ClerkClientError(message: "A hosted authentication session is already in progress.", localizationBundle: .module)
     }
     Self.isHostedAuthInFlight = true
     defer { Self.isHostedAuthInFlight = false }
@@ -99,7 +99,7 @@ extension Auth {
     try Task.checkCancellation()
     try runtime.validateStableRuntime()
     guard clerk.clientResponseGeneration == browserStartClientResponseGeneration else {
-      throw ClerkClientError(message: "Hosted auth completion could not update the current client.")
+      throw ClerkClientError(message: "Hosted auth completion could not update the current client.", localizationBundle: .module)
     }
 
     let response = try await hostedAuthService.redeem(params: HostedAuthRedeemParams(
@@ -111,26 +111,26 @@ extension Auth {
 
     if response.clientSyncContext.update == .explicitClear {
       try await clerk.identityController.applyNetworkResponse(response.clientSyncContext)
-      throw ClerkClientError(message: "Hosted auth completion could not update the current client.")
+      throw ClerkClientError(message: "Hosted auth completion could not update the current client.", localizationBundle: .module)
     }
 
     guard
       let returnedClient = response.client,
       returnedClient.sessions.contains(where: { $0.id == callback.createdSessionId })
     else {
-      throw ClerkClientError(message: "Hosted auth completion did not include the created session.")
+      throw ClerkClientError(message: "Hosted auth completion did not include the created session.", localizationBundle: .module)
     }
 
     guard
       response.clientSyncContext.clientResponseGeneration
         == browserStartClientResponseGeneration
     else {
-      throw ClerkClientError(message: "Hosted auth completion could not update the current client.")
+      throw ClerkClientError(message: "Hosted auth completion could not update the current client.", localizationBundle: .module)
     }
 
     try await clerk.identityController.applyNetworkResponse(response.clientSyncContext)
     guard clerk.client?.sessions.contains(where: { $0.id == callback.createdSessionId }) == true else {
-      throw ClerkClientError(message: "Hosted auth completion could not update the current client.")
+      throw ClerkClientError(message: "Hosted auth completion could not update the current client.", localizationBundle: .module)
     }
 
     try await activateSession(sessionId: callback.createdSessionId)
@@ -138,7 +138,7 @@ extension Auth {
       clerk.client?.lastActiveSessionId == callback.createdSessionId,
       let activeSession = clerk.client?.sessions.first(where: { $0.id == callback.createdSessionId })
     else {
-      throw ClerkClientError(message: "Hosted auth completion could not activate the created session.")
+      throw ClerkClientError(message: "Hosted auth completion could not activate the created session.", localizationBundle: .module)
     }
     return activeSession
   }

--- a/Sources/ClerkKit/Core/Auth.swift
+++ b/Sources/ClerkKit/Core/Auth.swift
@@ -128,7 +128,7 @@ public struct Auth {
   public func signInWithEmailLink(emailAddress: String) async throws -> SignIn {
     let identifier = emailAddress.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !identifier.isEmpty else {
-      throw ClerkClientError(message: "Email address is required.")
+      throw ClerkClientError(message: "Email address is required.", localizationBundle: .module)
     }
 
     let signIn = try await signInService.create(params: .init(identifier: identifier))
@@ -428,7 +428,7 @@ public struct Auth {
       let redirectUrl = verification.externalVerificationRedirectUrl,
       let url = URL(string: redirectUrl)
     else {
-      throw ClerkClientError(message: "Redirect URL is missing or invalid. Unable to start external authentication flow.")
+      throw ClerkClientError(message: "Redirect URL is missing or invalid. Unable to start external authentication flow.", localizationBundle: .module)
     }
 
     let authSession = WebAuthentication(
@@ -529,7 +529,7 @@ public struct Auth {
       let redirectUrl = verification.externalVerificationRedirectUrl,
       let url = URL(string: redirectUrl)
     else {
-      throw ClerkClientError(message: "Redirect URL is missing or invalid. Unable to start external authentication flow.")
+      throw ClerkClientError(message: "Redirect URL is missing or invalid. Unable to start external authentication flow.", localizationBundle: .module)
     }
 
     let authSession = WebAuthentication(
@@ -704,19 +704,19 @@ extension Auth {
     let resolvedApprovalToken = approvalToken.trimmingCharacters(in: .whitespacesAndNewlines)
 
     guard !resolvedFlowId.isEmpty else {
-      throw ClerkClientError(message: "Magic link callback is missing flow_id.")
+      throw ClerkClientError(message: "Magic link callback is missing flow_id.", localizationBundle: .module)
     }
 
     guard !resolvedApprovalToken.isEmpty else {
-      throw ClerkClientError(message: "Magic link callback is missing approval_token.")
+      throw ClerkClientError(message: "Magic link callback is missing approval_token.", localizationBundle: .module)
     }
 
     guard let pendingFlow = magicLinkStore.load() else {
-      throw ClerkClientError(message: "No pending magic link flow was found.")
+      throw ClerkClientError(message: "No pending magic link flow was found.", localizationBundle: .module)
     }
 
     if let expectedFlowId = pendingFlow.flowId, expectedFlowId != resolvedFlowId {
-      throw ClerkClientError(message: "Magic link callback does not match the pending flow.")
+      throw ClerkClientError(message: "Magic link callback does not match the pending flow.", localizationBundle: .module)
     }
 
     Clerk.shared.setCallbackContinuation(nil)
@@ -742,7 +742,7 @@ extension Auth {
     switch pendingFlow.kind {
     case .signIn:
       guard case .ticket(let completionResponse) = completionResult else {
-        throw ClerkClientError(message: "Magic link callback returned a sign-up for a sign-in flow.")
+        throw ClerkClientError(message: "Magic link callback returned a sign-up for a sign-in flow.", localizationBundle: .module)
       }
 
       let signIn = try await signInWithTicket(completionResponse.ticket)
@@ -754,7 +754,7 @@ extension Auth {
 
     case .signUp:
       guard case .signUp(let signUp) = completionResult else {
-        throw ClerkClientError(message: "Magic link callback returned a ticket for a sign-up flow.")
+        throw ClerkClientError(message: "Magic link callback returned a ticket for a sign-up flow.", localizationBundle: .module)
       }
 
       result = .signUp(signUp)

--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -559,9 +559,7 @@ extension Clerk {
     keychainStorage: any KeychainStorage
   ) throws -> Clerk {
     guard EnvironmentDetection.isRunningInTests else {
-      throw ClerkClientError(
-        message: "Isolated Clerk configuration is only available while running tests."
-      )
+      throw ClerkClientError(message: "Isolated Clerk configuration is only available while running tests.", localizationBundle: .module)
     }
 
     if let existing = _shared {
@@ -935,7 +933,7 @@ extension Clerk {
   @MainActor
   static func beginRuntimeReconfiguration() throws {
     guard !isRuntimeReconfigurationInProgress else {
-      throw ClerkClientError(message: "Clerk is already reconfiguring. Wait for the current reconfiguration to finish before starting another one.")
+      throw ClerkClientError(message: "Clerk is already reconfiguring. Wait for the current reconfiguration to finish before starting another one.", localizationBundle: .module)
     }
     isRuntimeReconfigurationInProgress = true
     _shared?.runtimeState.beginReconfiguration()
@@ -970,7 +968,7 @@ extension Clerk {
     }
 
     guard let shared = _shared else {
-      throw ClerkClientError(message: "Clerk must be configured before getting a session token.")
+      throw ClerkClientError(message: "Clerk must be configured before getting a session token.", localizationBundle: .module)
     }
 
     return shared.runtimeScope

--- a/Sources/ClerkKit/Dependencies/DependencyContainer.swift
+++ b/Sources/ClerkKit/Dependencies/DependencyContainer.swift
@@ -201,7 +201,8 @@ final class DependencyContainer: Dependencies {
             !usePersistentAdoptionState
       else {
         throw ClerkClientError(
-          message: "Injected Keychain storage cannot be used with persistent shared-session adoption."
+          message: "Injected Keychain storage cannot be used with persistent shared-session adoption.",
+          localizationBundle: .module
         )
       }
 
@@ -220,12 +221,14 @@ final class DependencyContainer: Dependencies {
     let syncEnabled = options.sharedSessionSync != nil
     if syncEnabled, config.normalizedAccessGroup == nil {
       throw ClerkClientError(
-        message: "Shared session sync requires a nonempty Keychain access group."
+        message: "Shared session sync requires a nonempty Keychain access group.",
+        localizationBundle: .module
       )
     }
     if syncEnabled, ownerIdentifier?.isEmpty != false {
       throw ClerkClientError(
-        message: "Shared session sync requires a nonempty application bundle identifier."
+        message: "Shared session sync requires a nonempty application bundle identifier.",
+        localizationBundle: .module
       )
     }
 

--- a/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
+++ b/Sources/ClerkKit/Domains/Auth/HostedAuth.swift
@@ -51,7 +51,7 @@ struct HostedAuthResource: Codable {
       let url = components.url,
       scheme == "https"
     else {
-      throw ClerkClientError(message: "Hosted auth creation returned an invalid response.")
+      throw ClerkClientError(message: "Hosted auth creation returned an invalid response.", localizationBundle: .module)
     }
     return url
   }
@@ -85,7 +85,7 @@ struct HostedAuthRedirect: Equatable {
       scheme.caseInsensitiveCompare("http") != .orderedSame,
       scheme.caseInsensitiveCompare("https") != .orderedSame
     else {
-      throw ClerkClientError(message: "Hosted auth requires a valid custom-scheme redirect URL.")
+      throw ClerkClientError(message: "Hosted auth requires a valid custom-scheme redirect URL.", localizationBundle: .module)
     }
 
     self.rawValue = rawValue
@@ -123,18 +123,18 @@ struct HostedAuthCallback: Equatable {
 
   init(url: URL, redirect: HostedAuthRedirect, state: String) throws {
     guard redirect.matches(url) else {
-      throw ClerkClientError(message: "Hosted auth callback URL did not match the initiated redirect URL.")
+      throw ClerkClientError(message: "Hosted auth callback URL did not match the initiated redirect URL.", localizationBundle: .module)
     }
 
     let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
     guard let callbackState = Self.nonEmptySingleValue(named: "state", in: queryItems), callbackState == state else {
-      throw ClerkClientError(message: "Hosted auth callback state was missing or did not match the initiated state.")
+      throw ClerkClientError(message: "Hosted auth callback state was missing or did not match the initiated state.", localizationBundle: .module)
     }
     guard let rotatingTokenNonce = Self.nonEmptySingleValue(named: "rotating_token_nonce", in: queryItems) else {
-      throw ClerkClientError(message: "Hosted auth callback did not include a rotating token nonce.")
+      throw ClerkClientError(message: "Hosted auth callback did not include a rotating token nonce.", localizationBundle: .module)
     }
     guard let createdSessionId = Self.nonEmptySingleValue(named: "created_session_id", in: queryItems) else {
-      throw ClerkClientError(message: "Hosted auth callback did not include the created session.")
+      throw ClerkClientError(message: "Hosted auth callback did not include the created session.", localizationBundle: .module)
     }
 
     self.rotatingTokenNonce = rotatingTokenNonce

--- a/Sources/ClerkKit/Domains/Auth/HostedAuthService.swift
+++ b/Sources/ClerkKit/Domains/Auth/HostedAuthService.swift
@@ -50,7 +50,8 @@ final class HostedAuthService: HostedAuthServiceProtocol {
     let response = try await apiClient.send(request)
     guard let clientSyncMetadata = response.deferredClientSyncMetadata else {
       throw ClerkClientError(
-        message: "Hosted auth completion response was missing identity synchronization metadata."
+        message: "Hosted auth completion response was missing identity synchronization metadata.",
+        localizationBundle: .module
       )
     }
     let client = response.value.response

--- a/Sources/ClerkKit/Domains/Auth/MagicLink.swift
+++ b/Sources/ClerkKit/Domains/Auth/MagicLink.swift
@@ -107,10 +107,10 @@ struct MagicLinkCallback: Equatable {
 
   init(url: URL) throws {
     guard let flowId = url.queryParam(named: Param.flowId.rawValue) else {
-      throw ClerkClientError(message: "Magic link callback is missing flow_id.")
+      throw ClerkClientError(message: "Magic link callback is missing flow_id.", localizationBundle: .module)
     }
     guard let approvalToken = url.queryParam(named: Param.approvalToken.rawValue) else {
-      throw ClerkClientError(message: "Magic link callback is missing approval_token.")
+      throw ClerkClientError(message: "Magic link callback is missing approval_token.", localizationBundle: .module)
     }
 
     self.flowId = flowId

--- a/Sources/ClerkKit/Domains/Auth/Session/Session+Verification.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/Session+Verification.swift
@@ -95,7 +95,7 @@ extension Session {
       let challengeString = nonceJSON["challenge"]?.stringValue,
       let challenge = challengeString.dataFromBase64URL()
     else {
-      throw ClerkClientError(message: "Unable to get the challenge for the passkey.")
+      throw ClerkClientError(message: "Unable to get the challenge for the passkey.", localizationBundle: .module)
     }
 
     let relyingPartyIdentifier = nonceJSON.webAuthnAssertionRelyingPartyIdentifier
@@ -112,7 +112,7 @@ extension Session {
       let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion,
       let authenticatorData = credentialAssertion.rawAuthenticatorData
     else {
-      throw ClerkClientError(message: "Invalid credential type.")
+      throw ClerkClientError(message: "Invalid credential type.", localizationBundle: .module)
     }
 
     let publicKeyCredential: [String: Any] = [

--- a/Sources/ClerkKit/Domains/Auth/SignIn/SignIn.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignIn/SignIn.swift
@@ -131,12 +131,12 @@ extension SignIn {
         ?? supportedFirstFactors?.first(where: { $0.strategy == .emailLink })?.emailAddressId
 
     guard let emailId else {
-      throw ClerkClientError(message: "Email link sign-in is not available for this sign-in.")
+      throw ClerkClientError(message: "Email link sign-in is not available for this sign-in.", localizationBundle: .module)
     }
 
     let resolvedRedirectUri = redirectUri ?? Clerk.shared.options.redirectConfig.redirectUrl
     guard !resolvedRedirectUri.isEmpty else {
-      throw ClerkClientError(message: "Redirect URI is missing. Unable to start email link sign-in.")
+      throw ClerkClientError(message: "Redirect URI is missing. Unable to start email link sign-in.", localizationBundle: .module)
     }
 
     let pkcePair = try PKCE.generatePair()
@@ -180,13 +180,11 @@ extension SignIn {
   @MainActor
   public func verifyCode(_ code: String) async throws -> SignIn {
     guard let resolvedStrategy = firstFactorVerification?.strategy else {
-      throw ClerkClientError(message: "Unable to verify code because no first factor strategy is set.")
+      throw ClerkClientError(message: "Unable to verify code because no first factor strategy is set.", localizationBundle: .module)
     }
 
     guard resolvedStrategy.canAttemptFirstFactorCode else {
-      throw ClerkClientError(
-        message: "Unable to verify code for strategy '\(resolvedStrategy.rawValue)'."
-      )
+      throw ClerkClientError(message: "Unable to verify code for strategy '\(resolvedStrategy.rawValue)'.", localizationBundle: .module)
     }
 
     return try await signInService.attemptFirstFactor(
@@ -282,7 +280,7 @@ extension SignIn {
     let credential = try await SignInWithAppleHelper.getAppleIdCredential(requestedScopes: requestedScopes)
 
     guard let idToken = credential.identityToken.flatMap({ String(data: $0, encoding: .utf8) }) else {
-      throw ClerkClientError(message: "Unable to retrieve the Apple identity token.")
+      throw ClerkClientError(message: "Unable to retrieve the Apple identity token.", localizationBundle: .module)
     }
 
     let signIn = try await authenticateWithIdToken(idToken, provider: .apple)
@@ -427,7 +425,7 @@ extension SignIn {
     guard let externalVerificationRedirectUrl = signIn.firstFactorVerification?.externalVerificationRedirectUrl,
           let url = URL(string: externalVerificationRedirectUrl)
     else {
-      throw ClerkClientError(message: "Redirect URL is missing or invalid. Unable to start external authentication flow.")
+      throw ClerkClientError(message: "Redirect URL is missing or invalid. Unable to start external authentication flow.", localizationBundle: .module)
     }
 
     let authSession = WebAuthentication(
@@ -475,7 +473,7 @@ extension SignIn {
     guard let externalVerificationRedirectUrl = signIn.firstFactorVerification?.externalVerificationRedirectUrl,
           let url = URL(string: externalVerificationRedirectUrl)
     else {
-      throw ClerkClientError(message: "Redirect URL is missing or invalid. Unable to start external authentication flow.")
+      throw ClerkClientError(message: "Redirect URL is missing or invalid. Unable to start external authentication flow.", localizationBundle: .module)
     }
 
     let authSession = WebAuthentication(
@@ -603,7 +601,7 @@ extension SignIn {
       let challengeString = nonceJSON["challenge"]?.stringValue,
       let challenge = challengeString.dataFromBase64URL()
     else {
-      throw ClerkClientError(message: "Unable to get the challenge for the passkey.")
+      throw ClerkClientError(message: "Unable to get the challenge for the passkey.", localizationBundle: .module)
     }
 
     let relyingPartyIdentifier = nonceJSON.webAuthnAssertionRelyingPartyIdentifier
@@ -639,7 +637,7 @@ extension SignIn {
       let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion,
       let authenticatorData = credentialAssertion.rawAuthenticatorData
     else {
-      throw ClerkClientError(message: "Invalid credential type.")
+      throw ClerkClientError(message: "Invalid credential type.", localizationBundle: .module)
     }
 
     let publicKeyCredential: [String: Any] = [

--- a/Sources/ClerkKit/Domains/Auth/SignUp/SignUp.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignUp/SignUp.swift
@@ -170,7 +170,7 @@ extension SignUp {
   public func sendEmailLink(redirectUri: String? = nil) async throws -> SignUp {
     let resolvedRedirectUri = redirectUri ?? Clerk.shared.options.redirectConfig.redirectUrl
     guard !resolvedRedirectUri.isEmpty else {
-      throw ClerkClientError(message: "Redirect URI is missing. Unable to start email link sign-up verification.")
+      throw ClerkClientError(message: "Redirect URI is missing. Unable to start email link sign-up verification.", localizationBundle: .module)
     }
 
     let pkcePair = try PKCE.generatePair()

--- a/Sources/ClerkKit/Domains/Common/ClerkClientError.swift
+++ b/Sources/ClerkKit/Domains/Common/ClerkClientError.swift
@@ -3,12 +3,32 @@
 //
 
 import Foundation
-import SwiftUI
 
 /// An object that represents an error created by Clerk on the client.
 public struct ClerkClientError: Error, LocalizedError, ClerkError {
+  private enum MessageStorage {
+    case localizationValue(String.LocalizationValue)
+    case localizedResource(LocalizedStringResource)
+  }
+
+  private var messageStorage: MessageStorage?
+
   /// A message that describes the error.
-  public var messageLocalizationValue: String.LocalizationValue?
+  public var messageLocalizationValue: String.LocalizationValue? {
+    get {
+      switch messageStorage {
+      case .localizationValue(let value):
+        value
+      case .localizedResource(let resource):
+        resource.defaultValue
+      case nil:
+        nil
+      }
+    }
+    set {
+      messageStorage = newValue.map(MessageStorage.localizationValue)
+    }
+  }
 
   /// Additional context about the error.
   public var context: [String: String]? {
@@ -17,12 +37,38 @@ public struct ClerkClientError: Error, LocalizedError, ClerkError {
 
   /// A human-readable error message.
   public var message: String? {
-    guard let messageLocalizationValue else { return nil }
-    return String(localized: messageLocalizationValue)
+    switch messageStorage {
+    case .localizationValue(let value):
+      String(localized: value)
+    case .localizedResource(let resource):
+      String(localized: resource)
+    case nil:
+      nil
+    }
   }
 
   public init(message: String.LocalizationValue? = nil) {
-    messageLocalizationValue = message
+    messageStorage = message.map(MessageStorage.localizationValue)
+  }
+
+  /// Creates an error whose message carries its localization bundle and locale.
+  public init(localizedMessage: LocalizedStringResource) {
+    messageStorage = .localizedResource(localizedMessage)
+  }
+
+  /// Creates an error whose message is localized using the provided bundle.
+  public init(
+    message: String.LocalizationValue,
+    localizationBundle: Bundle,
+    locale: Locale = .current
+  ) {
+    self.init(
+      localizedMessage: LocalizedStringResource(
+        message,
+        locale: locale,
+        bundle: localizationBundle
+      )
+    )
   }
 }
 

--- a/Sources/ClerkKit/Domains/Organization/OrganizationMembership.swift
+++ b/Sources/ClerkKit/Domains/Organization/OrganizationMembership.swift
@@ -136,7 +136,7 @@ extension OrganizationMembership {
   @discardableResult @MainActor
   public func destroy() async throws -> OrganizationMembership {
     guard let userId = publicUserData?.userId else {
-      throw ClerkClientError(message: "Unable to delete membership: missing userId")
+      throw ClerkClientError(message: "Unable to delete membership: missing userId", localizationBundle: .module)
     }
 
     return try await organizationService.destroyOrganizationMembership(organizationId: organization.id, userId: userId)
@@ -150,7 +150,7 @@ extension OrganizationMembership {
   @discardableResult @MainActor
   public func update(role: String) async throws -> OrganizationMembership {
     guard let userId = publicUserData?.userId else {
-      throw ClerkClientError(message: "Unable to update membership: missing userId")
+      throw ClerkClientError(message: "Unable to update membership: missing userId", localizationBundle: .module)
     }
 
     return try await organizationService.updateOrganizationMember(organizationId: organization.id, userId: userId, role: role)

--- a/Sources/ClerkKit/Domains/User/ExternalAccount/ExternalAccount.swift
+++ b/Sources/ClerkKit/Domains/User/ExternalAccount/ExternalAccount.swift
@@ -131,7 +131,7 @@ extension ExternalAccount {
       let redirectUrl = verification?.externalVerificationRedirectUrl,
       let url = URL(string: redirectUrl)
     else {
-      throw ClerkClientError(message: "Redirect URL is missing or invalid. Unable to start external authentication flow.")
+      throw ClerkClientError(message: "Redirect URL is missing or invalid. Unable to start external authentication flow.", localizationBundle: .module)
     }
 
     let authSession = WebAuthentication(
@@ -143,7 +143,7 @@ extension ExternalAccount {
 
     try await Clerk.shared.refreshClient()
     guard let externalAccount = Clerk.shared.user?.externalAccounts.first(where: { $0.id == id }) else {
-      throw ClerkClientError(message: "Something went wrong. Please try again.")
+      throw ClerkClientError(message: "Something went wrong. Please try again.", localizationBundle: .module)
     }
     return externalAccount
   }

--- a/Sources/ClerkKit/Domains/User/User.swift
+++ b/Sources/ClerkKit/Domains/User/User.swift
@@ -343,7 +343,7 @@ extension User {
     let credential = try await SignInWithAppleHelper.getAppleIdCredential(requestedScopes: requestedScopes)
 
     guard let idToken = credential.identityToken.flatMap({ String(data: $0, encoding: .utf8) }) else {
-      throw ClerkClientError(message: "Unable to retrieve the Apple identity token.")
+      throw ClerkClientError(message: "Unable to retrieve the Apple identity token.", localizationBundle: .module)
     }
 
     return try await createExternalAccount(provider: .apple, idToken: idToken)

--- a/Sources/ClerkKit/Domains/User/UserService.swift
+++ b/Sources/ClerkKit/Domains/User/UserService.swift
@@ -164,15 +164,15 @@ final class UserService: UserServiceProtocol {
     let passkey = try await passkeyService.create()
 
     guard let challenge = passkey.challenge else {
-      throw ClerkClientError(message: "Unable to get the challenge for the passkey.")
+      throw ClerkClientError(message: "Unable to get the challenge for the passkey.", localizationBundle: .module)
     }
 
     guard let name = passkey.username else {
-      throw ClerkClientError(message: "Unable to get the username for the passkey.")
+      throw ClerkClientError(message: "Unable to get the username for the passkey.", localizationBundle: .module)
     }
 
     guard let userId = passkey.userId else {
-      throw ClerkClientError(message: "Unable to get the user ID for the passkey.")
+      throw ClerkClientError(message: "Unable to get the user ID for the passkey.", localizationBundle: .module)
     }
 
     let manager = PasskeyHelper()
@@ -187,7 +187,7 @@ final class UserService: UserServiceProtocol {
       let credentialRegistration = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration,
       let rawAttestationObject = credentialRegistration.rawAttestationObject
     else {
-      throw ClerkClientError(message: "Invalid credential type.")
+      throw ClerkClientError(message: "Invalid credential type.", localizationBundle: .module)
     }
 
     let publicKeyCredential: [String: any Encodable] = [

--- a/Sources/ClerkKit/Helpers/AppAttestHelper.swift
+++ b/Sources/ClerkKit/Helpers/AppAttestHelper.swift
@@ -126,7 +126,7 @@ enum AppAttestHelper {
 
     let challenge = try await getChallenge()
     guard let clientId = await Clerk.shared.identityController.persistedClientID() else {
-      throw ClerkClientError(message: "Client ID is unavailble.", localizationBundle: .module)
+      throw ClerkClientError(message: "Client ID is unavailable.", localizationBundle: .module)
     }
     let payload = try JSONEncoder().encode(["client_id": clientId, "challenge": challenge])
     let assertion = try await createAssertion(payload: payload)

--- a/Sources/ClerkKit/Helpers/AppAttestHelper.swift
+++ b/Sources/ClerkKit/Helpers/AppAttestHelper.swift
@@ -126,7 +126,7 @@ enum AppAttestHelper {
 
     let challenge = try await getChallenge()
     guard let clientId = await Clerk.shared.identityController.persistedClientID() else {
-      throw ClerkClientError(message: "Client ID is unavailble.")
+      throw ClerkClientError(message: "Client ID is unavailble.", localizationBundle: .module)
     }
     let payload = try JSONEncoder().encode(["client_id": clientId, "challenge": challenge])
     let assertion = try await createAssertion(payload: payload)

--- a/Sources/ClerkKit/Helpers/SignInWithAppleHelper.swift
+++ b/Sources/ClerkKit/Helpers/SignInWithAppleHelper.swift
@@ -81,7 +81,7 @@ final class SignInWithAppleHelper: NSObject {
     let authorization = try await authManager.start(requestedScopes: requestedScopes)
 
     guard let appleIdCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
-      throw ClerkClientError(message: "Unable to get your Apple ID credential.")
+      throw ClerkClientError(message: "Unable to get your Apple ID credential.", localizationBundle: .module)
     }
 
     return appleIdCredential

--- a/Sources/ClerkKit/Resources/Localizable.xcstrings
+++ b/Sources/ClerkKit/Resources/Localizable.xcstrings
@@ -1,0 +1,100 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Redirect URL is missing or invalid. Unable to start external authentication flow." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عنوان URL لإعادة التوجيه مفقود أو غير صالح. لا يمكن بدء تدفق المصادقة الخارجية."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Weiterleitungs-URL fehlt oder ist ungültig. Es ist nicht möglich, die externe Authentifizierung zu starten."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η διεύθυνση URL ανακατεύθυνσης λείπει ή είναι άκυρη. Αδυναμία εκκίνησης της εξωτερικής ροής πιστοποίησης."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falta la URL de redirección o no es válida. No se puede iniciar el flujo de autenticación externa."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'URL de redirection est manquante ou invalide. Impossible de démarrer le flux d'authentification externe."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रिडायरेक्ट URL गायब है या अमान्य है। बाहरी प्रमाणीकरण प्रवाह शुरू करने में असमर्थ।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'URL di reindirizzamento è mancante o non valida. Impossibile avviare il flusso di autenticazione esterna."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リダイレクトURLが不足しているか無効です。外部認証フローを開始できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "리디렉션 URL이 없거나 유효하지 않습니다. 외부 인증 흐름을 시작할 수 없습니다。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brakuje adresu URL przekierowania lub jest on nieprawidłowy. Nie można uruchomić zewnętrznego przepływu uwierzytelniania."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL de redirecionamento está ausente ou inválida. Não foi possível iniciar o fluxo de autenticação externa."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adresa URL de redirecționare lipsește sau nu este validă. Nu se poate porni fluxul de autentificare externă."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL-адрес перенаправления отсутствует или недействителен. Не удалось запустить внешний поток аутентификации."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yönlendirme URL'si eksik veya geçersiz. Harici kimlik doğrulama akışı başlatılamıyor."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重定向 URL 缺失或无效。无法启动外部身份验证流程。"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.1"
+}

--- a/Sources/ClerkKit/Resources/Localizable.xcstrings
+++ b/Sources/ClerkKit/Resources/Localizable.xcstrings
@@ -1,6 +1,3108 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "A Watch identity metadata transition is still pending." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يزال انتقال بيانات تعريف هوية Watch معلقًا."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eine Metadatenübertragung der Watch-Identität steht noch aus."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Μια μετάβαση μεταδεδομένων ταυτότητας Watch παραμένει σε εκκρεμότητα."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todavía hay una transición de metadatos de identidad de Watch pendiente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une transition des métadonnées d’identité de la Watch est toujours en attente."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Watch पहचान मेटाडेटा का एक ट्रांज़िशन अभी भी लंबित है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Una transizione dei metadati dell’identità di Watch è ancora in sospeso."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WatchのIDメタデータの移行がまだ保留中です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Watch ID 메타데이터 전환이 아직 보류 중입니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przejście metadanych tożsamości Watch nadal oczekuje."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uma transição de metadados de identidade do Watch ainda está pendente."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O tranziție a metadatelor de identitate Watch este încă în așteptare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переход метаданных идентификации Watch всё ещё ожидает выполнения."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir Watch kimlik meta verisi geçişi hâlâ beklemede."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Watch 身份元数据转换仍处于待处理状态。"
+          }
+        }
+      }
+    },
+    "A hosted authentication session is already in progress." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هناك جلسة مصادقة مستضافة قيد التنفيذ بالفعل."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eine gehostete Authentifizierungssitzung läuft bereits."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Μια περίοδος λειτουργίας φιλοξενούμενου ελέγχου ταυτότητας βρίσκεται ήδη σε εξέλιξη."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ya hay una sesión de autenticación alojada en curso."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une session d’authentification hébergée est déjà en cours."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एक होस्टेड प्रमाणीकरण सत्र पहले से चल रहा है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "È già in corso una sessione di autenticazione ospitata."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト型認証セッションがすでに進行中です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스팅 인증 세션이 이미 진행 중입니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesja hostowanego uwierzytelniania jest już w toku."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uma sessão de autenticação hospedada já está em andamento."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O sesiune de autentificare găzduită este deja în desfășurare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сеанс размещенной аутентификации уже выполняется."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barındırılan bir kimlik doğrulama oturumu zaten devam ediyor."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已有托管身份验证会话正在进行。"
+          }
+        }
+      }
+    },
+    "A web authentication session is already in progress." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هناك جلسة مصادقة عبر الويب قيد التنفيذ بالفعل."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eine Web-Authentifizierungssitzung läuft bereits."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Μια περίοδος λειτουργίας ελέγχου ταυτότητας μέσω web βρίσκεται ήδη σε εξέλιξη."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ya hay una sesión de autenticación web en curso."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une session d’authentification web est déjà en cours."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एक वेब प्रमाणीकरण सत्र पहले से चल रहा है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "È già in corso una sessione di autenticazione web."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web認証セッションがすでに進行中です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웹 인증 세션이 이미 진행 중입니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesja uwierzytelniania internetowego jest już w toku."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uma sessão de autenticação web já está em andamento."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O sesiune de autentificare web este deja în desfășurare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сеанс веб-аутентификации уже выполняется."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir web kimlik doğrulama oturumu zaten devam ediyor."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已有网页身份验证会话正在进行。"
+          }
+        }
+      }
+    },
+    "Cannot publish unresolved Watch identity metadata." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يمكن نشر بيانات تعريف هوية Watch التي لم تتم تسويتها."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nicht aufgelöste Metadaten der Watch-Identität können nicht veröffentlicht werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν είναι δυνατή η δημοσίευση ανεπίλυτων μεταδεδομένων ταυτότητας Watch."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pueden publicar metadatos de identidad de Watch sin resolver."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de publier des métadonnées d’identité de la Watch non résolues."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अनसुलझा Watch पहचान मेटाडेटा प्रकाशित नहीं किया जा सकता।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile pubblicare metadati dell’identità di Watch non risolti."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未解決のWatch IDメタデータを公開できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "해결되지 않은 Watch ID 메타데이터를 게시할 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można opublikować nierozstrzygniętych metadanych tożsamości Watch."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não é possível publicar metadados de identidade do Watch não resolvidos."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu se pot publica metadatele de identitate Watch nerezolvate."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невозможно опубликовать неразрешенные метаданные идентификации Watch."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çözümlenmemiş Watch kimlik meta verileri yayımlanamıyor."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法发布尚未解析的 Watch 身份元数据。"
+          }
+        }
+      }
+    },
+    "Clerk is already reconfiguring. Wait for the current reconfiguration to finish before starting another one." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تجري إعادة تهيئة Clerk بالفعل. انتظر حتى تنتهي إعادة التهيئة الحالية قبل بدء أخرى."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk wird bereits neu konfiguriert. Warten Sie, bis die aktuelle Neukonfiguration abgeschlossen ist, bevor Sie eine weitere starten."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Το Clerk επαναδιαμορφώνεται ήδη. Περιμένετε να ολοκληρωθεί η τρέχουσα επαναδιαμόρφωση πριν ξεκινήσετε άλλη."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk ya se está reconfigurando. Espere a que finalice la reconfiguración actual antes de iniciar otra."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk est déjà en cours de reconfiguration. Attendez la fin de la reconfiguration actuelle avant d’en démarrer une autre."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk पहले से पुनः कॉन्फ़िगर हो रहा है। दूसरा शुरू करने से पहले मौजूदा पुनः कॉन्फ़िगरेशन के पूरा होने की प्रतीक्षा करें।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk è già in fase di riconfigurazione. Attendi il completamento della riconfigurazione corrente prima di avviarne un’altra."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerkはすでに再構成中です。現在の再構成が完了してから、別の再構成を開始してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk가 이미 재구성 중입니다. 현재 재구성이 완료될 때까지 기다린 후 다시 시작하세요."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trwa już ponowna konfiguracja Clerk. Poczekaj na jej zakończenie przed rozpoczęciem kolejnej."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O Clerk já está sendo reconfigurado. Aguarde a conclusão da reconfiguração atual antes de iniciar outra."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk este deja în curs de reconfigurare. Așteptați finalizarea reconfigurării curente înainte de a începe alta."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk уже перенастраивается. Дождитесь завершения текущей перенастройки, прежде чем запускать новую."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk zaten yeniden yapılandırılıyor. Başka bir yapılandırma başlatmadan önce mevcut işlemin tamamlanmasını bekleyin."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk 已在重新配置。请等待当前重新配置完成后再开始新的配置。"
+          }
+        }
+      }
+    },
+    "Clerk must be configured before getting a session token." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يجب تهيئة Clerk قبل الحصول على رمز الجلسة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk muss konfiguriert sein, bevor ein Sitzungstoken abgerufen werden kann."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Το Clerk πρέπει να διαμορφωθεί πριν από τη λήψη διακριτικού περιόδου λειτουργίας."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk debe estar configurado antes de obtener un token de sesión."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk doit être configuré avant d’obtenir un jeton de session."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सत्र टोकन प्राप्त करने से पहले Clerk को कॉन्फ़िगर करना आवश्यक है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk deve essere configurato prima di ottenere un token di sessione."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セッショントークンを取得する前にClerkを構成する必要があります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "세션 토큰을 가져오기 전에 Clerk를 구성해야 합니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przed pobraniem tokenu sesji należy skonfigurować Clerk."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O Clerk deve ser configurado antes de obter um token de sessão."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk trebuie configurat înainte de obținerea unui token de sesiune."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перед получением токена сеанса необходимо настроить Clerk."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oturum belirteci alınmadan önce Clerk yapılandırılmalıdır."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "必须先配置 Clerk，才能获取会话令牌。"
+          }
+        }
+      }
+    },
+    "Client ID is unavailable." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "معرّف العميل غير متاح."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Client-ID ist nicht verfügbar."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Το αναγνωριστικό πελάτη δεν είναι διαθέσιμο."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El ID de cliente no está disponible."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’identifiant client n’est pas disponible."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "क्लाइंट ID उपलब्ध नहीं है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’ID client non è disponibile."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クライアントIDを利用できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클라이언트 ID를 사용할 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Identyfikator klienta jest niedostępny."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O ID do cliente não está disponível."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID-ul clientului nu este disponibil."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Идентификатор клиента недоступен."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İstemci kimliği kullanılamıyor."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "客户端 ID 不可用。"
+          }
+        }
+      }
+    },
+    "Conflicting Watch auth payload reused a pending version." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أعادت حمولة مصادقة Watch المتعارضة استخدام إصدار معلق."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In Konflikt stehende Watch-Authentifizierungsdaten haben eine ausstehende Version erneut verwendet."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Το αντικρουόμενο ωφέλιμο φορτίο ελέγχου ταυτότητας Watch επαναχρησιμοποίησε μια έκδοση σε εκκρεμότητα."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La carga de autenticación de Watch en conflicto reutilizó una versión pendiente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La charge utile d’authentification de la Watch en conflit a réutilisé une version en attente."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विरोधी Watch प्रमाणीकरण पेलोड ने एक लंबित संस्करण का दोबारा उपयोग किया।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il payload di autenticazione di Watch in conflitto ha riutilizzato una versione in sospeso."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "競合するWatch認証ペイロードが保留中のバージョンを再利用しました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "충돌하는 Watch 인증 페이로드가 보류 중인 버전을 재사용했습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprzeczne dane uwierzytelniania Watch ponownie użyły oczekującej wersji."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A carga de autenticação conflitante do Watch reutilizou uma versão pendente."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datele de autentificare Watch aflate în conflict au reutilizat o versiune în așteptare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Конфликтующие данные аутентификации Watch повторно использовали ожидающую версию."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çakışan Watch kimlik doğrulama yükü, bekleyen bir sürümü yeniden kullandı."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存在冲突的 Watch 身份验证负载重复使用了待处理版本。"
+          }
+        }
+      }
+    },
+    "Conflicting Watch token payload reused a pending version." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أعادت حمولة رمز Watch المتعارضة استخدام إصدار معلق."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In Konflikt stehende Watch-Tokendaten haben eine ausstehende Version erneut verwendet."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Το αντικρουόμενο ωφέλιμο φορτίο διακριτικού Watch επαναχρησιμοποίησε μια έκδοση σε εκκρεμότητα."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La carga del token de Watch en conflicto reutilizó una versión pendiente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La charge utile du jeton de la Watch en conflit a réutilisé une version en attente."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विरोधी Watch टोकन पेलोड ने एक लंबित संस्करण का दोबारा उपयोग किया।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il payload del token di Watch in conflitto ha riutilizzato una versione in sospeso."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "競合するWatchトークンペイロードが保留中のバージョンを再利用しました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "충돌하는 Watch 토큰 페이로드가 보류 중인 버전을 재사용했습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprzeczne dane tokenu Watch ponownie użyły oczekującej wersji."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A carga de token conflitante do Watch reutilizou uma versão pendente."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datele tokenului Watch aflate în conflict au reutilizat o versiune în așteptare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Конфликтующие данные токена Watch повторно использовали ожидающую версию."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çakışan Watch belirteci yükü, bekleyen bir sürümü yeniden kullandı."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存在冲突的 Watch 令牌负载重复使用了待处理版本。"
+          }
+        }
+      }
+    },
+    "Email address is required." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عنوان البريد الإلكتروني مطلوب."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eine E-Mail-Adresse ist erforderlich."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Απαιτείται διεύθυνση email."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se requiere una dirección de correo electrónico."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une adresse e-mail est requise."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ईमेल पता आवश्यक है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "È richiesto un indirizzo email."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メールアドレスが必要です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이메일 주소가 필요합니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adres e-mail jest wymagany."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "É necessário informar um endereço de e-mail."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este necesară o adresă de e-mail."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Необходимо указать адрес электронной почты."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E-posta adresi gereklidir."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "电子邮件地址为必填项。"
+          }
+        }
+      }
+    },
+    "Email link sign-in is not available for this sign-in." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تسجيل الدخول عبر رابط البريد الإلكتروني غير متاح لعملية تسجيل الدخول هذه."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Anmeldung per E-Mail-Link ist für diese Anmeldung nicht verfügbar."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η σύνδεση μέσω συνδέσμου email δεν είναι διαθέσιμη για αυτήν τη σύνδεση."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El inicio de sesión mediante enlace de correo electrónico no está disponible para este inicio de sesión."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La connexion par lien e-mail n’est pas disponible pour cette connexion."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इस साइन-इन के लिए ईमेल लिंक से साइन-इन उपलब्ध नहीं है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’accesso tramite link email non è disponibile per questo accesso."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このサインインでは、メールリンクによるサインインを利用できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 로그인에는 이메일 링크 로그인을 사용할 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Logowanie za pomocą linku e-mail nie jest dostępne dla tego logowania."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O login por link de e-mail não está disponível para este login."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autentificarea prin link de e-mail nu este disponibilă pentru această autentificare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вход по ссылке из электронного письма недоступен для этого входа."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E-posta bağlantısıyla oturum açma bu oturum açma işlemi için kullanılamıyor."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此登录流程无法使用电子邮件链接登录。"
+          }
+        }
+      }
+    },
+    "Hosted auth callback URL did not match the initiated redirect URL." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لم يتطابق عنوان URL لرد اتصال المصادقة المستضافة مع عنوان URL لإعادة التوجيه الذي بدأ العملية."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Callback-URL der gehosteten Authentifizierung stimmte nicht mit der gestarteten Weiterleitungs-URL überein."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η διεύθυνση URL επανάκλησης του φιλοξενούμενου ελέγχου ταυτότητας δεν αντιστοιχούσε στη διεύθυνση URL ανακατεύθυνσης που ξεκίνησε τη διαδικασία."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La URL de devolución de llamada de la autenticación alojada no coincidió con la URL de redirección iniciada."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’URL de rappel de l’authentification hébergée ne correspondait pas à l’URL de redirection initiale."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "होस्टेड प्रमाणीकरण कॉलबैक URL शुरू किए गए रीडायरेक्ट URL से मेल नहीं खाता।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’URL di callback dell’autenticazione ospitata non corrispondeva all’URL di reindirizzamento iniziale."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト型認証のコールバックURLが、開始時のリダイレクトURLと一致しませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스팅 인증 콜백 URL이 시작된 리디렉션 URL과 일치하지 않습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adres URL wywołania zwrotnego hostowanego uwierzytelniania nie odpowiadał początkowemu adresowi URL przekierowania."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A URL de retorno da autenticação hospedada não correspondeu à URL de redirecionamento iniciada."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL-ul de revenire al autentificării găzduite nu a corespuns URL-ului de redirecționare inițial."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL-адрес обратного вызова размещенной аутентификации не совпал с исходным URL-адресом перенаправления."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barındırılan kimlik doğrulama geri çağırma URL'si başlatılan yönlendirme URL'siyle eşleşmedi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "托管身份验证回调 URL 与启动时的重定向 URL 不匹配。"
+          }
+        }
+      }
+    },
+    "Hosted auth callback did not include a rotating token nonce." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لم يتضمن رد اتصال المصادقة المستضافة قيمة nonce للرمز المتناوب."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Callback der gehosteten Authentifizierung enthielt keine Nonce für das rotierende Token."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η επανάκληση του φιλοξενούμενου ελέγχου ταυτότητας δεν περιλάμβανε nonce περιστρεφόμενου διακριτικού."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La devolución de llamada de la autenticación alojada no incluyó un nonce de token rotatorio."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le rappel de l’authentification hébergée ne contenait pas de nonce de jeton rotatif."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "होस्टेड प्रमाणीकरण कॉलबैक में रोटेटिंग टोकन nonce शामिल नहीं था।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il callback dell’autenticazione ospitata non includeva un nonce del token rotante."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト型認証のコールバックにローテーショントークンのnonceが含まれていませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스팅 인증 콜백에 순환 토큰 nonce가 포함되지 않았습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wywołanie zwrotne hostowanego uwierzytelniania nie zawierało wartości nonce rotacyjnego tokenu."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O retorno da autenticação hospedada não incluiu um nonce de token rotativo."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revenirea autentificării găzduite nu a inclus un nonce pentru tokenul rotativ."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обратный вызов размещенной аутентификации не содержал nonce для сменяемого токена."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barındırılan kimlik doğrulama geri çağrısı, dönen bir belirteç nonce değeri içermiyordu."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "托管身份验证回调未包含轮换令牌 nonce。"
+          }
+        }
+      }
+    },
+    "Hosted auth callback did not include the created session." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لم يتضمن رد اتصال المصادقة المستضافة الجلسة التي تم إنشاؤها."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Callback der gehosteten Authentifizierung enthielt die erstellte Sitzung nicht."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η επανάκληση του φιλοξενούμενου ελέγχου ταυτότητας δεν περιλάμβανε την περίοδο λειτουργίας που δημιουργήθηκε."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La devolución de llamada de la autenticación alojada no incluyó la sesión creada."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le rappel de l’authentification hébergée ne contenait pas la session créée."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "होस्टेड प्रमाणीकरण कॉलबैक में बनाया गया सत्र शामिल नहीं था।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il callback dell’autenticazione ospitata non includeva la sessione creata."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト型認証のコールバックに作成されたセッションが含まれていませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스팅 인증 콜백에 생성된 세션이 포함되지 않았습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wywołanie zwrotne hostowanego uwierzytelniania nie zawierało utworzonej sesji."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O retorno da autenticação hospedada não incluiu a sessão criada."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revenirea autentificării găzduite nu a inclus sesiunea creată."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обратный вызов размещенной аутентификации не содержал созданный сеанс."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barındırılan kimlik doğrulama geri çağrısı oluşturulan oturumu içermiyordu."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "托管身份验证回调未包含已创建的会话。"
+          }
+        }
+      }
+    },
+    "Hosted auth callback state was missing or did not match the initiated state." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "كانت حالة رد اتصال المصادقة المستضافة مفقودة أو لم تتطابق مع الحالة التي بدأت العملية."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Status des Callbacks der gehosteten Authentifizierung fehlte oder stimmte nicht mit dem gestarteten Status überein."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η κατάσταση επανάκλησης του φιλοξενούμενου ελέγχου ταυτότητας έλειπε ή δεν αντιστοιχούσε στην κατάσταση που ξεκίνησε τη διαδικασία."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faltaba el estado de la devolución de llamada de la autenticación alojada o no coincidía con el estado iniciado."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’état du rappel de l’authentification hébergée était absent ou ne correspondait pas à l’état initial."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "होस्टेड प्रमाणीकरण कॉलबैक की स्थिति मौजूद नहीं थी या शुरू की गई स्थिति से मेल नहीं खाती थी।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lo stato del callback dell’autenticazione ospitata era mancante o non corrispondeva allo stato iniziale."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト型認証のコールバック状態が存在しないか、開始時の状態と一致しませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스팅 인증 콜백 상태가 없거나 시작된 상태와 일치하지 않습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brakowało stanu wywołania zwrotnego hostowanego uwierzytelniania lub nie odpowiadał on stanowi początkowemu."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O estado do retorno da autenticação hospedada estava ausente ou não correspondia ao estado iniciado."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Starea revenirii autentificării găzduite lipsea sau nu corespundea stării inițiale."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Состояние обратного вызова размещенной аутентификации отсутствовало или не совпало с исходным состоянием."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barındırılan kimlik doğrulama geri çağrı durumu eksikti veya başlatılan durumla eşleşmedi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "托管身份验证回调状态缺失或与启动时的状态不匹配。"
+          }
+        }
+      }
+    },
+    "Hosted auth completion could not activate the created session." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر على إكمال المصادقة المستضافة تنشيط الجلسة التي تم إنشاؤها."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die gehostete Authentifizierung konnte die erstellte Sitzung nicht aktivieren."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η ολοκλήρωση του φιλοξενούμενου ελέγχου ταυτότητας δεν μπόρεσε να ενεργοποιήσει την περίοδο λειτουργίας που δημιουργήθηκε."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La autenticación alojada no pudo activar la sesión creada."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’authentification hébergée n’a pas pu activer la session créée."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "होस्टेड प्रमाणीकरण पूर्ण होने पर बनाया गया सत्र सक्रिय नहीं किया जा सका।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’autenticazione ospitata non ha potuto attivare la sessione creata."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト型認証の完了処理で作成されたセッションを有効化できませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스팅 인증 완료 과정에서 생성된 세션을 활성화할 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hostowane uwierzytelnianie nie mogło aktywować utworzonej sesji."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autenticação hospedada não conseguiu ativar a sessão criada."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autentificarea găzduită nu a putut activa sesiunea creată."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размещенная аутентификация не смогла активировать созданный сеанс."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barındırılan kimlik doğrulama oluşturulan oturumu etkinleştiremedi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "托管身份验证无法激活已创建的会话。"
+          }
+        }
+      }
+    },
+    "Hosted auth completion could not update the current client." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر على إكمال المصادقة المستضافة تحديث العميل الحالي."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die gehostete Authentifizierung konnte den aktuellen Client nicht aktualisieren."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η ολοκλήρωση του φιλοξενούμενου ελέγχου ταυτότητας δεν μπόρεσε να ενημερώσει τον τρέχοντα πελάτη."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La autenticación alojada no pudo actualizar el cliente actual."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’authentification hébergée n’a pas pu mettre à jour le client actuel."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "होस्टेड प्रमाणीकरण पूर्ण होने पर मौजूदा क्लाइंट अपडेट नहीं किया जा सका।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’autenticazione ospitata non ha potuto aggiornare il client corrente."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト型認証の完了処理で現在のクライアントを更新できませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스팅 인증 완료 과정에서 현재 클라이언트를 업데이트할 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hostowane uwierzytelnianie nie mogło zaktualizować bieżącego klienta."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autenticação hospedada não conseguiu atualizar o cliente atual."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autentificarea găzduită nu a putut actualiza clientul curent."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размещенная аутентификация не смогла обновить текущий клиент."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barındırılan kimlik doğrulama mevcut istemciyi güncelleyemedi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "托管身份验证无法更新当前客户端。"
+          }
+        }
+      }
+    },
+    "Hosted auth completion did not include the created session." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لم يتضمن إكمال المصادقة المستضافة الجلسة التي تم إنشاؤها."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Abschluss der gehosteten Authentifizierung enthielt die erstellte Sitzung nicht."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η ολοκλήρωση του φιλοξενούμενου ελέγχου ταυτότητας δεν περιλάμβανε την περίοδο λειτουργίας που δημιουργήθηκε."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La finalización de la autenticación alojada no incluyó la sesión creada."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La finalisation de l’authentification hébergée ne contenait pas la session créée."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "होस्टेड प्रमाणीकरण पूर्ण होने पर बनाया गया सत्र शामिल नहीं था।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il completamento dell’autenticazione ospitata non includeva la sessione creata."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト型認証の完了処理に作成されたセッションが含まれていませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스팅 인증 완료 과정에 생성된 세션이 포함되지 않았습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zakończenie hostowanego uwierzytelniania nie zawierało utworzonej sesji."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A conclusão da autenticação hospedada não incluiu a sessão criada."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizarea autentificării găzduite nu a inclus sesiunea creată."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завершение размещенной аутентификации не содержало созданный сеанс."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barındırılan kimlik doğrulama tamamlaması oluşturulan oturumu içermiyordu."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "托管身份验证完成结果未包含已创建的会话。"
+          }
+        }
+      }
+    },
+    "Hosted auth completion response was missing identity synchronization metadata." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "كان رد إكمال المصادقة المستضافة يفتقد بيانات تعريف مزامنة الهوية."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In der Abschlussantwort der gehosteten Authentifizierung fehlten Metadaten zur Identitätssynchronisierung."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Από την απόκριση ολοκλήρωσης του φιλοξενούμενου ελέγχου ταυτότητας έλειπαν μεταδεδομένα συγχρονισμού ταυτότητας."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A la respuesta de finalización de la autenticación alojada le faltaban los metadatos de sincronización de identidad."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La réponse de finalisation de l’authentification hébergée ne contenait pas les métadonnées de synchronisation d’identité."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "होस्टेड प्रमाणीकरण पूर्णता प्रतिक्रिया में पहचान सिंक्रोनाइज़ेशन मेटाडेटा मौजूद नहीं था।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nella risposta di completamento dell’autenticazione ospitata mancavano i metadati di sincronizzazione dell’identità."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト型認証の完了レスポンスにID同期メタデータが含まれていませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스팅 인증 완료 응답에 ID 동기화 메타데이터가 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "W odpowiedzi kończącej hostowane uwierzytelnianie brakowało metadanych synchronizacji tożsamości."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A resposta de conclusão da autenticação hospedada não continha os metadados de sincronização de identidade."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Răspunsul de finalizare a autentificării găzduite nu conținea metadatele de sincronizare a identității."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В ответе завершения размещенной аутентификации отсутствовали метаданные синхронизации идентификации."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barındırılan kimlik doğrulama tamamlama yanıtında kimlik eşitleme meta verileri eksikti."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "托管身份验证完成响应缺少身份同步元数据。"
+          }
+        }
+      }
+    },
+    "Hosted auth creation returned an invalid response." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أعاد إنشاء المصادقة المستضافة استجابة غير صالحة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beim Erstellen der gehosteten Authentifizierung wurde eine ungültige Antwort zurückgegeben."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η δημιουργία φιλοξενούμενου ελέγχου ταυτότητας επέστρεψε μη έγκυρη απόκριση."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La creación de la autenticación alojada devolvió una respuesta no válida."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La création de l’authentification hébergée a renvoyé une réponse non valide."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "होस्टेड प्रमाणीकरण बनाते समय अमान्य प्रतिक्रिया मिली।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La creazione dell’autenticazione ospitata ha restituito una risposta non valida."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト型認証の作成で無効なレスポンスが返されました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스팅 인증 생성에서 잘못된 응답이 반환되었습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utworzenie hostowanego uwierzytelniania zwróciło nieprawidłową odpowiedź."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A criação da autenticação hospedada retornou uma resposta inválida."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crearea autentificării găzduite a returnat un răspuns nevalid."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "При создании размещенной аутентификации был получен недопустимый ответ."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barındırılan kimlik doğrulama oluşturma işlemi geçersiz bir yanıt döndürdü."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建托管身份验证时返回了无效响应。"
+          }
+        }
+      }
+    },
+    "Hosted auth requires a valid custom-scheme redirect URL." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تتطلب المصادقة المستضافة عنوان URL صالحًا لإعادة التوجيه بمخطط مخصص."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die gehostete Authentifizierung erfordert eine gültige Weiterleitungs-URL mit benutzerdefiniertem Schema."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ο φιλοξενούμενος έλεγχος ταυτότητας απαιτεί έγκυρη διεύθυνση URL ανακατεύθυνσης προσαρμοσμένου σχήματος."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La autenticación alojada requiere una URL de redirección válida con un esquema personalizado."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’authentification hébergée nécessite une URL de redirection valide avec un schéma personnalisé."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "होस्टेड प्रमाणीकरण के लिए मान्य कस्टम-स्कीम रीडायरेक्ट URL आवश्यक है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’autenticazione ospitata richiede un URL di reindirizzamento valido con schema personalizzato."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホスト型認証には、有効なカスタムスキームのリダイレクトURLが必要です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "호스팅 인증에는 유효한 사용자 지정 스킴 리디렉션 URL이 필요합니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hostowane uwierzytelnianie wymaga prawidłowego adresu URL przekierowania z niestandardowym schematem."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A autenticação hospedada requer uma URL de redirecionamento válida com esquema personalizado."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autentificarea găzduită necesită un URL de redirecționare valid cu schemă personalizată."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Для размещенной аутентификации требуется допустимый URL-адрес перенаправления с пользовательской схемой."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barındırılan kimlik doğrulama, geçerli bir özel şema yönlendirme URL'si gerektirir."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "托管身份验证需要有效的自定义方案重定向 URL。"
+          }
+        }
+      }
+    },
+    "Injected Keychain storage cannot be used with persistent shared-session adoption." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يمكن استخدام تخزين Keychain المحقون مع اعتماد الجلسة المشتركة الدائم."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eingefügter Keychain-Speicher kann nicht mit der dauerhaften Übernahme gemeinsam genutzter Sitzungen verwendet werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ο παρεχόμενος χώρος αποθήκευσης Keychain δεν μπορεί να χρησιμοποιηθεί με μόνιμη υιοθέτηση κοινόχρηστης περιόδου λειτουργίας."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El almacenamiento Keychain inyectado no se puede usar con la adopción persistente de sesiones compartidas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le stockage Keychain injecté ne peut pas être utilisé avec l’adoption persistante d’une session partagée."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इंजेक्ट किए गए Keychain स्टोरेज का उपयोग स्थायी साझा-सत्र अपनाने के साथ नहीं किया जा सकता।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’archiviazione Keychain inserita non può essere utilizzata con l’adozione persistente di sessioni condivise."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "注入されたKeychainストレージは、永続的な共有セッションの採用には使用できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주입된 Keychain 저장소는 영구 공유 세션 채택과 함께 사용할 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wstrzykniętej pamięci Keychain nie można używać z trwałym przejmowaniem sesji współdzielonej."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O armazenamento Keychain injetado não pode ser usado com a adoção persistente de sessão compartilhada."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stocarea Keychain injectată nu poate fi utilizată cu adoptarea persistentă a sesiunii partajate."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Внедренное хранилище Keychain нельзя использовать с постоянным подключением общего сеанса."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eklenen Keychain depolaması, kalıcı paylaşılan oturum benimsemesiyle kullanılamaz."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "注入的 Keychain 存储不能用于持久采用共享会话。"
+          }
+        }
+      }
+    },
+    "Invalid credential type." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نوع بيانات الاعتماد غير صالح."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültiger Anmeldedatentyp."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Μη έγκυρος τύπος διαπιστευτηρίων."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de credencial no válido."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type d’identifiant non valide."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "क्रेडेंशियल का प्रकार अमान्य है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo di credenziale non valido."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資格情報の種類が無効です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자격 증명 유형이 올바르지 않습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nieprawidłowy typ danych uwierzytelniających."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de credencial inválido."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tip de acreditare nevalid."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недопустимый тип учетных данных."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geçersiz kimlik bilgisi türü."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "凭据类型无效。"
+          }
+        }
+      }
+    },
+    "Isolated Clerk configuration is only available while running tests." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يتوفر تكوين Clerk المعزول إلا أثناء تشغيل الاختبارات."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eine isolierte Clerk-Konfiguration ist nur während der Ausführung von Tests verfügbar."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η απομονωμένη διαμόρφωση του Clerk είναι διαθέσιμη μόνο κατά την εκτέλεση δοκιμών."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La configuración aislada de Clerk solo está disponible mientras se ejecutan pruebas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La configuration isolée de Clerk est uniquement disponible pendant l’exécution des tests."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अलग Clerk कॉन्फ़िगरेशन केवल परीक्षण चलाते समय उपलब्ध है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La configurazione isolata di Clerk è disponibile solo durante l’esecuzione dei test."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分離されたClerk構成は、テストの実行中のみ利用できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "격리된 Clerk 구성은 테스트를 실행하는 동안에만 사용할 수 있습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Izolowana konfiguracja Clerk jest dostępna tylko podczas uruchamiania testów."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A configuração isolada do Clerk só está disponível durante a execução de testes."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurația Clerk izolată este disponibilă numai în timpul rulării testelor."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изолированная конфигурация Clerk доступна только во время выполнения тестов."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yalıtılmış Clerk yapılandırması yalnızca testler çalıştırılırken kullanılabilir."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隔离的 Clerk 配置仅在运行测试时可用。"
+          }
+        }
+      }
+    },
+    "Magic link callback does not match the pending flow." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يتطابق رد اتصال الرابط السحري مع التدفق المعلق."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Callback des Magic Links stimmt nicht mit dem ausstehenden Ablauf überein."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η επανάκληση του μαγικού συνδέσμου δεν αντιστοιχεί στη ροή που εκκρεμεί."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La devolución de llamada del enlace mágico no coincide con el flujo pendiente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le rappel du lien magique ne correspond pas au flux en attente."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मैजिक लिंक कॉलबैक लंबित प्रवाह से मेल नहीं खाता।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il callback del link magico non corrisponde al flusso in sospeso."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マジックリンクのコールバックが保留中のフローと一致しません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "매직 링크 콜백이 보류 중인 흐름과 일치하지 않습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wywołanie zwrotne magicznego linku nie odpowiada oczekującemu przepływowi."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O retorno do link mágico não corresponde ao fluxo pendente."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revenirea linkului magic nu corespunde fluxului în așteptare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обратный вызов волшебной ссылки не соответствует ожидающему потоку."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sihirli bağlantı geri çağrısı bekleyen akışla eşleşmiyor."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "魔法链接回调与待处理流程不匹配。"
+          }
+        }
+      }
+    },
+    "Magic link callback is missing approval_token." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يفتقد رد اتصال الرابط السحري approval_token."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Im Callback des Magic Links fehlt approval_token."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Από την επανάκληση του μαγικού συνδέσμου λείπει το approval_token."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A la devolución de llamada del enlace mágico le falta approval_token."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il manque approval_token dans le rappel du lien magique."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मैजिक लिंक कॉलबैक में approval_token मौजूद नहीं है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nel callback del link magico manca approval_token."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マジックリンクのコールバックにapproval_tokenがありません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "매직 링크 콜백에 approval_token이 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "W wywołaniu zwrotnym magicznego linku brakuje approval_token."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O retorno do link mágico não contém approval_token."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Din revenirea linkului magic lipsește approval_token."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В обратном вызове волшебной ссылки отсутствует approval_token."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sihirli bağlantı geri çağrısında approval_token eksik."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "魔法链接回调缺少 approval_token。"
+          }
+        }
+      }
+    },
+    "Magic link callback is missing flow_id." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يفتقد رد اتصال الرابط السحري flow_id."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Im Callback des Magic Links fehlt flow_id."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Από την επανάκληση του μαγικού συνδέσμου λείπει το flow_id."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A la devolución de llamada del enlace mágico le falta flow_id."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il manque flow_id dans le rappel du lien magique."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मैजिक लिंक कॉलबैक में flow_id मौजूद नहीं है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nel callback del link magico manca flow_id."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マジックリンクのコールバックにflow_idがありません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "매직 링크 콜백에 flow_id가 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "W wywołaniu zwrotnym magicznego linku brakuje flow_id."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O retorno do link mágico não contém flow_id."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Din revenirea linkului magic lipsește flow_id."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В обратном вызове волшебной ссылки отсутствует flow_id."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sihirli bağlantı geri çağrısında flow_id eksik."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "魔法链接回调缺少 flow_id。"
+          }
+        }
+      }
+    },
+    "Magic link callback returned a sign-up for a sign-in flow." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أعاد رد اتصال الرابط السحري عملية تسجيل لحساب جديد ضمن تدفق تسجيل دخول."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Callback des Magic Links gab eine Registrierung für einen Anmeldeablauf zurück."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η επανάκληση του μαγικού συνδέσμου επέστρεψε εγγραφή για ροή σύνδεσης."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La devolución de llamada del enlace mágico devolvió un registro para un flujo de inicio de sesión."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le rappel du lien magique a renvoyé une inscription pour un flux de connexion."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मैजिक लिंक कॉलबैक ने साइन-इन प्रवाह के लिए साइन-अप लौटाया।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il callback del link magico ha restituito una registrazione per un flusso di accesso."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マジックリンクのコールバックが、サインインフローに対するサインアップを返しました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "매직 링크 콜백이 로그인 흐름에 대한 회원 가입을 반환했습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wywołanie zwrotne magicznego linku zwróciło rejestrację dla przepływu logowania."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O retorno do link mágico retornou um cadastro para um fluxo de login."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revenirea linkului magic a returnat o înregistrare pentru un flux de autentificare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обратный вызов волшебной ссылки вернул регистрацию для потока входа."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sihirli bağlantı geri çağrısı, oturum açma akışı için bir kaydolma döndürdü."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "魔法链接回调为登录流程返回了注册结果。"
+          }
+        }
+      }
+    },
+    "Magic link callback returned a ticket for a sign-up flow." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أعاد رد اتصال الرابط السحري تذكرة ضمن تدفق تسجيل حساب جديد."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Callback des Magic Links gab ein Ticket für einen Registrierungsablauf zurück."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η επανάκληση του μαγικού συνδέσμου επέστρεψε δελτίο για ροή εγγραφής."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La devolución de llamada del enlace mágico devolvió un ticket para un flujo de registro."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le rappel du lien magique a renvoyé un ticket pour un flux d’inscription."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मैजिक लिंक कॉलबैक ने साइन-अप प्रवाह के लिए टिकट लौटाया।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il callback del link magico ha restituito un ticket per un flusso di registrazione."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マジックリンクのコールバックが、サインアップフローに対するチケットを返しました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "매직 링크 콜백이 회원 가입 흐름에 대한 티켓을 반환했습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wywołanie zwrotne magicznego linku zwróciło bilet dla przepływu rejestracji."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O retorno do link mágico retornou um ticket para um fluxo de cadastro."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revenirea linkului magic a returnat un tichet pentru un flux de înregistrare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обратный вызов волшебной ссылки вернул билет для потока регистрации."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sihirli bağlantı geri çağrısı, kaydolma akışı için bir bilet döndürdü."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "魔法链接回调为注册流程返回了票证。"
+          }
+        }
+      }
+    },
+    "Missing callback URL" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عنوان URL لرد الاتصال مفقود"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Callback-URL fehlt"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Λείπει η διεύθυνση URL επανάκλησης"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falta la URL de devolución de llamada"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL de rappel manquante"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कॉलबैक URL मौजूद नहीं है"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL di callback mancante"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コールバックURLがありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "콜백 URL이 없습니다"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brak adresu URL wywołania zwrotnego"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL de retorno ausente"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lipsește URL-ul de revenire"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отсутствует URL-адрес обратного вызова"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geri çağırma URL'si eksik"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺少回调 URL"
+          }
+        }
+      }
+    },
+    "No pending magic link flow was found." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لم يتم العثور على تدفق رابط سحري معلق."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Es wurde kein ausstehender Magic-Link-Ablauf gefunden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν βρέθηκε ροή μαγικού συνδέσμου σε εκκρεμότητα."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontró ningún flujo de enlace mágico pendiente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun flux de lien magique en attente n’a été trouvé."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कोई लंबित मैजिक लिंक प्रवाह नहीं मिला।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non è stato trovato alcun flusso di link magico in sospeso."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留中のマジックリンクフローが見つかりませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보류 중인 매직 링크 흐름을 찾을 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie znaleziono oczekującego przepływu magicznego linku."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum fluxo de link mágico pendente foi encontrado."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu a fost găsit niciun flux de link magic în așteptare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ожидающий поток волшебной ссылки не найден."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bekleyen bir sihirli bağlantı akışı bulunamadı."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到待处理的魔法链接流程。"
+          }
+        }
+      }
+    },
+    "Redirect URI is missing. Unable to start email link sign-in." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "معرّف URI لإعادة التوجيه مفقود. لا يمكن بدء تسجيل الدخول عبر رابط البريد الإلكتروني."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Weiterleitungs-URI fehlt. Die Anmeldung per E-Mail-Link kann nicht gestartet werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Λείπει το URI ανακατεύθυνσης. Δεν είναι δυνατή η έναρξη σύνδεσης μέσω συνδέσμου email."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falta el URI de redirección. No se puede iniciar sesión mediante un enlace de correo electrónico."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’URI de redirection est manquant. Impossible de démarrer la connexion par lien e-mail."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रीडायरेक्ट URI मौजूद नहीं है। ईमेल लिंक से साइन-इन शुरू नहीं किया जा सका।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URI di reindirizzamento mancante. Impossibile avviare l’accesso tramite link email."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リダイレクトURIがありません。メールリンクによるサインインを開始できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "리디렉션 URI가 없습니다. 이메일 링크 로그인을 시작할 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brakuje identyfikatora URI przekierowania. Nie można rozpocząć logowania za pomocą linku e-mail."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O URI de redirecionamento está ausente. Não foi possível iniciar o login por link de e-mail."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lipsește URI-ul de redirecționare. Nu se poate porni autentificarea prin link de e-mail."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отсутствует URI перенаправления. Не удалось начать вход по ссылке из электронного письма."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yönlendirme URI'si eksik. E-posta bağlantısıyla oturum açma başlatılamıyor."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺少重定向 URI。无法开始通过电子邮件链接登录。"
+          }
+        }
+      }
+    },
+    "Redirect URI is missing. Unable to start email link sign-up verification." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "معرّف URI لإعادة التوجيه مفقود. لا يمكن بدء التحقق من تسجيل الحساب عبر رابط البريد الإلكتروني."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Weiterleitungs-URI fehlt. Die Registrierungsbestätigung per E-Mail-Link kann nicht gestartet werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Λείπει το URI ανακατεύθυνσης. Δεν είναι δυνατή η έναρξη επαλήθευσης εγγραφής μέσω συνδέσμου email."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falta el URI de redirección. No se puede iniciar la verificación del registro mediante un enlace de correo electrónico."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’URI de redirection est manquant. Impossible de démarrer la vérification de l’inscription par lien e-mail."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रीडायरेक्ट URI मौजूद नहीं है। ईमेल लिंक से साइन-अप सत्यापन शुरू नहीं किया जा सका।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URI di reindirizzamento mancante. Impossibile avviare la verifica della registrazione tramite link email."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リダイレクトURIがありません。メールリンクによるサインアップの検証を開始できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "리디렉션 URI가 없습니다. 이메일 링크 회원 가입 인증을 시작할 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brakuje identyfikatora URI przekierowania. Nie można rozpocząć weryfikacji rejestracji za pomocą linku e-mail."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O URI de redirecionamento está ausente. Não foi possível iniciar a verificação de cadastro por link de e-mail."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lipsește URI-ul de redirecționare. Nu se poate porni verificarea înregistrării prin link de e-mail."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отсутствует URI перенаправления. Не удалось начать подтверждение регистрации по ссылке из электронного письма."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yönlendirme URI'si eksik. E-posta bağlantısıyla kaydolma doğrulaması başlatılamıyor."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缺少重定向 URI。无法开始通过电子邮件链接进行注册验证。"
+          }
+        }
+      }
+    },
     "Redirect URL is missing or invalid. Unable to start external authentication flow." : {
       "localizations" : {
         "ar" : {
@@ -91,6 +3193,1510 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重定向 URL 缺失或无效。无法启动外部身份验证流程。"
+          }
+        }
+      }
+    },
+    "Shared session sync requires a nonempty Keychain access group." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تتطلب مزامنة الجلسة المشتركة مجموعة وصول غير فارغة في Keychain."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Für die Synchronisierung gemeinsam genutzter Sitzungen ist eine nicht leere Keychain-Zugriffsgruppe erforderlich."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ο συγχρονισμός κοινόχρηστης περιόδου λειτουργίας απαιτεί μη κενή ομάδα πρόσβασης Keychain."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La sincronización de sesiones compartidas requiere un grupo de acceso de Keychain que no esté vacío."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La synchronisation de session partagée nécessite un groupe d’accès Keychain non vide."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "साझा सत्र सिंक के लिए एक गैर-रिक्त Keychain एक्सेस समूह आवश्यक है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La sincronizzazione della sessione condivisa richiede un gruppo di accesso Keychain non vuoto."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共有セッションの同期には、空でないKeychainアクセスグループが必要です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "공유 세션 동기화에는 비어 있지 않은 Keychain 접근 그룹이 필요합니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronizacja sesji współdzielonej wymaga niepustej grupy dostępu Keychain."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A sincronização de sessão compartilhada requer um grupo de acesso Keychain não vazio."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizarea sesiunii partajate necesită un grup de acces Keychain nevid."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Для синхронизации общего сеанса требуется непустая группа доступа Keychain."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paylaşılan oturum eşitlemesi boş olmayan bir Keychain erişim grubu gerektirir."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共享会话同步需要非空的 Keychain 访问组。"
+          }
+        }
+      }
+    },
+    "Shared session sync requires a nonempty application bundle identifier." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تتطلب مزامنة الجلسة المشتركة معرّف حزمة تطبيق غير فارغ."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Für die Synchronisierung gemeinsam genutzter Sitzungen ist eine nicht leere Bundle-ID der Anwendung erforderlich."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ο συγχρονισμός κοινόχρηστης περιόδου λειτουργίας απαιτεί μη κενό αναγνωριστικό πακέτου εφαρμογής."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La sincronización de sesiones compartidas requiere un identificador de paquete de la aplicación que no esté vacío."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La synchronisation de session partagée nécessite un identifiant de bundle d’application non vide."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "साझा सत्र सिंक के लिए एक गैर-रिक्त एप्लिकेशन बंडल पहचानकर्ता आवश्यक है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La sincronizzazione della sessione condivisa richiede un identificatore del bundle dell’applicazione non vuoto."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共有セッションの同期には、空でないアプリケーションバンドル識別子が必要です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "공유 세션 동기화에는 비어 있지 않은 애플리케이션 번들 식별자가 필요합니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronizacja sesji współdzielonej wymaga niepustego identyfikatora pakietu aplikacji."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A sincronização de sessão compartilhada requer um identificador de pacote do aplicativo não vazio."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizarea sesiunii partajate necesită un identificator nevid al pachetului aplicației."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Для синхронизации общего сеанса требуется непустой идентификатор пакета приложения."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paylaşılan oturum eşitlemesi boş olmayan bir uygulama paketi tanımlayıcısı gerektirir."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共享会话同步需要非空的应用程序包标识符。"
+          }
+        }
+      }
+    },
+    "Something went wrong. Please try again." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حدث خطأ ما. يُرجى المحاولة مرة أخرى."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Κάτι πήγε στραβά. Δοκιμάστε ξανά."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algo salió mal. Inténtelo de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une erreur s’est produite. Veuillez réessayer."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कुछ गलत हुआ। कृपया पुनः प्रयास करें।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si è verificato un problema. Riprova."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "問題が発生しました。もう一度お試しください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "문제가 발생했습니다. 다시 시도해 주세요."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coś poszło nie tak. Spróbuj ponownie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algo deu errado. Tente novamente."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ceva nu a funcționat. Încercați din nou."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Что-то пошло не так. Повторите попытку."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir sorun oluştu. Lütfen tekrar deneyin."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出现问题。请重试。"
+          }
+        }
+      }
+    },
+    "Unable to clear Clerk keychain items during reconfiguration." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر مسح عناصر Clerk من Keychain أثناء إعادة التهيئة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clerk-Keychain-Einträge konnten während der Neukonfiguration nicht gelöscht werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν ήταν δυνατή η διαγραφή των στοιχείων Keychain του Clerk κατά την επαναδιαμόρφωση."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron eliminar los elementos de Clerk del Keychain durante la reconfiguración."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’effacer les éléments Clerk du Keychain pendant la reconfiguration."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पुनः कॉन्फ़िगरेशन के दौरान Clerk के Keychain आइटम साफ़ नहीं किए जा सके।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile cancellare gli elementi Clerk dal Keychain durante la riconfigurazione."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再構成中にClerkのKeychain項目を消去できませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "재구성 중에 Clerk Keychain 항목을 지울 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można wyczyścić elementów Clerk z Keychain podczas ponownej konfiguracji."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível limpar os itens do Clerk no Keychain durante a reconfiguração."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elementele Clerk din Keychain nu au putut fi șterse în timpul reconfigurării."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось очистить элементы Clerk в Keychain во время перенастройки."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yeniden yapılandırma sırasında Clerk Keychain öğeleri temizlenemedi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新配置期间无法清除 Clerk Keychain 项目。"
+          }
+        }
+      }
+    },
+    "Unable to delete membership: missing userId" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر حذف العضوية: userId مفقود"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mitgliedschaft kann nicht gelöscht werden: userId fehlt"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν είναι δυνατή η διαγραφή της ιδιότητας μέλους: λείπει το userId"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede eliminar la membresía: falta userId"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de supprimer l’adhésion : userId manquant"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सदस्यता हटाई नहीं जा सकी: userId मौजूद नहीं है"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile eliminare l’appartenenza: userId mancante"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メンバーシップを削除できません：userIdがありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "멤버십을 삭제할 수 없습니다: userId가 없습니다"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można usunąć członkostwa: brakuje userId"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível excluir a associação: userId ausente"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calitatea de membru nu poate fi ștearsă: lipsește userId"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось удалить членство: отсутствует userId"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Üyelik silinemiyor: userId eksik"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法删除成员资格：缺少 userId"
+          }
+        }
+      }
+    },
+    "Unable to generate secure random data." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر إنشاء بيانات عشوائية آمنة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sichere Zufallsdaten konnten nicht erzeugt werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν ήταν δυνατή η δημιουργία ασφαλών τυχαίων δεδομένων."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron generar datos aleatorios seguros."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de générer des données aléatoires sécurisées."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सुरक्षित रैंडम डेटा उत्पन्न नहीं किया जा सका।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile generare dati casuali sicuri."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全なランダムデータを生成できませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "안전한 무작위 데이터를 생성할 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można wygenerować bezpiecznych danych losowych."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível gerar dados aleatórios seguros."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-au putut genera date aleatorii securizate."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось создать безопасные случайные данные."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Güvenli rastgele veri oluşturulamadı."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法生成安全随机数据。"
+          }
+        }
+      }
+    },
+    "Unable to get the challenge for the passkey." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر الحصول على تحدي مفتاح المرور."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Challenge für den Passkey konnte nicht abgerufen werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν ήταν δυνατή η λήψη της πρόκλησης για το passkey."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo obtener el desafío para la clave de acceso."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’obtenir le défi pour la clé d’accès."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पासकी के लिए चुनौती प्राप्त नहीं की जा सकी।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile ottenere la richiesta per la passkey."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスキーのチャレンジを取得できませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "패스키에 대한 챌린지를 가져올 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można pobrać wyzwania dla klucza dostępu."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível obter o desafio para a chave de acesso."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-a putut obține provocarea pentru cheia de acces."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось получить запрос для ключа доступа."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geçiş anahtarı sınaması alınamadı."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法获取通行密钥的质询。"
+          }
+        }
+      }
+    },
+    "Unable to get the user ID for the passkey." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر الحصول على معرّف المستخدم لمفتاح المرور."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Benutzer-ID für den Passkey konnte nicht abgerufen werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν ήταν δυνατή η λήψη του αναγνωριστικού χρήστη για το passkey."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo obtener el ID de usuario para la clave de acceso."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’obtenir l’identifiant utilisateur pour la clé d’accès."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पासकी के लिए उपयोगकर्ता ID प्राप्त नहीं की जा सकी।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile ottenere l’ID utente per la passkey."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスキーのユーザーIDを取得できませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "패스키의 사용자 ID를 가져올 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można pobrać identyfikatora użytkownika dla klucza dostępu."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível obter o ID do usuário para a chave de acesso."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-a putut obține ID-ul utilizatorului pentru cheia de acces."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось получить идентификатор пользователя для ключа доступа."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geçiş anahtarı için kullanıcı kimliği alınamadı."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法获取通行密钥的用户 ID。"
+          }
+        }
+      }
+    },
+    "Unable to get the username for the passkey." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر الحصول على اسم المستخدم لمفتاح المرور."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Benutzername für den Passkey konnte nicht abgerufen werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν ήταν δυνατή η λήψη του ονόματος χρήστη για το passkey."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo obtener el nombre de usuario para la clave de acceso."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’obtenir le nom d’utilisateur pour la clé d’accès."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पासकी के लिए उपयोगकर्ता नाम प्राप्त नहीं किया जा सका।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile ottenere il nome utente per la passkey."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスキーのユーザー名を取得できませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "패스키의 사용자 이름을 가져올 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można pobrać nazwy użytkownika dla klucza dostępu."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível obter o nome de usuário para a chave de acesso."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-a putut obține numele de utilizator pentru cheia de acces."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось получить имя пользователя для ключа доступа."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geçiş anahtarı için kullanıcı adı alınamadı."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法获取通行密钥的用户名。"
+          }
+        }
+      }
+    },
+    "Unable to get your Apple ID credential." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر الحصول على بيانات اعتماد Apple ID الخاصة بك."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ihre Apple-ID-Anmeldedaten konnten nicht abgerufen werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν ήταν δυνατή η λήψη των διαπιστευτηρίων Apple ID σας."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo obtener su credencial de Apple ID."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’obtenir vos identifiants Apple ID."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आपका Apple ID क्रेडेंशियल प्राप्त नहीं किया जा सका।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile ottenere le credenziali Apple ID."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple IDの資格情報を取得できませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple ID 자격 증명을 가져올 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można pobrać danych uwierzytelniających Apple ID."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível obter sua credencial do Apple ID."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-au putut obține acreditările Apple ID."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось получить учетные данные Apple ID."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple ID kimlik bilgileriniz alınamadı."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法获取您的 Apple ID 凭据。"
+          }
+        }
+      }
+    },
+    "Unable to retrieve the Apple identity token." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر استرداد رمز هوية Apple."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das Apple-Identitätstoken konnte nicht abgerufen werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν ήταν δυνατή η ανάκτηση του διακριτικού ταυτότητας Apple."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo recuperar el token de identidad de Apple."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de récupérer le jeton d’identité Apple."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple पहचान टोकन प्राप्त नहीं किया जा सका।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile recuperare il token di identità Apple."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AppleのIDトークンを取得できませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple ID 토큰을 가져올 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można pobrać tokenu tożsamości Apple."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível recuperar o token de identidade da Apple."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-a putut prelua tokenul de identitate Apple."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось получить токен идентификации Apple."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple kimlik belirteci alınamadı."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法检索 Apple 身份令牌。"
+          }
+        }
+      }
+    },
+    "Unable to start web authentication session." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر بدء جلسة المصادقة عبر الويب."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Web-Authentifizierungssitzung konnte nicht gestartet werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν ήταν δυνατή η έναρξη περιόδου λειτουργίας ελέγχου ταυτότητας μέσω web."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo iniciar la sesión de autenticación web."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de démarrer la session d’authentification web."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "वेब प्रमाणीकरण सत्र शुरू नहीं किया जा सका।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile avviare la sessione di autenticazione web."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web認証セッションを開始できませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웹 인증 세션을 시작할 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można rozpocząć sesji uwierzytelniania internetowego."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível iniciar a sessão de autenticação web."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-a putut porni sesiunea de autentificare web."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось запустить сеанс веб-аутентификации."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Web kimlik doğrulama oturumu başlatılamadı."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法启动网页身份验证会话。"
+          }
+        }
+      }
+    },
+    "Unable to update membership: missing userId" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر تحديث العضوية: userId مفقود"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mitgliedschaft kann nicht aktualisiert werden: userId fehlt"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν είναι δυνατή η ενημέρωση της ιδιότητας μέλους: λείπει το userId"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede actualizar la membresía: falta userId"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de mettre à jour l’adhésion : userId manquant"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सदस्यता अपडेट नहीं की जा सकी: userId मौजूद नहीं है"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile aggiornare l’appartenenza: userId mancante"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メンバーシップを更新できません：userIdがありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "멤버십을 업데이트할 수 없습니다: userId가 없습니다"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można zaktualizować członkostwa: brakuje userId"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível atualizar a associação: userId ausente"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calitatea de membru nu poate fi actualizată: lipsește userId"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось обновить членство: отсутствует userId"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Üyelik güncellenemiyor: userId eksik"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法更新成员资格：缺少 userId"
+          }
+        }
+      }
+    },
+    "Unable to verify code because no first factor strategy is set." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر التحقق من الرمز لأنه لم يتم تعيين استراتيجية العامل الأول."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Code kann nicht überprüft werden, da keine Strategie für den ersten Faktor festgelegt ist."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν είναι δυνατή η επαλήθευση του κωδικού επειδή δεν έχει οριστεί στρατηγική πρώτου παράγοντα."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede verificar el código porque no se ha establecido ninguna estrategia de primer factor."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de vérifier le code, car aucune stratégie de premier facteur n’est définie."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कोड सत्यापित नहीं किया जा सका क्योंकि कोई प्रथम-कारक रणनीति सेट नहीं है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile verificare il codice perché non è impostata alcuna strategia di primo fattore."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第一要素の方式が設定されていないため、コードを検証できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "첫 번째 인증 요소 전략이 설정되지 않아 코드를 확인할 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można zweryfikować kodu, ponieważ nie ustawiono strategii pierwszego składnika."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível verificar o código porque nenhuma estratégia de primeiro fator foi definida."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Codul nu poate fi verificat deoarece nu este setată nicio strategie pentru primul factor."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невозможно проверить код, поскольку не задана стратегия первого фактора."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İlk faktör stratejisi ayarlanmadığından kod doğrulanamıyor."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法验证代码，因为未设置第一因素策略。"
+          }
+        }
+      }
+    },
+    "Unable to verify code for strategy '%@'." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر التحقق من الرمز للاستراتيجية '%@'."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Code für die Strategie '%@' kann nicht überprüft werden."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν είναι δυνατή η επαλήθευση του κωδικού για τη στρατηγική '%@'."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede verificar el código para la estrategia '%@'."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de vérifier le code pour la stratégie '%@'."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रणनीति '%@' के लिए कोड सत्यापित नहीं किया जा सका।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile verificare il codice per la strategia '%@'."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "方式「%@」のコードを検証できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전략 '%@'의 코드를 확인할 수 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można zweryfikować kodu dla strategii „%@”."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível verificar o código para a estratégia '%@'."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Codul nu poate fi verificat pentru strategia '%@'."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невозможно проверить код для стратегии «%@»."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'%@' stratejisi için kod doğrulanamıyor."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法验证策略“%@”的代码。"
+          }
+        }
+      }
+    },
+    "Watch identity metadata version is exhausted." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم استنفاد إصدار بيانات تعريف هوية Watch."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Version der Metadaten der Watch-Identität ist ausgeschöpft."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Η έκδοση μεταδεδομένων ταυτότητας Watch έχει εξαντληθεί."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se agotó la versión de los metadatos de identidad de Watch."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La version des métadonnées d’identité de la Watch est épuisée."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Watch पहचान मेटाडेटा संस्करण समाप्त हो गया है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La versione dei metadati dell’identità di Watch è esaurita."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WatchのIDメタデータのバージョンを使い切りました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Watch ID 메타데이터 버전이 소진되었습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wersja metadanych tożsamości Watch została wyczerpana."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A versão dos metadados de identidade do Watch foi esgotada."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versiunea metadatelor de identitate Watch a fost epuizată."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Версии метаданных идентификации Watch исчерпаны."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Watch kimlik meta verisi sürümü tükendi."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Watch 身份元数据版本已耗尽。"
           }
         }
       }

--- a/Sources/ClerkKit/Storage/Keychain/Clerk+Keychain.swift
+++ b/Sources/ClerkKit/Storage/Keychain/Clerk+Keychain.swift
@@ -583,7 +583,8 @@ extension Clerk {
 
     guard failures.isEmpty else {
       throw ClerkClientError(
-        message: "Unable to clear Clerk keychain items during reconfiguration."
+        message: "Unable to clear Clerk keychain items during reconfiguration.",
+        localizationBundle: .module
       )
     }
   }

--- a/Sources/ClerkKit/Utils/PKCE.swift
+++ b/Sources/ClerkKit/Utils/PKCE.swift
@@ -32,7 +32,7 @@ enum SecureRandom {
   static func bytes(count: Int) throws -> [UInt8] {
     var bytes = [UInt8](repeating: 0, count: count)
     guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
-      throw ClerkClientError(message: "Unable to generate secure random data.")
+      throw ClerkClientError(message: "Unable to generate secure random data.", localizationBundle: .module)
     }
     return bytes
   }

--- a/Sources/ClerkKit/Utils/WebAuthentication.swift
+++ b/Sources/ClerkKit/Utils/WebAuthentication.swift
@@ -83,7 +83,7 @@ final class WebAuthentication: NSObject {
     } else if let error {
       continuation.resume(throwing: error)
     } else {
-      continuation.resume(throwing: ClerkClientError(message: "Missing callback URL"))
+      continuation.resume(throwing: ClerkClientError(message: "Missing callback URL", localizationBundle: .module))
     }
   }
 
@@ -106,7 +106,7 @@ final class WebAuthentication: NSObject {
 
   private func beginSession(identifier sessionIdentifier: Int, continuation: CheckedContinuation<URL, any Error>) {
     guard Self.activeSession == nil else {
-      continuation.resume(throwing: ClerkClientError(message: "A web authentication session is already in progress."))
+      continuation.resume(throwing: ClerkClientError(message: "A web authentication session is already in progress.", localizationBundle: .module))
       return
     }
 
@@ -153,7 +153,7 @@ final class WebAuthentication: NSObject {
       Self.completeSession(
         identifier: sessionIdentifier,
         with: nil,
-        error: ClerkClientError(message: "Unable to start web authentication session.")
+        error: ClerkClientError(message: "Unable to start web authentication session.", localizationBundle: .module)
       )
       return
     }

--- a/Sources/ClerkKit/WatchSync/WatchConnectivityCoordinator+StatePersistence.swift
+++ b/Sources/ClerkKit/WatchSync/WatchConnectivityCoordinator+StatePersistence.swift
@@ -191,7 +191,7 @@ struct WatchSyncMetadataStore {
     }
     let currentVersion = max(record.effectiveDeviceTokenVersion, record.effectiveAuthVersion)
     guard currentVersion < Int.max else {
-      throw ClerkClientError(message: "Watch identity metadata version is exhausted.")
+      throw ClerkClientError(message: "Watch identity metadata version is exhausted.", localizationBundle: .module)
     }
     let wallClockVersion = Int(Date().timeIntervalSince1970 * 1000)
     let clearVersion = max(currentVersion + 1, minimumVersion ?? wallClockVersion)
@@ -387,7 +387,7 @@ extension WatchConnectivityCoordinator {
       guard record.pendingDeviceTokenVersion != tokenVersion.rawValue
         || record.pendingDeviceTokenFingerprint == fingerprint
       else {
-        throw ClerkClientError(message: "Conflicting Watch token payload reused a pending version.")
+        throw ClerkClientError(message: "Conflicting Watch token payload reused a pending version.", localizationBundle: .module)
       }
       record.pendingDeviceTokenState = deviceToken == nil ? .cleared : .set
       record.pendingDeviceTokenVersion = tokenVersion.rawValue
@@ -407,7 +407,7 @@ extension WatchConnectivityCoordinator {
       guard record.pendingAuthVersion != authVersion.rawValue
         || record.pendingAuthFingerprint == fingerprint
       else {
-        throw ClerkClientError(message: "Conflicting Watch auth payload reused a pending version.")
+        throw ClerkClientError(message: "Conflicting Watch auth payload reused a pending version.", localizationBundle: .module)
       }
       record.pendingAuthState = intent.client == nil ? .cleared : .set
       record.pendingAuthVersion = authVersion.rawValue
@@ -537,7 +537,7 @@ extension WatchConnectivityCoordinator {
       }
     }
     guard !record.hasPendingIdentityMetadata else {
-      throw ClerkClientError(message: "A Watch identity metadata transition is still pending.")
+      throw ClerkClientError(message: "A Watch identity metadata transition is still pending.", localizationBundle: .module)
     }
     return record
   }

--- a/Sources/ClerkKit/WatchSync/WatchSyncPayload.swift
+++ b/Sources/ClerkKit/WatchSync/WatchSyncPayload.swift
@@ -220,7 +220,7 @@ package struct WatchSyncPayload {
     authGeneration: WatchSyncVersion
   ) throws {
     guard !metadata.hasPendingIdentityMetadata else {
-      throw ClerkClientError(message: "Cannot publish unresolved Watch identity metadata.")
+      throw ClerkClientError(message: "Cannot publish unresolved Watch identity metadata.", localizationBundle: .module)
     }
     deviceTokenUpdate = Self.deviceTokenUpdate(
       deviceToken: clerk.deviceToken,

--- a/Sources/ClerkKitUI/Common/Badge.swift
+++ b/Sources/ClerkKitUI/Common/Badge.swift
@@ -118,7 +118,7 @@ extension View {
   func lastUsedAuthBadgeOverlay(_ isVisible: Bool) -> some View {
     overlay(alignment: .topTrailing) {
       if isVisible {
-        Badge(key: "Last Used", style: .secondary)
+        Badge(key: "Last used", style: .secondary)
           .padding(.trailing, 8)
           .visualEffect { content, proxy in
             content.offset(y: -proxy.size.height / 2)

--- a/Sources/ClerkKitUI/Common/CancelToolbarItem.swift
+++ b/Sources/ClerkKitUI/Common/CancelToolbarItem.swift
@@ -3,14 +3,17 @@
 import SwiftUI
 
 struct CancelToolbarItem: ToolbarContent {
-  @Environment(\.dismiss) private var dismiss
   @Environment(\.clerkTheme) private var theme
+
+  private let action: () -> Void
+
+  init(action: @escaping () -> Void) {
+    self.action = action
+  }
 
   var body: some ToolbarContent {
     ToolbarItem(placement: .cancellationAction) {
-      Button {
-        dismiss()
-      } label: {
+      Button(action: action) {
         Text("Cancel", bundle: .module)
       }
       .foregroundStyle(theme.colors.primary)

--- a/Sources/ClerkKitUI/Common/CancelToolbarItem.swift
+++ b/Sources/ClerkKitUI/Common/CancelToolbarItem.swift
@@ -1,0 +1,21 @@
+#if os(iOS) || os(macOS)
+
+import SwiftUI
+
+struct CancelToolbarItem: ToolbarContent {
+  @Environment(\.dismiss) private var dismiss
+  @Environment(\.clerkTheme) private var theme
+
+  var body: some ToolbarContent {
+    ToolbarItem(placement: .cancellationAction) {
+      Button {
+        dismiss()
+      } label: {
+        Text("Cancel", bundle: .module)
+      }
+      .foregroundStyle(theme.colors.primary)
+    }
+  }
+}
+
+#endif

--- a/Sources/ClerkKitUI/Common/ClerkTextField.swift
+++ b/Sources/ClerkKitUI/Common/ClerkTextField.swift
@@ -132,6 +132,9 @@ struct ClerkTextField: View {
             .foregroundStyle(theme.colors.mutedForeground)
         }
         .frame(width: 24)
+        .accessibilityLabel(
+          Text(revealText ? "Hide password" : "Show password", bundle: .module)
+        )
       }
     }
     .opacity(isEnabled ? 1 : 0.6)

--- a/Sources/ClerkKitUI/Common/ErrorText.swift
+++ b/Sources/ClerkKitUI/Common/ErrorText.swift
@@ -40,7 +40,7 @@ struct ErrorText: View {
 }
 
 #Preview {
-  ErrorText(error: ClerkClientError(message: "Password is incorrect. Try again, or use another method."))
+  ErrorText(error: ClerkClientError(message: "Password is incorrect. Try again, or use another method.", localizationBundle: .module))
     .padding()
 }
 

--- a/Sources/ClerkKitUI/Common/ErrorView.swift
+++ b/Sources/ClerkKitUI/Common/ErrorView.swift
@@ -75,7 +75,7 @@ struct ErrorView: View {
 
 #Preview {
   ErrorView(
-    error: ClerkClientError(message: "Similique qui enim placeat tempore. Labore voluptates aliquam est quaerat aut perferendis similique."),
+    error: ClerkClientError(message: "Similique qui enim placeat tempore. Labore voluptates aliquam est quaerat aut perferendis similique.", localizationBundle: .module),
     action: .init(
       text: "Call to action",
       action: {

--- a/Sources/ClerkKitUI/Common/MacOSBackButton.swift
+++ b/Sources/ClerkKitUI/Common/MacOSBackButton.swift
@@ -26,6 +26,7 @@ struct MacOSBackButton: View {
           )
       }
       .buttonStyle(.plain)
+      .accessibilityLabel(Text("Back", bundle: .module))
 
       Spacer()
     }

--- a/Sources/ClerkKitUI/Common/ThreeDotsMenuLabel.swift
+++ b/Sources/ClerkKitUI/Common/ThreeDotsMenuLabel.swift
@@ -15,6 +15,7 @@ struct ThreeDotsMenuLabel: View {
       .scaledToFit()
       .foregroundColor(theme.colors.mutedForeground)
       .frame(width: 20, height: 20)
+      .accessibilityLabel(Text("Manage", bundle: .module))
   }
 }
 

--- a/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskBackupCodesView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskBackupCodesView.swift
@@ -25,7 +25,7 @@ struct SessionTaskBackupCodesView: View {
     case .phoneCode:
       "SMS code verification enabled"
     case .authenticatorApp:
-      "Authenticator app verification enabled"
+      "Authenticator application verification enabled"
     }
   }
 

--- a/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskChooseOrganizationView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskChooseOrganizationView.swift
@@ -71,7 +71,7 @@ struct SessionTaskChooseOrganizationView: View {
     ScrollView {
       VStack(spacing: 32) {
         VStack(spacing: 8) {
-          HeaderView(style: .title, text: "Choose an Organization")
+          HeaderView(style: .title, text: "Choose an organization")
           if user?.createOrganizationEnabled == true {
             HeaderView(style: .subtitle, text: "Join an existing organization or create a new one")
           } else {

--- a/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskChooseOrganizationView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskChooseOrganizationView.swift
@@ -130,9 +130,9 @@ struct SessionTaskChooseOrganizationView: View {
        ["organization_not_found_or_unauthorized", "not_a_member_in_organization"].contains(clerkError.code)
     {
       if user?.createOrganizationEnabled == true {
-        return ClerkClientError(message: "You are no longer a member of this organization. Please choose or create another one.")
+        return ClerkClientError(message: "You are no longer a member of this organization. Please choose or create another one.", localizationBundle: .module)
       } else {
-        return ClerkClientError(message: "You are no longer a member of this organization. Please choose another one.")
+        return ClerkClientError(message: "You are no longer a member of this organization. Please choose another one.", localizationBundle: .module)
       }
     }
     return error

--- a/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskMfaVerifySmsView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskMfaVerifySmsView.swift
@@ -44,7 +44,7 @@ struct SessionTaskMfaVerifySmsView: View {
       VStack(spacing: 0) {
         SessionTaskHeaderSection(
           title: "Verify your phone number",
-          subtitle: "A text message containing a verification code will be sent to this phone number. Message and data rates may apply."
+          subtitle: "Enter the verification code sent to"
         )
         .padding(.bottom, 16)
 

--- a/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskMfaVerifyTotpView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskMfaVerifyTotpView.swift
@@ -25,7 +25,7 @@ struct SessionTaskMfaVerifyTotpView: View {
       VStack(spacing: 0) {
         SessionTaskHeaderSection(
           title: "Add authenticator application",
-          subtitle: "Enter the verification code from authenticator application"
+          subtitle: "Enter the verification code from your authenticator application."
         )
         .padding(.bottom, 24)
 

--- a/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskMfaVerifyTotpView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskMfaVerifyTotpView.swift
@@ -25,7 +25,7 @@ struct SessionTaskMfaVerifyTotpView: View {
       VStack(spacing: 0) {
         SessionTaskHeaderSection(
           title: "Add authenticator application",
-          subtitle: "Enter the verification code from your authenticator application."
+          subtitle: "Enter the verification code from your authenticator app."
         )
         .padding(.bottom, 24)
 

--- a/Sources/ClerkKitUI/Components/Auth/SignIn/SignInFactorCodeView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/SignIn/SignInFactorCodeView.swift
@@ -323,7 +323,7 @@ extension SignInFactorCodeView {
     case .totp:
       return try await signIn.verifyMfaCode(code, type: .totp)
     default:
-      throw ClerkClientError(message: "Unknown code verification method. Please use another method.")
+      throw ClerkClientError(message: "Unknown code verification method. Please use another method.", localizationBundle: .module)
     }
   }
 

--- a/Sources/ClerkKitUI/Components/Auth/SignIn/SignInFactorOneEmailLinkView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/SignIn/SignInFactorOneEmailLinkView.swift
@@ -237,14 +237,14 @@ extension EmailLinkVerificationView {
   @MainActor
   private func openEmailApp() {
     guard let url = URL(string: "mailto:") else {
-      error = ClerkClientError(message: "No email app is available on this device.")
+      error = ClerkClientError(message: "No email app is available on this device.", localizationBundle: .module)
       return
     }
 
     openURL(url) { accepted in
       if !accepted {
         Task { @MainActor in
-          error = ClerkClientError(message: "No email app is available on this device.")
+          error = ClerkClientError(message: "No email app is available on this device.", localizationBundle: .module)
         }
       }
     }

--- a/Sources/ClerkKitUI/Components/Auth/SignIn/SignInFactorTwoBackupCodeView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/SignIn/SignInFactorTwoBackupCodeView.swift
@@ -30,7 +30,7 @@ struct SignInFactorTwoBackupCodeView: View {
       VStack(spacing: 0) {
         VStack(spacing: 8) {
           HeaderView(style: .title, text: "Enter a backup code")
-          HeaderView(style: .subtitle, text: "Your backup code is the one you got when setting up two-step authentication.")
+          HeaderView(style: .subtitle, text: "Your backup code is the one you got when setting up two-step verification.")
         }
         .padding(.bottom, 32)
 
@@ -78,6 +78,14 @@ struct SignInFactorTwoBackupCodeView: View {
           Text("Use another method", bundle: .module)
             .frame(maxWidth: .infinity)
         }
+        .buttonStyle(
+          .primary(
+            config: .init(
+              emphasis: .none,
+              size: .small
+            )
+          )
+        )
         .padding(.bottom, 32)
 
         SecuredByClerkView()

--- a/Sources/ClerkKitUI/Components/Auth/SignIn/SignInSetNewPasswordView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/SignIn/SignInSetNewPasswordView.swift
@@ -158,7 +158,7 @@ extension SignInSetNewPasswordView {
 
     do {
       guard authState.signInNewPassword == authState.signInConfirmNewPassword else {
-        throw ClerkClientError(message: "Passwords don't match.")
+        throw ClerkClientError(message: "Passwords don't match.", localizationBundle: .module)
       }
 
       switch mode {

--- a/Sources/ClerkKitUI/Components/Auth/SignIn/SignInSetNewPasswordView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/SignIn/SignInSetNewPasswordView.swift
@@ -63,7 +63,7 @@ struct SignInSetNewPasswordView: View {
             isSecure: true,
             fieldState: fieldError != nil ? .error : .default
           )
-          .textContentType(.newPassword)
+          .textContentType(ClerkE2EEnvironment.isEnabled ? nil : .newPassword)
           #if os(iOS)
           .textInputAutocapitalization(.never)
           #endif
@@ -85,7 +85,7 @@ struct SignInSetNewPasswordView: View {
               isSecure: true,
               fieldState: fieldError != nil ? .error : .default
             )
-            .textContentType(.newPassword)
+            .textContentType(ClerkE2EEnvironment.isEnabled ? nil : .newPassword)
             #if os(iOS)
             .textInputAutocapitalization(.never)
             #endif

--- a/Sources/ClerkKitUI/Components/Auth/SignUp/SignUpCompleteProfileView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/SignUp/SignUpCompleteProfileView.swift
@@ -58,7 +58,7 @@ struct SignUpCompleteProfileView: View {
     ScrollView {
       VStack(spacing: 32) {
         VStack(spacing: 8) {
-          HeaderView(style: .title, text: "Profile Details")
+          HeaderView(style: .title, text: "Profile details")
           HeaderView(style: .subtitle, text: "Complete your profile")
         }
 

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationAddDomainView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationAddDomainView.swift
@@ -86,12 +86,7 @@ struct OrganizationAddDomainView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
 
         ToolbarItem(placement: .principal) {
           Text("Add domain", bundle: .module)

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationAddDomainView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationAddDomainView.swift
@@ -86,7 +86,9 @@ struct OrganizationAddDomainView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
 
         ToolbarItem(placement: .principal) {
           Text("Add domain", bundle: .module)

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationDomainDeleteConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationDomainDeleteConfirmationView.swift
@@ -59,7 +59,9 @@ struct OrganizationDomainDeleteConfirmationView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
 
         ToolbarItem(placement: .principal) {
           Text("Remove domain", bundle: .module)

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationDomainDeleteConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationDomainDeleteConfirmationView.swift
@@ -59,12 +59,7 @@ struct OrganizationDomainDeleteConfirmationView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
 
         ToolbarItem(placement: .principal) {
           Text("Remove domain", bundle: .module)

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationDomainEnrollmentModeView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationDomainEnrollmentModeView.swift
@@ -95,7 +95,9 @@ struct OrganizationDomainEnrollmentModeView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
 
         ToolbarItem(placement: .principal) {
           Text("Update \(domain.name)", bundle: .module)

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationDomainEnrollmentModeView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationDomainEnrollmentModeView.swift
@@ -95,12 +95,7 @@ struct OrganizationDomainEnrollmentModeView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
 
         ToolbarItem(placement: .principal) {
           Text("Update \(domain.name)", bundle: .module)
@@ -231,7 +226,7 @@ private struct OrganizationDomainEnrollmentModeOption: Identifiable {
       .init(
         mode: .automaticInvitation,
         title: "Automatic invitations",
-        description: "Users are automatically invited to join the organization when they sign-up and can join anytime."
+        description: "Users are automatically invited to join the organization when they sign up and can join anytime."
       ),
       .init(
         mode: .automaticSuggestion,

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationInviteMembersView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationInviteMembersView.swift
@@ -236,7 +236,7 @@ struct OrganizationInviteMembersView: View {
     let submittedEmailAddresses = emailAddresses
     guard !submittedEmailAddresses.isEmpty, roleOptions.contains(where: { $0.key == selectedRoleKey }) else { return }
     guard let organization = clerk.organization else {
-      error = ClerkClientError(message: "Unable to send invitations without an active organization.")
+      error = ClerkClientError(message: "Unable to send invitations without an active organization.", localizationBundle: .module)
       return
     }
 

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationListView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationListView.swift
@@ -192,12 +192,7 @@ public struct OrganizationListView: View {
     .toolbar {
       #if os(iOS)
       if isDismissible {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
       }
       #endif
 

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationListView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationListView.swift
@@ -326,7 +326,7 @@ extension OrganizationListView {
     if let clerkError = error as? ClerkAPIError,
        ["organization_not_found_or_unauthorized", "not_a_member_in_organization"].contains(clerkError.code)
     {
-      return ClerkClientError(message: "You are no longer a member of this organization. Please choose another one.")
+      return ClerkClientError(message: "You are no longer a member of this organization. Please choose another one.", localizationBundle: .module)
     }
     return error
   }

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationListView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationListView.swift
@@ -192,7 +192,9 @@ public struct OrganizationListView: View {
     .toolbar {
       #if os(iOS)
       if isDismissible {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
       }
       #endif
 

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationMembersRows.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationMembersRows.swift
@@ -35,10 +35,6 @@ struct OrganizationMemberRow: View {
     publicUserData?.identifier
   }
 
-  private var joinedDate: String {
-    membership.createdAt.formatted(.dateTime.month(.defaultDigits).day(.defaultDigits).year())
-  }
-
   private var roleMenuIsDisabled: Bool {
     roles.isEmpty || hasRoleSetMigration || isMutating
   }
@@ -78,7 +74,10 @@ struct OrganizationMemberRow: View {
           }
 
           if isCurrentUser {
-            Text("\(roleName) · Joined \(joinedDate)", bundle: .module)
+            Text(
+              "\(roleName) · Joined \(membership.createdAt, format: .dateTime.month(.defaultDigits).day(.defaultDigits).year())",
+              bundle: .module
+            )
               .font(theme.fonts.footnote)
               .foregroundStyle(theme.colors.mutedForeground)
               .lineLimit(1)
@@ -87,7 +86,10 @@ struct OrganizationMemberRow: View {
               .font(theme.fonts.subheadline)
               .foregroundStyle(theme.colors.mutedForeground)
               .lineLimit(1)
-            Text("Joined \(joinedDate)", bundle: .module)
+            Text(
+              "Joined \(membership.createdAt, format: .dateTime.month(.defaultDigits).day(.defaultDigits).year())",
+              bundle: .module
+            )
               .font(theme.fonts.subheadline)
               .foregroundStyle(theme.colors.mutedForeground)
               .lineLimit(1)
@@ -149,10 +151,6 @@ struct OrganizationInvitationRow: View {
   let isRevoking: Bool
   let onRevoke: () async -> Void
 
-  private var invitedDate: String {
-    invitation.createdAt.formatted(.dateTime.month(.defaultDigits).day(.defaultDigits).year())
-  }
-
   var body: some View {
     HStack(alignment: .center, spacing: 16) {
       HStack(alignment: .top, spacing: 16) {
@@ -169,7 +167,10 @@ struct OrganizationInvitationRow: View {
             .foregroundStyle(theme.colors.mutedForeground)
             .lineLimit(1)
 
-          Text("Invited \(invitedDate)", bundle: .module)
+          Text(
+            "Invited \(invitation.createdAt, format: .dateTime.month(.defaultDigits).day(.defaultDigits).year())",
+            bundle: .module
+          )
             .font(theme.fonts.subheadline)
             .foregroundStyle(theme.colors.mutedForeground)
             .lineLimit(1)
@@ -221,10 +222,6 @@ struct OrganizationMembershipRequestRow: View {
     publicUserData?.identifier
   }
 
-  private var requestedDate: String {
-    request.createdAt.formatted(.dateTime.month(.defaultDigits).day(.defaultDigits).year())
-  }
-
   var body: some View {
     HStack(alignment: .center, spacing: 16) {
       HStack(alignment: .top, spacing: 16) {
@@ -245,7 +242,10 @@ struct OrganizationMembershipRequestRow: View {
               .lineLimit(1)
           }
 
-          Text("Requested \(requestedDate)", bundle: .module)
+          Text(
+            "Requested \(request.createdAt, format: .dateTime.month(.defaultDigits).day(.defaultDigits).year())",
+            bundle: .module
+          )
             .font(theme.fonts.subheadline)
             .foregroundStyle(theme.colors.mutedForeground)
             .lineLimit(1)

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationMembersRows.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationMembersRows.swift
@@ -78,7 +78,7 @@ struct OrganizationMemberRow: View {
           }
 
           if isCurrentUser {
-            Text(verbatim: "\(roleName) · Joined \(joinedDate)")
+            Text("\(roleName) · Joined \(joinedDate)", bundle: .module)
               .font(theme.fonts.footnote)
               .foregroundStyle(theme.colors.mutedForeground)
               .lineLimit(1)
@@ -87,7 +87,7 @@ struct OrganizationMemberRow: View {
               .font(theme.fonts.subheadline)
               .foregroundStyle(theme.colors.mutedForeground)
               .lineLimit(1)
-            Text(verbatim: "Joined \(joinedDate)")
+            Text("Joined \(joinedDate)", bundle: .module)
               .font(theme.fonts.subheadline)
               .foregroundStyle(theme.colors.mutedForeground)
               .lineLimit(1)
@@ -169,7 +169,7 @@ struct OrganizationInvitationRow: View {
             .foregroundStyle(theme.colors.mutedForeground)
             .lineLimit(1)
 
-          Text(verbatim: "Invited \(invitedDate)")
+          Text("Invited \(invitedDate)", bundle: .module)
             .font(theme.fonts.subheadline)
             .foregroundStyle(theme.colors.mutedForeground)
             .lineLimit(1)
@@ -245,7 +245,7 @@ struct OrganizationMembershipRequestRow: View {
               .lineLimit(1)
           }
 
-          Text(verbatim: "Requested \(requestedDate)")
+          Text("Requested \(requestedDate)", bundle: .module)
             .font(theme.fonts.subheadline)
             .foregroundStyle(theme.colors.mutedForeground)
             .lineLimit(1)

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationProfileActionConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationProfileActionConfirmationView.swift
@@ -86,12 +86,7 @@ struct OrganizationProfileActionConfirmationView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
 
         ToolbarItem(placement: .principal) {
           Text(action.title, bundle: .module)

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationProfileActionConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationProfileActionConfirmationView.swift
@@ -86,7 +86,9 @@ struct OrganizationProfileActionConfirmationView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
 
         ToolbarItem(placement: .principal) {
           Text(action.title, bundle: .module)

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationProfileFormView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationProfileFormView.swift
@@ -377,9 +377,7 @@ extension OrganizationProfileFormView {
     guard !name.isEmpty else { return }
 
     guard !slugEnabled || isValidSlug(trimmedSlug) else {
-      slugValidationError = ClerkClientError(
-        message: "Enter a slug using lowercase letters, numbers, and hyphens."
-      )
+      slugValidationError = ClerkClientError(message: "Enter a slug using lowercase letters, numbers, and hyphens.", localizationBundle: .module)
       return
     }
 
@@ -424,7 +422,7 @@ extension OrganizationProfileFormView {
     slug: String?
   ) async throws -> Organization {
     guard let organization else {
-      throw ClerkClientError(message: "Unable to update organization without an active organization.")
+      throw ClerkClientError(message: "Unable to update organization without an active organization.", localizationBundle: .module)
     }
 
     let updatedOrganization = try await organization.update(name: name, slug: slug)
@@ -458,7 +456,7 @@ extension OrganizationProfileFormView {
           let data = try await item.loadTransferable(type: Data.self),
           let resizedData = processImageData(data)
         else {
-          throw ClerkClientError(message: "There was an error loading the image from the photos library.")
+          throw ClerkClientError(message: "There was an error loading the image from the photos library.", localizationBundle: .module)
         }
         guard !Task.isCancelled else { return }
         if mode.isUpdate {
@@ -490,7 +488,7 @@ extension OrganizationProfileFormView {
         let url = try result.get()
         let data = try await Self.readSecurityScopedFileData(from: url)
         guard let resizedData = processImageData(data) else {
-          throw ClerkClientError(message: "There was an error loading the selected image file.")
+          throw ClerkClientError(message: "There was an error loading the selected image file.", localizationBundle: .module)
         }
         guard !Task.isCancelled else { return }
         photosPickerItem = nil

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationProfileUpdateProfileView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationProfileUpdateProfileView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct OrganizationProfileUpdateProfileView: View {
   @Environment(\.clerkTheme) private var theme
+  @Environment(\.dismiss) private var dismiss
 
   private let organization: Organization
 
@@ -26,7 +27,9 @@ struct OrganizationProfileUpdateProfileView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
 
         ToolbarItem(placement: .principal) {
           Text("Update profile", bundle: .module)

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationProfileUpdateProfileView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationProfileUpdateProfileView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct OrganizationProfileUpdateProfileView: View {
   @Environment(\.clerkTheme) private var theme
-  @Environment(\.dismiss) private var dismiss
 
   private let organization: Organization
 
@@ -27,12 +26,7 @@ struct OrganizationProfileUpdateProfileView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
 
         ToolbarItem(placement: .principal) {
           Text("Update profile", bundle: .module)

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationVerifiedDomainsView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationVerifiedDomainsView.swift
@@ -363,7 +363,9 @@ private struct OrganizationDomainVerificationFlowSheet: View {
         path.append(.verifyCode(preparedDomain, affiliationEmailAddress: affiliationEmailAddress))
       }
       .toolbar {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
       }
       .navigationDestination(for: Destination.self) { destination in
         switch destination {

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationVerifiedDomainsView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationVerifiedDomainsView.swift
@@ -363,12 +363,7 @@ private struct OrganizationDomainVerificationFlowSheet: View {
         path.append(.verifyCode(preparedDomain, affiliationEmailAddress: affiliationEmailAddress))
       }
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
       }
       .navigationDestination(for: Destination.self) { destination in
         switch destination {

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddConnectedAccountView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddConnectedAccountView.swift
@@ -80,12 +80,7 @@ struct UserProfileAddConnectedAccountView: View {
       .scrollBounceBehavior(.basedOnSize)
       .background(theme.colors.background)
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
 
         ToolbarItem(placement: .principal) {
           Text("Connect account", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddConnectedAccountView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddConnectedAccountView.swift
@@ -80,7 +80,9 @@ struct UserProfileAddConnectedAccountView: View {
       .scrollBounceBehavior(.basedOnSize)
       .background(theme.colors.background)
       .toolbar {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
 
         ToolbarItem(placement: .principal) {
           Text("Connect account", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddEmailView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddEmailView.swift
@@ -93,12 +93,7 @@ struct UserProfileAddEmailView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
 
         ToolbarItem(placement: .principal) {
           Text("Add email address", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddEmailView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddEmailView.swift
@@ -93,7 +93,9 @@ struct UserProfileAddEmailView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
 
         ToolbarItem(placement: .principal) {
           Text("Add email address", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddMfaView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddMfaView.swift
@@ -12,7 +12,6 @@ struct UserProfileAddMfaView: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
   @Environment(UserProfileSheetNavigation.self) private var navigation
-  @Environment(\.dismiss) private var dismiss
 
   @State private var error: Error?
 
@@ -119,12 +118,7 @@ struct UserProfileAddMfaView: View {
         .preGlassSolidNavBar()
         .preGlassDetentSheetBackground()
         .toolbar {
-          ToolbarItem(placement: .cancellationAction) {
-            Button("Cancel") {
-              dismiss()
-            }
-            .foregroundStyle(theme.colors.primary)
-          }
+          CancelToolbarItem()
 
           ToolbarItem(placement: .principal) {
             Text("Add two-step verification", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddMfaView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddMfaView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct UserProfileAddMfaView: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
+  @Environment(\.dismiss) private var dismiss
   @Environment(UserProfileSheetNavigation.self) private var navigation
 
   @State private var error: Error?
@@ -118,7 +119,9 @@ struct UserProfileAddMfaView: View {
         .preGlassSolidNavBar()
         .preGlassDetentSheetBackground()
         .toolbar {
-          CancelToolbarItem()
+          CancelToolbarItem {
+            dismiss()
+          }
 
           ToolbarItem(placement: .principal) {
             Text("Add two-step verification", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddPhoneView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddPhoneView.swift
@@ -96,7 +96,9 @@ struct UserProfileAddPhoneView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
 
         ToolbarItem(placement: .principal) {
           Text("Add phone number", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddPhoneView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileAddPhoneView.swift
@@ -96,12 +96,7 @@ struct UserProfileAddPhoneView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
 
         ToolbarItem(placement: .principal) {
           Text("Add phone number", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileChangePasswordView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileChangePasswordView.swift
@@ -100,12 +100,7 @@ struct UserProfileChangePasswordView: View {
     #endif
     .preGlassSolidNavBar()
     .toolbar {
-      ToolbarItem(placement: .cancellationAction) {
-        Button("Cancel") {
-          dismiss()
-        }
-        .foregroundStyle(theme.colors.primary)
-      }
+      CancelToolbarItem()
 
       ToolbarItem(placement: .principal) {
         Text("Update password", bundle: .module)
@@ -181,12 +176,7 @@ struct UserProfileChangePasswordView: View {
     .preGlassSolidNavBar()
     .toolbar {
       if isAddingPassword {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
       }
 
       ToolbarItem(placement: .principal) {

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileChangePasswordView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileChangePasswordView.swift
@@ -100,7 +100,9 @@ struct UserProfileChangePasswordView: View {
     #endif
     .preGlassSolidNavBar()
     .toolbar {
-      CancelToolbarItem()
+      CancelToolbarItem {
+        dismiss()
+      }
 
       ToolbarItem(placement: .principal) {
         Text("Update password", bundle: .module)
@@ -176,7 +178,9 @@ struct UserProfileChangePasswordView: View {
     .preGlassSolidNavBar()
     .toolbar {
       if isAddingPassword {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
       }
 
       ToolbarItem(placement: .principal) {

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
@@ -80,12 +80,7 @@ struct UserProfileDeleteAccountConfirmationView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
 
         ToolbarItem(placement: .principal) {
           Text("Delete account", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountConfirmationView.swift
@@ -80,7 +80,9 @@ struct UserProfileDeleteAccountConfirmationView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
 
         ToolbarItem(placement: .principal) {
           Text("Delete account", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileEmailRow.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileEmailRow.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct UserProfileEmailRow: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
+  @Environment(\.locale) private var locale
 
   @State private var addEmailAddressDestination: UserProfileAddEmailView.Destination?
   @State private var isLoading = false
@@ -116,14 +117,14 @@ struct UserProfileEmailRow: View {
       if $1 != nil { isConfirmingRemoval = true }
     }
     .confirmationDialog(
-      removeResource?.messageLine1 ?? "",
+      removeResource?.messageLine1(locale: locale) ?? "",
       isPresented: $isConfirmingRemoval,
       titleVisibility: .visible,
       actions: {
         AsyncButton(role: .destructive) {
           await removeResource(removeResource)
         } label: { _ in
-          Text(removeResource?.title ?? "", bundle: .module)
+          Text(verbatim: removeResource?.title(locale: locale) ?? "")
         }
         .onIsRunningChanged { isLoading = $0 }
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileExternalAccountRow.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileExternalAccountRow.swift
@@ -14,6 +14,7 @@ struct UserProfileExternalAccountRow: View {
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.clerkUserProfileOAuthConfig) private var oauthConfig
   @Environment(\.clerkTheme) private var theme
+  @Environment(\.locale) private var locale
 
   @State private var removeResource: RemoveResource?
   @State private var isConfirmingRemoval = false
@@ -116,14 +117,14 @@ struct UserProfileExternalAccountRow: View {
       if $1 != nil { isConfirmingRemoval = true }
     }
     .confirmationDialog(
-      removeResource?.messageLine1 ?? "",
+      removeResource?.messageLine1(locale: locale) ?? "",
       isPresented: $isConfirmingRemoval,
       titleVisibility: .visible,
       actions: {
         AsyncButton(role: .destructive) {
           await removeResource(removeResource)
         } label: { _ in
-          Text(removeResource?.title ?? "", bundle: .module)
+          Text(verbatim: removeResource?.title(locale: locale) ?? "")
         }
         .onIsRunningChanged { isLoading = $0 }
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddSmsView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddSmsView.swift
@@ -12,7 +12,6 @@ import SwiftUI
 struct UserProfileMfaAddSmsView: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
-  @Environment(\.dismiss) private var dismiss
   @Environment(UserProfileSheetNavigation.self) private var navigation
 
   @State private var selectedPhoneNumber: ClerkKit.PhoneNumber?
@@ -109,12 +108,7 @@ struct UserProfileMfaAddSmsView: View {
         #endif
         .preGlassSolidNavBar()
         .toolbar {
-          ToolbarItem(placement: .cancellationAction) {
-            Button("Cancel") {
-              dismiss()
-            }
-            .foregroundStyle(theme.colors.primary)
-          }
+          CancelToolbarItem()
 
           ToolbarItem(placement: .principal) {
             Text("Add SMS code verification", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddSmsView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddSmsView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct UserProfileMfaAddSmsView: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
+  @Environment(\.dismiss) private var dismiss
   @Environment(UserProfileSheetNavigation.self) private var navigation
 
   @State private var selectedPhoneNumber: ClerkKit.PhoneNumber?
@@ -108,7 +109,9 @@ struct UserProfileMfaAddSmsView: View {
         #endif
         .preGlassSolidNavBar()
         .toolbar {
-          CancelToolbarItem()
+          CancelToolbarItem {
+            dismiss()
+          }
 
           ToolbarItem(placement: .principal) {
             Text("Add SMS code verification", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddTotpView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddTotpView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct UserProfileMfaAddTotpView: View {
   @Environment(\.clerkTheme) private var theme
+  @Environment(\.dismiss) private var dismiss
   @Environment(UserProfileSheetNavigation.self) private var navigation
 
   @State private var path = NavigationPath()
@@ -105,7 +106,9 @@ struct UserProfileMfaAddTotpView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
 
         ToolbarItem(placement: .principal) {
           Text("Add authenticator application", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddTotpView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddTotpView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct UserProfileMfaAddTotpView: View {
   @Environment(\.clerkTheme) private var theme
   @Environment(UserProfileSheetNavigation.self) private var navigation
-  @Environment(\.dismiss) private var dismiss
 
   @State private var path = NavigationPath()
   @State private var error: Error?
@@ -106,12 +105,7 @@ struct UserProfileMfaAddTotpView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
 
         ToolbarItem(placement: .principal) {
           Text("Add authenticator application", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaRow.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaRow.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct UserProfileMfaRow: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
+  @Environment(\.locale) private var locale
   @Environment(UserProfileSheetNavigation.self) private var navigation
 
   @State private var isConfirmingRemoval = false
@@ -43,7 +44,7 @@ struct UserProfileMfaRow: View {
   private var text: Text {
     switch style {
     case .authenticatorApp:
-      Text("Authenticator app", bundle: .module)
+      Text("Authenticator application", bundle: .module)
     case .sms:
       Text("SMS code", bundle: .module)
     case .backupCodes:
@@ -55,8 +56,10 @@ struct UserProfileMfaRow: View {
   private var menuItems: some View {
     switch style {
     case .authenticatorApp:
-      Button("Remove", role: .destructive) {
+      Button(role: .destructive) {
         removeResource = .totp
+      } label: {
+        Text("Remove", bundle: .module)
       }
     case let .sms(phoneNumber):
       if user?.totpEnabled != true, !phoneNumber.defaultSecondFactor {
@@ -68,8 +71,10 @@ struct UserProfileMfaRow: View {
         .onIsRunningChanged { isLoading = $0 }
       }
 
-      Button("Remove", role: .destructive) {
+      Button(role: .destructive) {
         removeResource = .secondFactorPhoneNumber(phoneNumber)
+      } label: {
+        Text("Remove", bundle: .module)
       }
     case .backupCodes:
       AsyncButton {
@@ -129,18 +134,19 @@ struct UserProfileMfaRow: View {
         .frame(height: 1)
         .foregroundStyle(theme.colors.border)
     }
+    .clerkErrorPresenting($error)
     .onChange(of: removeResource) {
       if $1 != nil { isConfirmingRemoval = true }
     }
     .confirmationDialog(
-      removeResource?.messageLine1 ?? "",
+      removeResource?.messageLine1(locale: locale) ?? "",
       isPresented: $isConfirmingRemoval,
       titleVisibility: .visible,
       actions: {
         AsyncButton(role: .destructive) {
           await removeResource()
         } label: { _ in
-          Text(removeResource?.title ?? "", bundle: .module)
+          Text(verbatim: removeResource?.title(locale: locale) ?? "")
         }
         .onIsRunningChanged { isLoading = $0 }
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfilePasskeyRenameView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfilePasskeyRenameView.swift
@@ -65,7 +65,9 @@ struct UserProfilePasskeyRenameView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
 
         ToolbarItem(placement: .principal) {
           Text("Rename passkey", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfilePasskeyRenameView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfilePasskeyRenameView.swift
@@ -65,12 +65,7 @@ struct UserProfilePasskeyRenameView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
 
         ToolbarItem(placement: .principal) {
           Text("Rename passkey", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfilePasskeyRow.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfilePasskeyRow.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct UserProfilePasskeyRow: View {
   @Environment(\.clerkTheme) private var theme
+  @Environment(\.locale) private var locale
 
   @State private var renameIsPresented = false
   @State private var isConfirmingRemoval = false
@@ -76,16 +77,23 @@ struct UserProfilePasskeyRow: View {
       UserProfilePasskeyRenameView(passkey: passkey)
     }
     .confirmationDialog(
-      removeResource?.messageLine1 ?? "",
+      removeResource?.messageLine1(locale: locale) ?? "",
       isPresented: $isConfirmingRemoval,
       titleVisibility: .visible,
       actions: {
         AsyncButton(role: .destructive) {
           await removeResource()
         } label: { _ in
-          Text(removeResource?.title ?? "", bundle: .module)
+          Text(verbatim: removeResource?.title(locale: locale) ?? "")
         }
         .onIsRunningChanged { isLoading = $0 }
+
+        Button(role: .cancel) {
+          isConfirmingRemoval = false
+          removeResource = nil
+        } label: {
+          Text("Cancel", bundle: .module)
+        }
       }
     )
     .onChange(of: removeResource) {

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfilePhoneRow.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfilePhoneRow.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct UserProfilePhoneRow: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
+  @Environment(\.locale) private var locale
 
   @State private var addPhoneNumberDestination: UserProfileAddPhoneView.Destination?
   @State private var isLoading = false
@@ -116,14 +117,14 @@ struct UserProfilePhoneRow: View {
       UserProfileAddPhoneView(desintation: $0)
     }
     .confirmationDialog(
-      removeResource?.messageLine1 ?? "",
+      removeResource?.messageLine1(locale: locale) ?? "",
       isPresented: $isConfirmingRemoval,
       titleVisibility: .visible,
       actions: {
         AsyncButton(role: .destructive) {
           await removeResource(removeResource)
         } label: { _ in
-          Text(removeResource?.title ?? "", bundle: .module)
+          Text(verbatim: removeResource?.title(locale: locale) ?? "")
         }
         .onIsRunningChanged { isLoading = $0 }
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileUpdateProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileUpdateProfileView.swift
@@ -99,12 +99,7 @@ struct UserProfileUpdateProfileView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
 
         ToolbarItem(placement: .principal) {
           Text("Edit profile", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileUpdateProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileUpdateProfileView.swift
@@ -99,7 +99,9 @@ struct UserProfileUpdateProfileView: View {
       #endif
       .preGlassSolidNavBar()
       .toolbar {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
 
         ToolbarItem(placement: .principal) {
           Text("Edit profile", bundle: .module)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileUpdateProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileUpdateProfileView.swift
@@ -123,7 +123,7 @@ struct UserProfileUpdateProfileView: View {
               let data = try await item.loadTransferable(type: Data.self),
               let resizedData = resizedImageData(from: data)
             else {
-              throw ClerkClientError(message: "There was an error loading the image from the photos library.")
+              throw ClerkClientError(message: "There was an error loading the image from the photos library.", localizationBundle: .module)
             }
 
             try await user.setProfileImage(imageData: resizedData)

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileVerifyView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileVerifyView.swift
@@ -183,7 +183,9 @@ struct UserProfileVerifyView: View {
     .preGlassSolidNavBar()
     .toolbar {
       if hasCancelAction {
-        CancelToolbarItem()
+        CancelToolbarItem {
+          dismiss()
+        }
       }
 
       ToolbarItem(placement: .principal) {

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileVerifyView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileVerifyView.swift
@@ -57,7 +57,7 @@ struct UserProfileVerifyView: View {
     case let .phone(phoneNumber):
       Text("Enter the verification code sent to \(phoneNumber.phoneNumber.formattedAsPhoneNumberIfPossible)", bundle: .module)
     case .totp:
-      Text("Enter the verification code from your authenticator application.", bundle: .module)
+      Text("Enter the verification code from your authenticator app.", bundle: .module)
     }
   }
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileVerifyView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileVerifyView.swift
@@ -183,12 +183,7 @@ struct UserProfileVerifyView: View {
     .preGlassSolidNavBar()
     .toolbar {
       if hasCancelAction {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
-            dismiss()
-          }
-          .foregroundStyle(theme.colors.primary)
-        }
+        CancelToolbarItem()
       }
 
       ToolbarItem(placement: .principal) {

--- a/Sources/ClerkKitUI/Extensions/View+ErrorPresenting.swift
+++ b/Sources/ClerkKitUI/Extensions/View+ErrorPresenting.swift
@@ -53,7 +53,7 @@ extension View {
   @Previewable @State var error: Error?
 
   Button("Show Error") {
-    error = ClerkClientError(message: "Password is incorrect. Try again, or use another method.")
+    error = ClerkClientError(message: "Password is incorrect. Try again, or use another method.", localizationBundle: .module)
   }
   .clerkErrorPresenting(
     $error,

--- a/Sources/ClerkKitUI/Resources/Localizable.xcstrings
+++ b/Sources/ClerkKitUI/Resources/Localizable.xcstrings
@@ -3776,7 +3776,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "تغيير كلمة لمرور"
+            "value" : "تغيير كلمة المرور"
           }
         },
         "de" : {

--- a/Sources/ClerkKitUI/Resources/Localizable.xcstrings
+++ b/Sources/ClerkKitUI/Resources/Localizable.xcstrings
@@ -191,6 +191,101 @@
       },
       "shouldTranslate" : false
     },
+    "%@ · Joined %@" : {
+      "comment" : "A member's role followed by the date they joined the organization. The first argument is the role and the second is the localized date.",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · تاريخ الانضمام: %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · Beigetreten am %@"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · Έγινε μέλος στις %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · Se unió el %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · A rejoint le %@"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · शामिल होने की तारीख: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · Data di iscrizione: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@・参加日：%@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · 가입일: %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · Data dołączenia: %@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · Entrou em %@"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · Data aderării: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · Дата вступления: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · Katılma tarihi: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · 加入日期：%@"
+          }
+        }
+      }
+    },
     "%@ will be removed from this account. You will no longer be able to sign in using this connected account." : {
       "localizations" : {
         "ar" : {
@@ -2642,6 +2737,7 @@
       }
     },
     "Authenticator app" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -2735,7 +2831,7 @@
         }
       }
     },
-    "Authenticator app verification enabled" : {
+    "Authenticator application verification enabled" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -3581,100 +3677,6 @@
         }
       }
     },
-    "Change password" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تغيير كلمة لمرور"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passwort ändern"
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Αλλαγή κωδικού πρόσβασης"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambiar la contraseña"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changer le mot de passe"
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पासवर्ड बदलें"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia password"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パスワードを変更"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "비밀번호 변경"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zmień hasło"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alterar senha"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schimbă parola"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Изменить пароль"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parolayı değiştir"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更改密码"
-          }
-        }
-      }
-    },
     "Change logo" : {
       "localizations" : {
         "ar" : {
@@ -3765,6 +3767,100 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更改徽标"
+          }
+        }
+      }
+    },
+    "Change password" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تغيير كلمة لمرور"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passwort ändern"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Αλλαγή κωδικού πρόσβασης"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar la contraseña"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changer le mot de passe"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पासवर्ड बदलें"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambia password"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスワードを変更"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비밀번호 변경"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zmień hasło"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alterar senha"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schimbă parola"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изменить пароль"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parolayı değiştir"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改密码"
           }
         }
       }
@@ -4241,7 +4337,7 @@
         }
       }
     },
-    "Choose an Organization" : {
+    "Choose an organization" : {
       "comment" : "Title of a view that appears when a user is asked to choose an organization.",
       "isCommentAutoGenerated" : true,
       "localizations" : {
@@ -9154,6 +9250,7 @@
       }
     },
     "Enter the verification code from authenticator application" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -9247,7 +9344,7 @@
         }
       }
     },
-    "Enter the verification code from your authenticator application." : {
+    "Enter the verification code from your authenticator app." : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -9337,6 +9434,101 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "输入来自您的身份验证应用的验证码。"
+          }
+        }
+      }
+    },
+    "Enter the verification code sent to" : {
+      "comment" : "Instruction shown above the phone number that received an SMS verification code.",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أدخل رمز التحقق المرسل إلى"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geben Sie den an die folgende Nummer gesendeten Bestätigungscode ein"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Εισαγάγετε τον κωδικό επαλήθευσης που στάλθηκε στο"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingrese el código de verificación enviado a"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrez le code de vérification envoyé à"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इस पर भेजा गया सत्यापन कोड दर्ज करें"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inserisci il codice di verifica inviato a"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次の宛先に送信された確認コードを入力してください"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음으로 전송된 인증 코드를 입력하세요"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wprowadź kod weryfikacyjny wysłany do"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digite o código de verificação enviado para"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introdu codul de verificare trimis la"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите код подтверждения, отправленный на"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aşağıdaki adrese gönderilen doğrulama kodunu girin"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "输入发送到以下号码的验证码"
           }
         }
       }
@@ -10847,6 +11039,100 @@
         }
       }
     },
+    "Hide password" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إخفاء كلمة المرور"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passwort ausblenden"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Απόκρυψη κωδικού πρόσβασης"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar contraseña"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer le mot de passe"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पासवर्ड छिपाएँ"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nascondi password"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスワードを非表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비밀번호 숨기기"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ukryj hasło"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar senha"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ascunde parola"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скрыть пароль"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parolayı gizle"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏密码"
+          }
+        }
+      }
+    },
     "I agree to the [Privacy Policy](LegalConsentView://privacy)" : {
       "localizations" : {
         "ar" : {
@@ -11789,6 +12075,101 @@
         }
       }
     },
+    "Invited %@" : {
+      "comment" : "The date an organization invitation was sent. The argument is the localized date.",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تاريخ الدعوة: %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eingeladen am %@"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Προσκλήθηκε στις %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invitación enviada el %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invitation envoyée le %@"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आमंत्रण की तारीख: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data dell’invito: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "招待日：%@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "초대일: %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data zaproszenia: %@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Convite enviado em %@"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data invitației: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата приглашения: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Davet tarihi: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "邀请日期：%@"
+          }
+        }
+      }
+    },
     "It is recommended to sign out of all other devices which may have used your old password." : {
       "localizations" : {
         "ar" : {
@@ -12167,6 +12548,101 @@
         }
       }
     },
+    "Joined %@" : {
+      "comment" : "The date a member joined the organization. The argument is the localized date.",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تاريخ الانضمام: %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beigetreten am %@"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Έγινε μέλος στις %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se unió el %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A rejoint le %@"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "शामिल होने की तारीख: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di iscrizione: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参加日：%@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가입일: %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data dołączenia: %@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrou em %@"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data aderării: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата вступления: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Katılma tarihi: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入日期：%@"
+          }
+        }
+      }
+    },
     "Last name" : {
       "localizations" : {
         "ar" : {
@@ -12261,7 +12737,7 @@
         }
       }
     },
-    "Last Used" : {
+    "Last used" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -13869,6 +14345,100 @@
         }
       }
     },
+    "No email app is available on this device." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يتوفر تطبيق بريد إلكتروني على هذا الجهاز."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auf diesem Gerät ist keine E-Mail-App verfügbar."
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Δεν υπάρχει διαθέσιμη εφαρμογή email σε αυτή τη συσκευή."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay ninguna app de correo disponible en este dispositivo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune app e-mail n’est disponible sur cet appareil."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इस डिवाइस पर कोई ईमेल ऐप उपलब्ध नहीं है।"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna app e-mail è disponibile su questo dispositivo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このデバイスではメールアプリを利用できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 기기에서 사용할 수 있는 이메일 앱이 없습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Na tym urządzeniu nie jest dostępna żadna aplikacja e-mail."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não há nenhum app de e-mail disponível neste dispositivo."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu există nicio aplicație de e-mail disponibilă pe acest dispozitiv."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "На этом устройстве нет доступного почтового приложения."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu cihazda kullanılabilir bir e-posta uygulaması yok."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备上没有可用的邮件应用。"
+          }
+        }
+      }
+    },
     "No invitations sent" : {
       "localizations" : {
         "ar" : {
@@ -14337,100 +14907,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "没有可用角色"
-          }
-        }
-      }
-    },
-    "No email app is available on this device." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا يتوفر تطبيق بريد إلكتروني على هذا الجهاز."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auf diesem Gerät ist keine E-Mail-App verfügbar."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Δεν υπάρχει διαθέσιμη εφαρμογή email σε αυτή τη συσκευή."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay ninguna app de correo disponible en este dispositivo."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune app e-mail n’est disponible sur cet appareil."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इस डिवाइस पर कोई ईमेल ऐप उपलब्ध नहीं है।"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna app e-mail è disponibile su questo dispositivo."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このデバイスではメールアプリを利用できません。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 기기에서 사용할 수 있는 이메일 앱이 없습니다."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Na tym urządzeniu nie jest dostępna żadna aplikacja e-mail."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não há nenhum app de e-mail disponível neste dispositivo."
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu există nicio aplicație de e-mail disponibilă pe acest dispozitiv."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "На этом устройстве нет доступного почтового приложения."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu cihazda kullanılabilir bir e-posta uygulaması yok."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此设备上没有可用的邮件应用。"
           }
         }
       }
@@ -16041,7 +16517,7 @@
         }
       }
     },
-    "Profile Details" : {
+    "Profile details" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -16225,101 +16701,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新连接"
-          }
-        }
-      }
-    },
-    "Redirect URL is missing or invalid. Unable to start external authentication flow." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عنوان URL لإعادة التوجيه مفقود أو غير صالح. لا يمكن بدء تدفق المصادقة الخارجية."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Weiterleitungs-URL fehlt oder ist ungültig. Es ist nicht möglich, die externe Authentifizierung zu starten."
-          }
-        },
-        "el" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Η διεύθυνση URL ανακατεύθυνσης λείπει ή είναι άκυρη. Αδυναμία εκκίνησης της εξωτερικής ροής πιστοποίησης."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falta la URL de redirección o no es válida. No se puede iniciar el flujo de autenticación externa."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'URL de redirection est manquante ou invalide. Impossible de démarrer le flux d'authentification externe."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रिडायरेक्ट URL गायब है या अमान्य है। बाहरी प्रमाणीकरण प्रवाह शुरू करने में असमर्थ।"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'URL di reindirizzamento è mancante o non valida. Impossibile avviare il flusso di autenticazione esterna."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リダイレクトURLが不足しているか無効です。外部認証フローを開始できません。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "리디렉션 URL이 없거나 유효하지 않습니다. 외부 인증 흐름을 시작할 수 없습니다。"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brakuje adresu URL przekierowania lub jest on nieprawidłowy. Nie można uruchomić zewnętrznego przepływu uwierzytelniania."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL de redirecionamento está ausente ou inválida. Não foi possível iniciar o fluxo de autenticação externa."
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adresa URL de redirecționare lipsește sau nu este validă. Nu se poate porni fluxul de autentificare externă."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL-адрес перенаправления отсутствует или недействителен. Не удалось запустить внешний поток аутентификации."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yönlendirme URL'si eksik veya geçersiz. Harici kimlik doğrulama akışı başlatılamıyor."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重定向 URL 缺失或无效。无法启动外部身份验证流程。"
           }
         }
       }
@@ -18014,6 +18395,101 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请求加入"
+          }
+        }
+      }
+    },
+    "Requested %@" : {
+      "comment" : "The date an organization membership request was submitted. The argument is the localized date.",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تاريخ الطلب: %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anfrage gestellt am %@"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Υπέβαλε αίτημα στις %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solicitud enviada el %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Demande envoyée le %@"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अनुरोध की तारीख: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data della richiesta: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参加リクエスト日：%@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가입 요청일: %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data wysłania prośby: %@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solicitação enviada em %@"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data solicitării: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата запроса: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Katılma isteği tarihi: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入申请日期：%@"
           }
         }
       }
@@ -20282,6 +20758,100 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设置两步验证"
+          }
+        }
+      }
+    },
+    "Show password" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إظهار كلمة المرور"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passwort anzeigen"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Εμφάνιση κωδικού πρόσβασης"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar contraseña"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le mot de passe"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पासवर्ड दिखाएँ"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra password"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスワードを表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비밀번호 표시"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokaż hasło"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar senha"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afișează parola"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показать пароль"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parolayı göster"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示密码"
           }
         }
       }
@@ -24714,7 +25284,7 @@
         }
       }
     },
-    "Users are automatically invited to join the organization when they sign-up and can join anytime." : {
+    "Users are automatically invited to join the organization when they sign up and can join anytime." : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -27732,7 +28302,7 @@
         }
       }
     },
-    "Your backup code is the one you got when setting up two-step authentication." : {
+    "Your backup code is the one you got when setting up two-step verification." : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {

--- a/Sources/ClerkKitUI/Utils/RemoveResource.swift
+++ b/Sources/ClerkKitUI/Utils/RemoveResource.swift
@@ -17,36 +17,36 @@ enum RemoveResource: Equatable {
   case totp
   case secondFactorPhoneNumber(PhoneNumber)
 
-  var title: LocalizedStringKey {
+  func title(locale: Locale) -> String {
     switch self {
     case .email:
-      "Remove email address"
+      String(localized: "Remove email address", bundle: .module, locale: locale)
     case .phoneNumber:
-      "Remove phone number"
+      String(localized: "Remove phone number", bundle: .module, locale: locale)
     case .externalAccount:
-      "Remove connected account"
+      String(localized: "Remove connected account", bundle: .module, locale: locale)
     case .passkey:
-      "Remove passkey"
+      String(localized: "Remove passkey", bundle: .module, locale: locale)
     case .totp, .secondFactorPhoneNumber:
-      "Remove two-step verification"
+      String(localized: "Remove two-step verification", bundle: .module, locale: locale)
     }
   }
 
   @MainActor
-  var messageLine1: LocalizedStringKey {
+  func messageLine1(locale: Locale) -> String {
     switch self {
     case let .email(emailAddress):
-      "\(emailAddress.emailAddress) will be removed from this account. You will no longer be able to sign in using this email address."
+      String(localized: "\(emailAddress.emailAddress) will be removed from this account. You will no longer be able to sign in using this email address.", bundle: .module, locale: locale)
     case let .phoneNumber(phoneNumber):
-      "\(phoneNumber.phoneNumber.formattedAsPhoneNumberIfPossible) will be removed from this account. You will no longer be able to sign in using this phone number."
+      String(localized: "\(phoneNumber.phoneNumber.formattedAsPhoneNumberIfPossible) will be removed from this account. You will no longer be able to sign in using this phone number.", bundle: .module, locale: locale)
     case let .externalAccount(externalAccount):
-      "\(externalAccount.oauthProvider.name) will be removed from this account. You will no longer be able to sign in using this connected account."
+      String(localized: "\(externalAccount.oauthProvider.name) will be removed from this account. You will no longer be able to sign in using this connected account.", bundle: .module, locale: locale)
     case let .passkey(passkey):
-      "\(passkey.name) will be removed from this account. You will no longer be able to sign in using this passkey."
+      String(localized: "\(passkey.name) will be removed from this account. You will no longer be able to sign in using this passkey.", bundle: .module, locale: locale)
     case .totp:
-      "Verification codes from this authenticator will no longer be required when signing in."
+      String(localized: "Verification codes from this authenticator will no longer be required when signing in.", bundle: .module, locale: locale)
     case let .secondFactorPhoneNumber(phoneNumber):
-      "\(phoneNumber.phoneNumber.formattedAsPhoneNumberIfPossible) will no longer be receiving verification codes when signing in."
+      String(localized: "\(phoneNumber.phoneNumber.formattedAsPhoneNumberIfPossible) will no longer be receiving verification codes when signing in.", bundle: .module, locale: locale)
     }
   }
 

--- a/Tests/Errors/ErrorTests.swift
+++ b/Tests/Errors/ErrorTests.swift
@@ -180,6 +180,34 @@ struct ErrorTests {
     #expect(error.errorDescription == nil)
   }
 
+  @Test
+  func clerkClientErrorUsesLocalizedMessageResource() {
+    let error = ClerkClientError(
+      localizedMessage: LocalizedStringResource(
+        "Localized test error",
+        locale: Locale(identifier: "es"),
+        bundle: .module
+      )
+    )
+
+    #expect(error.message == "Error de prueba localizado")
+  }
+
+  @Test
+  func clerkClientErrorReplacesLocalizedMessage() {
+    var error = ClerkClientError(
+      message: "Localized test error",
+      localizationBundle: .module,
+      locale: Locale(identifier: "es")
+    )
+
+    #expect(error.message == "Error de prueba localizado")
+
+    error.messageLocalizationValue = "Replacement message"
+
+    #expect(error.message == "Replacement message")
+  }
+
   // MARK: - ClerkInitializationError Tests
 
   @Test

--- a/Tests/Resources/es.lproj/Localizable.strings
+++ b/Tests/Resources/es.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+"Localized test error" = "Error de prueba localizado";

--- a/scripts/check-e2e-hooks.sh
+++ b/scripts/check-e2e-hooks.sh
@@ -29,6 +29,7 @@ scan_sources_for() {
 is_allowed_e2e_usage_file() {
   case "$1" in
     Sources/ClerkKitUI/Components/Auth/SignIn/SignInFactorOnePasswordView.swift | \
+      Sources/ClerkKitUI/Components/Auth/SignIn/SignInSetNewPasswordView.swift | \
       Sources/ClerkKitUI/Components/Auth/SignUp/SignUpCollectFieldView.swift | \
       Sources/ClerkKitUI/Components/UserProfile/UserProfileChangePasswordView.swift | \
       Sources/ClerkKitUI/Extensions/View+HiddenTextField.swift)
@@ -41,7 +42,7 @@ is_allowed_e2e_usage_file() {
 }
 
 reviewed_usage_count=0
-expected_reviewed_usage_count=6
+expected_reviewed_usage_count=8
 
 while IFS=: read -r file line _; do
   if [ -z "$file" ]; then


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add localization bundle support to `ClerkClientError` and standardize cancel toolbar items across UserProfile and Organization views
- Extends `ClerkClientError` with a new `init(message:localizationBundle:locale:)` initializer and internal `MessageStorage` enum so errors can carry an explicit bundle and locale for localized message resolution.
- Updates dozens of error throw sites across auth, sign-in, sign-up, organization, user, and watch sync flows to pass `localizationBundle: .module`, enabling localized error display.
- Adds a reusable `CancelToolbarItem` component and replaces ad-hoc cancel `ToolbarItem` buttons across all UserProfile and Organization views with it.
- Updates `RemoveResource.title` and `RemoveResource.messageLine1` from computed properties returning `LocalizedStringKey` to methods accepting a `Locale`, so confirmation dialogs in member rows render locale-aware text.
- Fixes swapped translations for "Change logo" and "Change password" in `Localizable.xcstrings`, and adds new localized strings for joined/invited/requested dates, show/hide password, and SMS verification instructions.
- Behavioral Change: `UserProfileMfaRow` now shows "Authenticator application" instead of "Authenticator app"; several UI strings change casing or wording (e.g. "Profile details", "Choose an organization", "Last used").

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77cb4a2.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->