### PR TITLE
Add Cursor Cloud environment instructions for Linux dev workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,20 @@ You are a **Senior iOS Engineer**, specializing in SwiftUI, SwiftData, and relat
 - Do not add `codex`, `[codex]`, or other assistant branding to pull request titles.
 - Do not add assistant branding to commit subjects, branch names, or release-note headings unless explicitly requested by the user.
 - Use concise, human-readable pull request titles that describe the actual change.
+
+## Cursor Cloud specific instructions
+
+This is an Apple-platform SDK (iOS/macOS/tvOS/watchOS/visionOS). Cloud Agent VMs run Linux (x86_64), so the toolchain is split into what does and does not run here.
+
+### Works on Linux (use these to validate changes)
+- `make format-check` — SwiftFormat lint mode over all Swift files.
+- `make lint` — SwiftLint. Requires a Swift toolchain because SwiftLint loads `libsourcekitdInProc.so` from it.
+- `make check` — the CI gate: `format-check` + `lint` + the Ruby-based E2E contract checks (`check-e2e-hooks`, `check-e2e-selectors`, `check-e2e-phone-numbers`). It prints SwiftLint warnings (non-zero warning count is normal, e.g. "58 violations, 0 serious") and still exits 0 when passing.
+- Command reference lives in `Makefile` and `CONTRIBUTING.md`; don't duplicate it here.
+
+### Does NOT work on Linux (needs macOS + Xcode 26 + Apple SDKs)
+- `swift build` / `swift test`, `make test`, `make test-ui`, `make test-e2e`, `make smoke-macos`, and the Xcode example apps under `Examples/`. `swift build` fails on Linux with `no such module 'UIKit'` / `AuthenticationServices` because `ClerkKit`, `ClerkKitUI`, and the `Nuke` dependency import Apple-only frameworks. Building, running the example apps, and running unit/UI/E2E tests must be done on macOS. Do not attempt to make these pass on Linux.
+
+### Non-obvious environment notes
+- The base VM image provides the system dependencies the Linux workflow needs: a Swift 6.2 toolchain on `PATH` (with its `lib` dirs registered via `ldconfig` so SwiftLint can load sourcekit) and `ruby` (for the E2E contract check scripts). These are baked into the snapshot, not installed by the update script.
+- The pinned `SwiftFormat`/`SwiftLint` binaries live in the gitignored `.tools/` dir and are (re)installed idempotently by `make install-tools`, which the startup update script runs.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents how to develop this Apple-platform SDK from a Cursor Cloud (Linux) agent VM, since building/running the SDK and example apps requires macOS + Xcode while the lint/format/validation workflow runs fine on Linux.

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering:
- Commands that work on Linux: `make format-check`, `make lint`, `make check` (and that `make check` prints non-serious SwiftLint warnings while still exiting 0).
- Commands that require macOS + Xcode 26 + Apple SDKs and cannot run on Linux (`swift build`/`swift test`, `make test`, `make test-ui`, `make test-e2e`, `make smoke-macos`, Xcode examples) — `swift build` fails with `no such module 'UIKit'`.
- Non-obvious environment notes: SwiftLint needs a Swift toolchain (`libsourcekitdInProc.so`) and the E2E contract checks need Ruby; both are baked into the base VM snapshot, while `make install-tools` (the startup update script) idempotently reinstalls the repo-pinned SwiftFormat/SwiftLint into `.tools/`.

## Validation

`make check` passes on the Linux VM (format-check + SwiftLint + Ruby E2E contract checks):

```
0/603 files require formatting, 10 files skipped.
Done linting! Found 58 violations, 0 serious in 419 files.
E2E hook check passed: 8 reviewed call sites.
E2E selector check passed: 73 product selectors, 7 E2EHost selectors, 65 Maestro selector usages.
E2E phone-number check passed: approved range 5555550100...5555550199.
✅ All checks passed!
```

No code changes; documentation only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-debd7d5a-efa8-444a-99f5-cdf957065078?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-debd7d5a-efa8-444a-99f5-cdf957065078&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

