### PR TITLE
chore(repo): add Cursor Cloud multi-repo dev environment setup

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,9 @@
+{
+  "name": "Clerk multi-repo (iOS + Android + Expo)",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "repositoryDependencies": [
+    "github.com/clerk/clerk-android",
+    "github.com/clerk/javascript"
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Cursor Cloud Agent setup for the Clerk multi-repo workspace.
+#
+# Primary repo: clerk-ios (Swift). Sibling repos (checked out next to it via
+# repositoryDependencies): clerk-android (Kotlin/Gradle) and javascript (@clerk/expo).
+#
+# This script is idempotent: every toolchain install is guarded so re-runs against
+# a warm snapshot are fast. It installs the toolchains that run on Linux and refreshes
+# each repo's dependencies. iOS build/test require macOS + Xcode and are not possible
+# here; on Linux the runnable iOS dev loop is `make check` (SwiftFormat + SwiftLint).
+set -euo pipefail
+
+# --- Pinned versions -------------------------------------------------------
+JDK_TARGET_PKG="openjdk-17-jdk-headless"          # Gradle runs on JDK 21, compiles with the 17 toolchain
+NODE_VERSION="24.15.0"                              # javascript monorepo engines: node >=24.15
+SWIFT_VERSION="6.2"                                 # provides sourcekit for SwiftLint on Linux
+SWIFT_DIR="/opt/swift"
+ANDROID_HOME="${ANDROID_HOME:-$HOME/Android/sdk}"
+ANDROID_CMDLINE_BUILD="9862592"                     # bootstrap command-line tools build
+ANDROID_PLATFORM="android-36"
+ANDROID_BUILD_TOOLS="36.0.0"
+
+# --- Locate repos ----------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IOS_REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPOS_ROOT="$(cd "$IOS_REPO/.." && pwd)"
+ANDROID_REPO="$REPOS_ROOT/clerk-android"
+JS_REPO="$REPOS_ROOT/javascript"
+
+log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+
+# --- System packages -------------------------------------------------------
+install_apt_packages() {
+  local pkgs=("$JDK_TARGET_PKG" ruby unzip zip
+    binutils libc6-dev libcurl4-openssl-dev libedit2 libpython3-dev
+    libstdc++-13-dev libxml2-dev libz3-dev pkg-config tzdata zlib1g-dev
+    libncurses-dev libsqlite3-0 libtinfo6)
+  local missing=()
+  for p in "${pkgs[@]}"; do
+    dpkg -s "$p" >/dev/null 2>&1 || missing+=("$p")
+  done
+  if [ "${#missing[@]}" -eq 0 ]; then
+    log "System packages already installed"
+    return
+  fi
+  log "Installing system packages: ${missing[*]}"
+  sudo apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "${missing[@]}"
+}
+
+# --- Swift toolchain (SwiftLint sourcekit + SwiftFormat host) --------------
+install_swift() {
+  if [ -x "$SWIFT_DIR/usr/bin/swift" ]; then
+    log "Swift toolchain already present ($("$SWIFT_DIR/usr/bin/swift" --version | head -1))"
+    return
+  fi
+  log "Installing Swift $SWIFT_VERSION toolchain"
+  local url="https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2404/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu24.04.tar.gz"
+  local tmp; tmp="$(mktemp -d)"
+  curl -fsSL -o "$tmp/swift.tar.gz" "$url"
+  sudo mkdir -p "$SWIFT_DIR"
+  sudo tar -xzf "$tmp/swift.tar.gz" -C "$SWIFT_DIR" --strip-components=1
+  rm -rf "$tmp"
+}
+
+# --- Android SDK -----------------------------------------------------------
+install_android_sdk() {
+  local sdkmanager="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+  if [ ! -x "$sdkmanager" ]; then
+    log "Installing Android command-line tools"
+    mkdir -p "$ANDROID_HOME/cmdline-tools"
+    local tmp; tmp="$(mktemp -d)"
+    curl -fsSL -o "$tmp/cmdline-tools.zip" \
+      "https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_CMDLINE_BUILD}_latest.zip"
+    unzip -oq "$tmp/cmdline-tools.zip" -d "$ANDROID_HOME/cmdline-tools"
+    rm -rf "$ANDROID_HOME/cmdline-tools/latest"
+    mv "$ANDROID_HOME/cmdline-tools/cmdline-tools" "$ANDROID_HOME/cmdline-tools/latest"
+    rm -rf "$tmp"
+  fi
+  local java21; java21="$(dirname "$(dirname "$(readlink -f "$(command -v java)")")")"
+  export JAVA_HOME="${JAVA_HOME:-$java21}"
+  if [ -d "$ANDROID_HOME/platforms/$ANDROID_PLATFORM" ] \
+     && [ -d "$ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS" ] \
+     && [ -d "$ANDROID_HOME/platform-tools" ]; then
+    log "Android SDK packages already installed"
+    return
+  fi
+  log "Installing Android SDK packages ($ANDROID_PLATFORM, build-tools $ANDROID_BUILD_TOOLS)"
+  yes | "$sdkmanager" --licenses >/dev/null 2>&1 || true
+  "$sdkmanager" --install "platform-tools" "platforms;$ANDROID_PLATFORM" "build-tools;$ANDROID_BUILD_TOOLS" >/dev/null
+  yes | "$sdkmanager" --licenses >/dev/null 2>&1 || true
+}
+
+# --- Node 24 via nvm -------------------------------------------------------
+install_node() {
+  export NVM_DIR="$HOME/.nvm"
+  if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+    log "Installing nvm"
+    curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+  fi
+  # shellcheck disable=SC1091
+  . "$NVM_DIR/nvm.sh"
+  if [ ! -d "$NVM_DIR/versions/node/v$NODE_VERSION" ]; then
+    log "Installing Node $NODE_VERSION"
+    nvm install "$NODE_VERSION"
+    nvm alias default "$NODE_VERSION"
+  else
+    log "Node $NODE_VERSION already installed"
+  fi
+  corepack enable >/dev/null 2>&1 || true
+}
+
+# --- Shell environment for interactive agent shells ------------------------
+write_shell_env() {
+  local marker_begin="# >>> clerk multi-repo cloud env >>>"
+  local marker_end="# <<< clerk multi-repo cloud env <<<"
+  local bashrc="$HOME/.bashrc"
+  local java_home; java_home="$(dirname "$(dirname "$(readlink -f "$(command -v java)")")")"
+  touch "$bashrc"
+  # Remove any previous block, then append a fresh one.
+  if grep -qF "$marker_begin" "$bashrc"; then
+    awk -v b="$marker_begin" -v e="$marker_end" '
+      $0==b {skip=1} !skip {print} $0==e {skip=0}' "$bashrc" > "$bashrc.tmp"
+    mv "$bashrc.tmp" "$bashrc"
+  fi
+  log "Writing shell environment block to ~/.bashrc"
+  cat >> "$bashrc" <<EOF
+$marker_begin
+# Java: Gradle runs on the system JDK (21); the Android build uses the 17 toolchain automatically.
+export JAVA_HOME="$java_home"
+# Android SDK
+export ANDROID_HOME="$ANDROID_HOME"
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
+export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/cmdline-tools/latest/bin:\$PATH"
+# Swift (SwiftFormat/SwiftLint on Linux); sourcekit needs LD_LIBRARY_PATH
+export PATH="$SWIFT_DIR/usr/bin:\$PATH"
+export LD_LIBRARY_PATH="$SWIFT_DIR/usr/lib/swift/linux:\${LD_LIBRARY_PATH:-}"
+# Node 24 (javascript monorepo) ahead of the system node
+export NVM_DIR="\$HOME/.nvm"
+[ -s "\$NVM_DIR/nvm.sh" ] && \\. "\$NVM_DIR/nvm.sh"
+if [ -d "\$NVM_DIR/versions/node/v$NODE_VERSION/bin" ]; then
+  export PATH="\$NVM_DIR/versions/node/v$NODE_VERSION/bin:\$PATH"
+fi
+$marker_end
+EOF
+}
+
+# --- Per-repo dependency refresh ------------------------------------------
+setup_ios() {
+  [ -d "$IOS_REPO" ] || { log "clerk-ios missing, skipping"; return; }
+  log "clerk-ios: installing SwiftFormat + SwiftLint"
+  ( cd "$IOS_REPO" && ./scripts/install-swiftformat.sh && ./scripts/install-swiftlint.sh )
+}
+
+setup_android() {
+  [ -d "$ANDROID_REPO" ] || { log "clerk-android missing, skipping"; return; }
+  log "clerk-android: warming Gradle dependencies (best-effort)"
+  local java_home; java_home="$(dirname "$(dirname "$(readlink -f "$(command -v java)")")")"
+  ( cd "$ANDROID_REPO" && JAVA_HOME="$java_home" ANDROID_HOME="$ANDROID_HOME" \
+      ./gradlew --quiet :source:api:assembleDebug ) || log "clerk-android warm build skipped/failed (non-fatal)"
+}
+
+setup_javascript() {
+  [ -d "$JS_REPO" ] || { log "javascript missing, skipping"; return; }
+  export NVM_DIR="$HOME/.nvm"
+  # shellcheck disable=SC1091
+  . "$NVM_DIR/nvm.sh"
+  export PATH="$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"
+  log "javascript: pnpm install (frozen lockfile)"
+  ( cd "$JS_REPO" && pnpm install --frozen-lockfile )
+}
+
+main() {
+  install_apt_packages
+  install_swift
+  install_android_sdk
+  install_node
+  write_shell_env
+  setup_ios
+  setup_javascript
+  setup_android
+  log "Setup complete for clerk-ios, clerk-android, and javascript (@clerk/expo)."
+}
+
+main "$@"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -183,6 +183,10 @@ setup_javascript() {
   export PATH="$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"
   log "javascript: pnpm install (frozen lockfile)"
   ( cd "$JS_REPO" && pnpm install --frozen-lockfile )
+  # Build @clerk/expo and its workspace deps so `pnpm test` works out of the box.
+  log "javascript: building @clerk/expo (+ workspace deps)"
+  ( cd "$JS_REPO" && pnpm turbo build --filter=@clerk/expo ) \
+    || log "javascript @clerk/expo build skipped/failed (non-fatal)"
 }
 
 main() {

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -23,11 +23,26 @@ ANDROID_BUILD_TOOLS="36.0.0"
 # --- Locate repos ----------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IOS_REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
-REPOS_ROOT="$(cd "$IOS_REPO/.." && pwd)"
-ANDROID_REPO="$REPOS_ROOT/clerk-android"
-JS_REPO="$REPOS_ROOT/javascript"
 
 log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+
+# Find a sibling repo by name + a marker file, searching the layouts a Cloud
+# Agent might use (repositoryDependencies land next to the primary /workspace
+# checkout, but exact roots vary, so probe several candidates).
+locate_repo() {
+  local name="$1" marker="$2" root
+  for root in "$(dirname "$IOS_REPO")" "$HOME/repos" "$HOME" /agent/repos \
+              "$(dirname "${WORKSPACE_ROOT:-/workspace}")" /workspace /workspaces; do
+    if [ -n "$root" ] && [ -f "$root/$name/$marker" ]; then
+      printf '%s' "$root/$name"
+      return 0
+    fi
+  done
+  return 1
+}
+
+ANDROID_REPO="$(locate_repo clerk-android settings.gradle.kts || true)"
+JS_REPO="$(locate_repo javascript pnpm-workspace.yaml || true)"
 
 # --- System packages -------------------------------------------------------
 install_apt_packages() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repo-managed Cursor Cloud Agent environment for the multi-repo Clerk workspace (iOS + Android + Expo), so a single Cloud Agent can work across all three SDKs checked out side by side:

- **`.cursor/environment.json`** — declares the environment: runs the install script and pulls in `clerk-android` and `javascript` as `repositoryDependencies` so all three repos are checked out together.
- **`.cursor/install.sh`** — idempotent setup that provisions the Linux-runnable toolchains and refreshes each repo's dependencies.

### What the install script sets up

- **`clerk-ios`** (primary, Swift) — Swift 6.2 Linux toolchain + repo-pinned SwiftFormat 0.60.0 / SwiftLint 0.63.2, so `make check` (format-check + lint + E2E checks) runs on Linux.
- **`clerk-android`** (Kotlin/Gradle) — JDK 17 + Android SDK (platform 36, build-tools 36.0.0, platform-tools); Gradle runs on the system JDK 21 with the 17 toolchain auto-detected.
- **`javascript` / `@clerk/expo`** (Node) — Node 24.15.0 via nvm ahead of the system node, then `pnpm install` and a turbo build of `@clerk/expo` so `pnpm test` works directly.

It also writes a `~/.bashrc` block wiring `JAVA_HOME`, `ANDROID_HOME`, the Swift toolchain (`PATH` + `LD_LIBRARY_PATH`), and Node 24 so interactive agent shells resolve every tool.

## Notes

- Toolchain installs are guarded, so re-runs against a warm snapshot are fast (~3s no-op); the `~/.bashrc` block is rewritten in place (no duplication). Sibling-repo dependency refresh is located across common checkout layouts and skipped gracefully if a repo is absent.
- iOS **build/test** still require macOS + Xcode and are not possible on the Linux Cloud VM; the runnable iOS dev loop here is `make check`.
- No application code is changed.

## Validation

Run on the Cloud VM (Ubuntu 24.04, x86_64), and independently re-verified on a fresh Cloud Agent booted from a draft environment build:

| Repo | Check | Result |
| --- | --- | --- |
| clerk-ios | `make check` (SwiftFormat + SwiftLint + E2E checks) | All checks passed |
| clerk-android | `:source:api:assembleDebug` | BUILD SUCCESSFUL |
| clerk-android | `:source:api` + `:source:ui` unit/Paparazzi tests | BUILD SUCCESSFUL |
| clerk-android | `:samples:quickstart:assembleDebug` | APK produced (15.9 MB) |
| javascript | build `@clerk/expo` (+ workspace deps) | 10/10 tasks |
| javascript | `@clerk/expo` vitest | 279 passed |
| — | `install.sh` idempotence | Passed twice |
| — | Fresh Cloud Agent (draft build) | node 24.15.0, Java 21 (+17 toolchain), Swift 6.2, Android SDK 36; all three dev loops passed |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-240289be-b70e-499e-a057-826197655b7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-240289be-b70e-499e-a057-826197655b7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

