### PR TITLE
feat(ui): notify embedded hosts when an auth flow completes

### DIFF
--- a/Sources/ClerkKit/Core/AuthFlowCoordinator.swift
+++ b/Sources/ClerkKit/Core/AuthFlowCoordinator.swift
@@ -280,8 +280,7 @@ struct AuthFlowCoordinator {
   }
 
   mutating func finishPresentation(
-    token: AuthFlowPresentationToken,
-    completesWork: Bool
+    token: AuthFlowPresentationToken
   ) -> Bool {
     guard registration?.id == token.work.ownerId,
           case .presenting(let target, let currentToken) = phase,
@@ -292,7 +291,7 @@ struct AuthFlowCoordinator {
       return false
     }
 
-    phase = completesWork ? .observing : .awaiting(target)
+    phase = .awaiting(target)
     advanceRevision()
     return true
   }

--- a/Sources/ClerkKit/Core/Clerk+AuthFlow.swift
+++ b/Sources/ClerkKit/Core/Clerk+AuthFlow.swift
@@ -81,13 +81,8 @@ extension Clerk {
     _ token: AuthFlowPresentationToken
   ) -> Bool {
     guard session?.id == token.sessionId else { return false }
-    let completesWork = token.kind == .trustedDeviceEnrollment
-      && session?.status == .active
-      && session?.pendingTasks.isEmpty == true
-    return authFlowCoordinator.finishPresentation(
-      token: token,
-      completesWork: completesWork
-    )
+    // Completing here would mark the flow complete before reconciliation can deliver it.
+    return authFlowCoordinator.finishPresentation(token: token)
   }
 
   @discardableResult

--- a/Sources/ClerkKitUI/Common/EmbeddedAuthCompletion.swift
+++ b/Sources/ClerkKitUI/Common/EmbeddedAuthCompletion.swift
@@ -1,0 +1,35 @@
+//
+//  EmbeddedAuthCompletion.swift
+//  Clerk
+//
+
+#if os(iOS) || os(macOS)
+
+import SwiftUI
+
+/// Lets a host that embeds ``AuthView`` in its own presentation (e.g. Clerk's Expo
+/// SDK) learn that the auth flow finished, so it can close that presentation.
+/// A non-dismissible `AuthView` never calls `dismiss()`, so this is the only
+/// completion signal such a host receives.
+@_spi(FrameworkIntegration)
+@MainActor
+public struct ClerkAuthCompletionAction {
+  private let handler: () -> Void
+
+  public init(_ handler: @escaping () -> Void) {
+    self.handler = handler
+  }
+
+  func callAsFunction() {
+    handler()
+  }
+}
+
+@_spi(FrameworkIntegration)
+extension EnvironmentValues {
+  /// The host's action to run when an embedded auth flow completes.
+  /// `nil` (the default) leaves the component unchanged.
+  @Entry public var clerkAuthCompletionAction: ClerkAuthCompletionAction?
+}
+
+#endif

--- a/Sources/ClerkKitUI/Common/EmbeddedAuthFlowCompletion.swift
+++ b/Sources/ClerkKitUI/Common/EmbeddedAuthFlowCompletion.swift
@@ -1,5 +1,5 @@
 //
-//  EmbeddedAuthCompletion.swift
+//  EmbeddedAuthFlowCompletion.swift
 //  Clerk
 //
 
@@ -13,7 +13,7 @@ import SwiftUI
 /// completion signal such a host receives.
 @_spi(FrameworkIntegration)
 @MainActor
-public struct ClerkAuthCompletionAction {
+public struct ClerkAuthFlowCompletionAction {
   private let handler: () -> Void
 
   public init(_ handler: @escaping () -> Void) {
@@ -29,7 +29,7 @@ public struct ClerkAuthCompletionAction {
 extension EnvironmentValues {
   /// The host's action to run when an embedded auth flow completes.
   /// `nil` (the default) leaves the component unchanged.
-  @Entry public var clerkAuthCompletionAction: ClerkAuthCompletionAction?
+  @Entry public var clerkAuthFlowCompletionAction: ClerkAuthFlowCompletionAction?
 }
 
 #endif

--- a/Sources/ClerkKitUI/Components/Auth/AuthView+AuthFlow.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthView+AuthFlow.swift
@@ -144,6 +144,11 @@ extension AuthView {
       return
     }
 
+    // Trusted device enrollment completes work in `finishPresentation`, not `completeAuthFlow`.
+    if clerk.isAuthFlowComplete {
+      authCompletionAction?()
+    }
+
     if isDismissible {
       dismissAuthView()
     } else if !clerk.isAuthFlowComplete {
@@ -238,6 +243,7 @@ extension AuthView {
     authFlowRegistrationIsTerminated = true
     owner.cancel()
     authFlowRegistration = nil
+    authCompletionAction?()
     if isDismissible {
       dismiss()
     }

--- a/Sources/ClerkKitUI/Components/Auth/AuthView+AuthFlow.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthView+AuthFlow.swift
@@ -144,14 +144,6 @@ extension AuthView {
       return
     }
 
-    // Trusted device enrollment completes work in `finishPresentation`, not `completeAuthFlow`.
-    if clerk.isAuthFlowComplete {
-      authFlowRegistrationIsTerminated = true
-      owner.cancel()
-      authFlowRegistration = nil
-      authCompletionAction?()
-    }
-
     if isDismissible {
       dismissAuthView()
     } else if !clerk.isAuthFlowComplete {
@@ -246,7 +238,7 @@ extension AuthView {
     authFlowRegistrationIsTerminated = true
     owner.cancel()
     authFlowRegistration = nil
-    authCompletionAction?()
+    authFlowCompletionAction?()
     if isDismissible {
       dismiss()
     }

--- a/Sources/ClerkKitUI/Components/Auth/AuthView+AuthFlow.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthView+AuthFlow.swift
@@ -146,6 +146,9 @@ extension AuthView {
 
     // Trusted device enrollment completes work in `finishPresentation`, not `completeAuthFlow`.
     if clerk.isAuthFlowComplete {
+      authFlowRegistrationIsTerminated = true
+      owner.cancel()
+      authFlowRegistration = nil
       authCompletionAction?()
     }
 

--- a/Sources/ClerkKitUI/Components/Auth/AuthView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthView.swift
@@ -70,7 +70,7 @@ public struct AuthView: View {
   @Environment(Clerk.self) var clerk
   @Environment(\.clerkTheme) private var theme
   @Environment(\.dismiss) var dismiss
-  @Environment(\.clerkAuthCompletionAction) var authCompletionAction
+  @Environment(\.clerkAuthFlowCompletionAction) var authFlowCompletionAction
   /// Navigation state for the auth flow.
   @State var navigation = AuthNavigation()
 

--- a/Sources/ClerkKitUI/Components/Auth/AuthView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/AuthView.swift
@@ -70,6 +70,7 @@ public struct AuthView: View {
   @Environment(Clerk.self) var clerk
   @Environment(\.clerkTheme) private var theme
   @Environment(\.dismiss) var dismiss
+  @Environment(\.clerkAuthCompletionAction) var authCompletionAction
   /// Navigation state for the auth flow.
   @State var navigation = AuthNavigation()
 

--- a/Tests/Core/ClerkTests.swift
+++ b/Tests/Core/ClerkTests.swift
@@ -1624,6 +1624,11 @@ struct ClerkTests {
     #expect(clerk.isAuthFlowComplete == false)
 
     #expect(clerk.finishAuthFlowPresentation(token))
+    let reconciled = try #require(awaitingAuthFlow(in: clerk, for: registration))
+    #expect(reconciled.workId == awaiting.workId)
+    #expect(clerk.isAuthFlowComplete == false)
+
+    #expect(clerk.completeAuthFlow(reconciled.work))
     #expect(observesAuthFlow(in: clerk, for: registration))
     #expect(clerk.isAuthFlowComplete)
     withExtendedLifetime(registration) {}
@@ -2079,7 +2084,7 @@ struct ClerkTests {
   }
 
   @Test
-  func finishingTrustedDeviceEnrollmentCompletesItsExactAuthWork() throws {
+  func finishingTrustedDeviceEnrollmentReturnsItsExactAuthWorkForCompletion() throws {
     let clerk = Clerk.mockSignedOut
     let registration = try #require(clerk.registerAuthFlow())
     clerk.applyResponseClient(.mock, completedAuthFlow: completedAuthFlow())
@@ -2091,11 +2096,55 @@ struct ClerkTests {
       presentation: .trustedDeviceEnrollment
     ))
     #expect(clerk.finishAuthFlowPresentation(token))
+
+    // A host gated on isAuthFlowComplete must not see completion before it is delivered.
+    #expect(clerk.isAuthFlowComplete == false)
+    let resumed = try #require(awaitingAuthFlow(in: clerk, for: registration))
+    #expect(resumed.workId == awaiting.workId)
+
+    #expect(clerk.completeAuthFlow(resumed.work))
     #expect(clerk.isAuthFlowComplete)
     guard case .observing = clerk.authFlowSnapshot(for: registration)?.phase else {
-      Issue.record("Expected enrollment completion to finish the auth work.")
+      Issue.record("Expected completion to finish the auth work.")
       return
     }
+    withExtendedLifetime(registration) {}
+  }
+
+  @Test
+  func completingAuthFlowIsAcceptedOnceForAnOrdinaryFlow() throws {
+    let clerk = Clerk.mockSignedOut
+    let registration = try #require(clerk.registerAuthFlow())
+    clerk.applyResponseClient(.mock, completedAuthFlow: completedAuthFlow())
+    let awaiting = try #require(awaitingAuthFlow(in: clerk, for: registration))
+
+    #expect(clerk.completeAuthFlow(awaiting.work))
+    // A second attempt is rejected, so a host bound to this call site is told once.
+    #expect(clerk.completeAuthFlow(awaiting.work) == false)
+    #expect(clerk.isAuthFlowComplete)
+    withExtendedLifetime(registration) {}
+  }
+
+  @Test
+  func completingAuthFlowIsAcceptedOnceAfterTrustedDeviceEnrollment() throws {
+    let clerk = Clerk.mockSignedOut
+    let registration = try #require(clerk.registerAuthFlow())
+    clerk.applyResponseClient(.mock, completedAuthFlow: completedAuthFlow())
+    let awaiting = try #require(awaitingAuthFlow(in: clerk, for: registration))
+
+    let token = try #require(clerk.startAuthFlowPresentation(
+      for: registration,
+      work: awaiting.work,
+      presentation: .trustedDeviceEnrollment
+    ))
+    #expect(clerk.finishAuthFlowPresentation(token))
+    let resumed = try #require(awaitingAuthFlow(in: clerk, for: registration))
+
+    #expect(clerk.completeAuthFlow(resumed.work))
+    #expect(clerk.completeAuthFlow(resumed.work) == false)
+    // Finishing the presentation again must not re-open a completed flow.
+    #expect(clerk.finishAuthFlowPresentation(token) == false)
+    #expect(clerk.isAuthFlowComplete)
     withExtendedLifetime(registration) {}
   }
 


### PR DESCRIPTION
## Description

A non-dismissible `AuthView` never calls `dismiss()`, which is its only completion signal. A host that owns the presentation, like the Expo SDK, has no way to know sign-in finished and leaves its modal open.

Adds `ClerkAuthCompletionAction`, a `FrameworkIntegration` SPI environment value that fires on completion regardless of `isDismissible`. It defaults to `nil`, so nothing changes for existing consumers.

Part of MOBILE-625

Expo bridge wiring PR https://github.com/clerk/javascript/pull/9501

### Reproduction

https://github.com/user-attachments/assets/3a928485-483e-4192-8c5a-ba0a2552ce24

### Fixed

https://github.com/user-attachments/assets/db26a582-8d79-43d5-974e-7623181f50a3



