### PR TITLE
Rename "Client Trust" to "Device Trust" in doc comments

### DIFF
--- a/Sources/ClerkKit/Domains/Auth/SignIn/SignIn+Status.swift
+++ b/Sources/ClerkKit/Domains/Auth/SignIn/SignIn+Status.swift
@@ -23,7 +23,7 @@ extension SignIn {
     /// The user needs to set a new password.
     case needsNewPassword
 
-    /// Client trust verification is required.
+    /// Device trust verification is required.
     case needsClientTrust
 
     /// The sign-in returned an unknown status value.

--- a/Sources/ClerkKitUI/Components/Auth/AuthNavigation.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthNavigation.swift
@@ -54,7 +54,7 @@ final class AuthNavigation {
       path.append(AuthView.Destination.signInSetNewPassword)
     case .needsClientTrust:
       guard let factor = signIn.startingSecondFactor else {
-        ClerkLogger.info("Navigating to GetHelp: No starting second factor available for client trust", force: true)
+        ClerkLogger.info("Navigating to GetHelp: No starting second factor available for device trust", force: true)
         path.append(AuthView.Destination.getHelp(.signIn))
         return
       }


### PR DESCRIPTION
Part of [PROT-875](https://linear.app/clerk/issue/PROT-875/fully-rename-client-trust-to-device-trust).

## What

Renames the customer-facing feature name "Client Trust" → "Device Trust" in the two places it appears as prose in this SDK:

| File | What |
| --- | --- |
| `SignIn+Status.swift` | `needsClientTrust` doc comment — surfaces in Xcode Quick Help and generated API docs |
| `AuthNavigation.swift` | one navigation log message |

"Client" is jargon to less technical readers, and "Device Trust" aligns with Protect's "Device Intelligence" naming. This SDK was flagged as still carrying the old name during review of the docs PR.

## API values are deliberately unchanged

Per Kyle in the naming thread: _"we don't have to change APIs but the way we discuss clients externally should flip to devices."_

So `needsClientTrust`, the `needs_client_trust` wire value, `SignInClientTrustView`, `signInClientTrust`, and `Mode.clientTrust` all keep their names — renaming them would break existing custom sign-in flows. **The diff is 2 lines and touches no identifier.**

## No user-facing string changes

The end-user copy in `SignInFactorCodeView.clientTrustWarning` already reads "You're signing in from a new device. We're asking for verification to keep your account secure." — it was device-worded from the start, so nothing an end user sees changes here.

## Related

- clerk/clerk#3051 — docs + marketing (approved; landing as part of a combined typedoc sync PR)
- clerk/javascript#9266 — JSDoc (merged)
- clerk/dashboard#9839 — dashboard UI labels
- clerk/clerk_go#20787, clerk/skills#59
- Companion PRs: clerk-android, clerk-expo-quickstart

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename 'Client Trust' to 'Device Trust' in doc comments and log messages
> Updates terminology in two places to align with the product rename from "Client Trust" to "Device Trust": the `needsClientTrust` case doc comment in [SignIn+Status.swift](https://github.com/clerk/clerk-ios/pull/540/files#diff-8a5ddc0ade68e274e54854eb8d64eb56e5a274368d32621743065dfb8d3f114d) and a log message in [AuthNavigation.swift](https://github.com/clerk/clerk-ios/pull/540/files#diff-2b16d99c37fe7a0405c15840ca21d74744b1b5e61823e916bc9600352fb0b81c). No logic, routing, or public API signatures are changed.
>
> #### 🖇️ Linked Issues
> Partially addresses [PROT-875](https://linear.app/clerk/issue/PROT-875), which tracks the full rename of "Client Trust" to "Device Trust" across docs and product surfaces.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b67dd8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->