### PR TITLE
fix(ui): make OTP submission state-driven

### DIFF
--- a/Sources/ClerkKitUI/Common/OTPField.swift
+++ b/Sources/ClerkKitUI/Common/OTPField.swift
@@ -62,12 +62,17 @@ struct OTPField: View {
       code = String(newValue.prefix(numberOfInputs))
       if previousCode == code { return }
 
-      if code.count == numberOfInputs {
-        fieldState = .default
-        Task { await onCodeEntry(code) }
-      } else if code.isEmpty {
+      if code.isEmpty {
         fieldState = .default
       }
+    }
+    .task(id: code) {
+      guard code.count == numberOfInputs else {
+        return
+      }
+
+      fieldState = .default
+      await onCodeEntry(code)
     }
     .onChange(
       of: fieldState,


### PR DESCRIPTION
## What

Restore state-driven OTP submission so a complete code inserted by paste or one-time-code autofill cannot render without starting verification.

## How

Move the six-digit submission effect from an unstructured Task inside onChange to task(id: code), matching the earlier fix in 49910f2f that was later lost during unrelated OTPField changes.

## Testing

- swift test --filter SignUpEmailVerificationStrategyTests
- Source diff matches the previously shipped state-driven submission fix