### PR TITLE
Fix Clerk environment in edit profile sheet

### DIFF
--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -207,6 +207,7 @@ public struct UserProfileView<Route: Hashable, Destination: View>: View {
       }
       .sheet(isPresented: $updateProfileIsPresented) {
         UserProfileUpdateProfileView(user: user)
+          .environment(clerk)
       }
       .sheet(isPresented: $sheetNavigation.authViewIsPresented) {
         // The add-account sheet is modal over the host, so it dismisses itself


### PR DESCRIPTION
## Summary

- forward the injected Clerk instance into the nested Edit Profile sheet
- prevent a missing `@Environment(Clerk.self)` crash on My Mac (Designed for iPad)

## Testing

- `swift build --target ClerkKitUI`