### PR TITLE
fix(ui): forward observable environment into nested sheets

### DIFF
--- a/Examples/Quickstart/Quickstart/ContentView.swift
+++ b/Examples/Quickstart/Quickstart/ContentView.swift
@@ -47,6 +47,7 @@ struct ContentView: View {
     }
     .sheet(isPresented: $authViewIsPresented) {
       AuthView()
+        .environment(clerk)
     }
   }
 }

--- a/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskMfaSmsChooseNumberView.swift
+++ b/Sources/ClerkKitUI/Components/Auth/SessionTask/SessionTaskMfaSmsChooseNumberView.swift
@@ -84,6 +84,7 @@ struct SessionTaskMfaSmsChooseNumberView: View {
       }
       .presentationBackground(theme.colors.background)
       .tint(theme.colors.primary)
+      .environment(clerk)
     }
   }
 

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationMembersView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationMembersView.swift
@@ -112,6 +112,7 @@ struct OrganizationMembersView: View {
           inviteMembersIsPresented = false
         }
       }
+      .environment(clerk)
     }
     .clerkErrorPresenting($dataSource.error)
     .task(id: organization?.id) {

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationProfileView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationProfileView.swift
@@ -217,11 +217,19 @@ public struct OrganizationProfileView<Route: Hashable, Destination: View>: View 
         }
         .sheet(isPresented: $updateProfileIsPresented) {
           OrganizationProfileUpdateProfileView(organization: organization)
+            .environment(clerk)
         }
         .sheet(item: $presentedConfirmation) { confirmation in
           OrganizationProfileActionConfirmationView(
             action: confirmation,
             organization: organization
+          )
+          .environment(clerk)
+          .environment(
+            OrganizationProfileBuiltInRouter(
+              push: navigateToBuiltIn,
+              dismissAction: dismissAction
+            )
           )
         }
         .task {

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationSwitcher.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationSwitcher.swift
@@ -176,6 +176,7 @@ public struct OrganizationSwitcher<Route: Hashable, LabelContent: View, Destinat
     }
     .sheet(item: $presentedSheet) { sheet in
       view(for: sheet)
+        .environment(clerk)
     }
     .onChange(of: user?.id) { _, userId in
       if userId == nil {

--- a/Sources/ClerkKitUI/Components/Organization/OrganizationVerifiedDomainsView.swift
+++ b/Sources/ClerkKitUI/Components/Organization/OrganizationVerifiedDomainsView.swift
@@ -110,6 +110,7 @@ struct OrganizationVerifiedDomainsView: View {
     .clerkErrorPresenting($error)
     .sheet(item: $presentedDomainFlow) { presentedDomainFlow in
       view(for: presentedDomainFlow)
+        .environment(clerk)
     }
     .task(id: organization?.id) {
       await loadDomains(page: 1)

--- a/Sources/ClerkKitUI/Components/UserButton/UserButton.swift
+++ b/Sources/ClerkKitUI/Components/UserButton/UserButton.swift
@@ -166,14 +166,17 @@ public struct UserButton<Route: Hashable, SignedOutContent: View, Destination: V
         #if os(iOS)
         .presentationDragIndicator(.visible)
         #endif
+        .environment(clerk)
       case .sessionTaskAuth:
         AuthView()
           #if os(iOS)
           .presentationDragIndicator(.visible)
           #endif
+          .environment(clerk)
       case .signOut:
         UserButtonSignOutView()
           .contentSizingDetent()
+          .environment(clerk)
       }
     }
     .onChange(of: clerk.user) { _, newValue in

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountSection.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountSection.swift
@@ -40,6 +40,12 @@ struct UserProfileDeleteAccountSection: View {
 
 #Preview {
   UserProfileDeleteAccountSection()
+    .environment(
+      UserProfileBuiltInRouter(
+        push: { _ in },
+        dismissAction: { _ in }
+      )
+    )
     .clerkPreview()
 }
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountSection.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileDeleteAccountSection.swift
@@ -9,7 +9,10 @@ import ClerkKit
 import SwiftUI
 
 struct UserProfileDeleteAccountSection: View {
+  @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
+  @Environment(UserProfileSheetNavigation.self) private var navigation
+  @Environment(UserProfileBuiltInRouter.self) private var builtInRouter
 
   @State private var confirmationIsPresented = false
 
@@ -28,6 +31,9 @@ struct UserProfileDeleteAccountSection: View {
     }
     .sheet(isPresented: $confirmationIsPresented) {
       UserProfileDeleteAccountConfirmationView()
+        .environment(clerk)
+        .environment(navigation)
+        .environment(builtInRouter)
     }
   }
 }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileDetailView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileDetailView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct UserProfileDetailView: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
+  @Environment(CodeLimiter.self) private var codeLimiter
 
   @State private var addEmailAddressDestination: UserProfileAddEmailView.Destination?
   @State private var addPhoneNumberDestination: UserProfileAddPhoneView.Destination?
@@ -158,15 +159,20 @@ struct UserProfileDetailView: View {
     .background(theme.colors.background)
     .sheet(item: $addEmailAddressDestination) {
       UserProfileAddEmailView(desintation: $0)
+        .environment(clerk)
+        .environment(codeLimiter)
     }
     .sheet(item: $addPhoneNumberDestination) {
       UserProfileAddPhoneView(desintation: $0)
+        .environment(clerk)
+        .environment(codeLimiter)
     }
     .sheet(isPresented: $addConnectedAccountIsPresented) {
       UserProfileAddConnectedAccountView(contentHeight: $connectAccountSheetHeight)
       #if os(iOS)
       .presentationDetents([.height(connectAccountSheetHeight)])
       #endif
+      .environment(clerk)
     }
     .task {
       _ = try? await clerk.refreshClient()

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileEmailRow.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileEmailRow.swift
@@ -12,6 +12,7 @@ struct UserProfileEmailRow: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
   @Environment(\.locale) private var locale
+  @Environment(CodeLimiter.self) private var codeLimiter
 
   @State private var addEmailAddressDestination: UserProfileAddEmailView.Destination?
   @State private var isLoading = false
@@ -112,6 +113,8 @@ struct UserProfileEmailRow: View {
     .clerkErrorPresenting($error)
     .sheet(item: $addEmailAddressDestination) {
       UserProfileAddEmailView(desintation: $0)
+        .environment(clerk)
+        .environment(codeLimiter)
     }
     .onChange(of: removeResource) {
       if $1 != nil { isConfirmingRemoval = true }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddSmsView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaAddSmsView.swift
@@ -14,6 +14,7 @@ struct UserProfileMfaAddSmsView: View {
   @Environment(\.clerkTheme) private var theme
   @Environment(\.dismiss) private var dismiss
   @Environment(UserProfileSheetNavigation.self) private var navigation
+  @Environment(CodeLimiter.self) private var codeLimiter
 
   @State private var selectedPhoneNumber: ClerkKit.PhoneNumber?
   @State private var addPhoneNumberIsPresented = false
@@ -134,6 +135,8 @@ struct UserProfileMfaAddSmsView: View {
     #endif
     .sheet(isPresented: $addPhoneNumberIsPresented) {
       UserProfileAddPhoneView()
+        .environment(clerk)
+        .environment(codeLimiter)
     }
   }
 }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaSection.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaSection.swift
@@ -12,6 +12,7 @@ struct UserProfileMfaSection: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
   @Environment(UserProfileSheetNavigation.self) private var navigation
+  @Environment(CodeLimiter.self) private var codeLimiter
 
   @State private var addMfaHeight: CGFloat = 400
 
@@ -80,6 +81,9 @@ struct UserProfileMfaSection: View {
       #if os(iOS)
       .presentationDetents([.height(addMfaHeight)])
       #endif
+      .environment(clerk)
+      .environment(navigation)
+      .environment(codeLimiter)
     }
   }
 }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaSection.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileMfaSection.swift
@@ -12,7 +12,6 @@ struct UserProfileMfaSection: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
   @Environment(UserProfileSheetNavigation.self) private var navigation
-  @Environment(CodeLimiter.self) private var codeLimiter
 
   @State private var addMfaHeight: CGFloat = 400
 
@@ -83,7 +82,6 @@ struct UserProfileMfaSection: View {
       #endif
       .environment(clerk)
       .environment(navigation)
-      .environment(codeLimiter)
     }
   }
 }

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfilePasswordSection.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfilePasswordSection.swift
@@ -49,6 +49,7 @@ struct UserProfilePasswordSection: View {
     }
     .sheet(item: $passwordAction) { action in
       UserProfileChangePasswordView(isAddingPassword: action == .add)
+        .environment(clerk)
     }
   }
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfilePhoneRow.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfilePhoneRow.swift
@@ -12,6 +12,7 @@ struct UserProfilePhoneRow: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
   @Environment(\.locale) private var locale
+  @Environment(CodeLimiter.self) private var codeLimiter
 
   @State private var addPhoneNumberDestination: UserProfileAddPhoneView.Destination?
   @State private var isLoading = false
@@ -115,6 +116,8 @@ struct UserProfilePhoneRow: View {
     }
     .sheet(item: $addPhoneNumberDestination) {
       UserProfileAddPhoneView(desintation: $0)
+        .environment(clerk)
+        .environment(codeLimiter)
     }
     .confirmationDialog(
       removeResource?.messageLine1(locale: locale) ?? "",

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileSecurityView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileSecurityView.swift
@@ -12,6 +12,7 @@ struct UserProfileSecurityView: View {
   @Environment(Clerk.self) private var clerk
   @Environment(\.clerkTheme) private var theme
   @Environment(UserProfileSheetNavigation.self) private var navigation
+  @Environment(CodeLimiter.self) private var codeLimiter
   @State private var error: Error?
 
   @State private var biometricCredentialAvailability: BiometricCredentialAvailability?
@@ -143,6 +144,9 @@ struct UserProfileSecurityView: View {
     }
     .sheet(item: $navigation.presentedAddMfaType) {
       $0.view
+        .environment(clerk)
+        .environment(navigation)
+        .environment(codeLimiter)
     }
     #if os(macOS)
     .frame(minWidth: 460, maxWidth: 620, alignment: .leading)
@@ -196,6 +200,12 @@ extension UserProfileSecurityView {
   }
   .clerkPreview()
   .environment(UserProfileSheetNavigation())
+  .environment(
+    UserProfileBuiltInRouter(
+      push: { _ in },
+      dismissAction: { _ in }
+    )
+  )
   .environment(\.clerkTheme, .clerk)
 }
 

--- a/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
+++ b/Sources/ClerkKitUI/Components/UserProfile/UserProfileView.swift
@@ -201,8 +201,12 @@ public struct UserProfileView<Route: Hashable, Destination: View>: View {
         #if os(iOS)
         UserButtonAccountSwitcher(contentHeight: $accountSwitcherHeight)
           .presentationDetents([.height(accountSwitcherHeight)])
+          .environment(clerk)
+          .environment(sheetNavigation)
         #elseif os(macOS)
         UserButtonAccountSwitcher()
+          .environment(clerk)
+          .environment(sheetNavigation)
         #endif
       }
       .sheet(isPresented: $updateProfileIsPresented) {
@@ -214,6 +218,7 @@ public struct UserProfileView<Route: Hashable, Destination: View>: View {
         // rather than showing the host's back button.
         AuthView()
           .environment(\.clerkHostBackAction, nil)
+          .environment(clerk)
       }
       .task(id: user) {
         await getSessionsOnAllDevices()


### PR DESCRIPTION
## Summary

- forward the injected `@Observable` environment values into 19 nested sheets that read them
- fix missing-environment crashes on macOS — the same failure #546 fixed for Edit Profile
- runtime environment: Designed for iPad crashes, iPhone does not crash, iPad does not crash

On macOS a sheet does not carry `@Observable` environment values across the
presentation boundary. The most reachable case is User Profile → Security →
**Delete account**: its confirmation reads `Clerk`, `UserProfileSheetNavigation`
and `UserProfileBuiltInRouter`, none of them forwarded, so the account cannot be
deleted on macOS at all. Every forwarded value is an instance an ancestor
already owns.

Sites were found by computing, for each sheet, the `@Observable` values its whole
subtree reads and does not provide for itself — not just its root view. That
matters in one place: `UserProfileAddMfaView` dismisses itself and asks
`UserProfileSecurityView` to present the next sheet, so anything forwarded at the
chooser never reaches the SMS/TOTP screens — hence the forward at both.

Two presenters gained an `@Environment` read their own sheets need;
`.clerkPreview()` does not inject `UserProfileBuiltInRouter`, so those previews
now provide one.

## Testing

- `swift build --target ClerkKitUI`, and `xcodebuild -scheme ClerkKitUI -destination 'generic/platform=iOS Simulator' build`
- manually on My Mac (Designed for iPad): Delete account now opens and completes; on 1.5.0 it traps immediately
 
`shared-checks.yml` runs the UI tests on iOS only, so nothing in CI covers the
macOS presentation boundary this class of bug lives on.
