### PR TITLE
feat(billing): decode commerce settings from environment

### DIFF
--- a/Sources/ClerkKit/Domains/Environment/CommerceSettings.swift
+++ b/Sources/ClerkKit/Domains/Environment/CommerceSettings.swift
@@ -1,0 +1,56 @@
+//
+//  CommerceSettings.swift
+//
+
+import Foundation
+
+extension Clerk.Environment {
+  public struct CommerceSettings: Codable, Equatable, Sendable {
+    public var billing: Billing
+
+    public struct Billing: Codable, Equatable, Sendable {
+      public var stripePublishableKey: String?
+      public var organization: Payer
+      public var user: Payer
+
+      public struct Payer: Codable, Equatable, Sendable {
+        public var enabled: Bool
+        public var hasPaidPlans: Bool
+      }
+    }
+
+    /// Sensible defaults when commerce settings are absent from a decoded payload.
+    public static let `default` = CommerceSettings(
+      billing: Billing(
+        stripePublishableKey: nil,
+        organization: Billing.Payer(enabled: false, hasPaidPlans: false),
+        user: Billing.Payer(enabled: false, hasPaidPlans: false)
+      )
+    )
+  }
+}
+
+extension Clerk.Environment.CommerceSettings {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    billing = try container.decodeIfPresent(Billing.self, forKey: .billing) ?? Self.default.billing
+  }
+}
+
+extension Clerk.Environment.CommerceSettings.Billing {
+  public init(from decoder: Decoder) throws {
+    let defaults = Clerk.Environment.CommerceSettings.default.billing
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    stripePublishableKey = try container.decodeIfPresent(String.self, forKey: .stripePublishableKey)
+    organization = try container.decodeIfPresent(Payer.self, forKey: .organization) ?? defaults.organization
+    user = try container.decodeIfPresent(Payer.self, forKey: .user) ?? defaults.user
+  }
+}
+
+extension Clerk.Environment.CommerceSettings.Billing.Payer {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+    hasPaidPlans = try container.decodeIfPresent(Bool.self, forKey: .hasPaidPlans) ?? false
+  }
+}

--- a/Sources/ClerkKit/Domains/Environment/Environment.swift
+++ b/Sources/ClerkKit/Domains/Environment/Environment.swift
@@ -10,17 +10,20 @@ extension Clerk {
     public var userSettings: UserSettings
     public var displayConfig: DisplayConfig
     public var organizationSettings: OrganizationSettings
+    public var commerceSettings: CommerceSettings
 
     public init(
       authConfig: AuthConfig,
       userSettings: UserSettings,
       displayConfig: DisplayConfig,
-      organizationSettings: OrganizationSettings = .default
+      organizationSettings: OrganizationSettings = .default,
+      commerceSettings: CommerceSettings = .default
     ) {
       self.authConfig = authConfig
       self.userSettings = userSettings
       self.displayConfig = displayConfig
       self.organizationSettings = organizationSettings
+      self.commerceSettings = commerceSettings
     }
 
     public init(from decoder: Decoder) throws {
@@ -29,6 +32,7 @@ extension Clerk {
       userSettings = try container.decode(UserSettings.self, forKey: .userSettings)
       displayConfig = try container.decode(DisplayConfig.self, forKey: .displayConfig)
       organizationSettings = try container.decodeIfPresent(OrganizationSettings.self, forKey: .organizationSettings) ?? .default
+      commerceSettings = try container.decodeIfPresent(CommerceSettings.self, forKey: .commerceSettings) ?? .default
     }
   }
 }

--- a/Sources/ClerkKit/Mocks/MockModels.swift
+++ b/Sources/ClerkKit/Mocks/MockModels.swift
@@ -904,8 +904,17 @@ extension Clerk.Environment {
       authConfig: .mock,
       userSettings: .mock,
       displayConfig: .mock,
-      organizationSettings: .mock
+      organizationSettings: .mock,
+      commerceSettings: .mock
     )
+  }
+}
+
+// MARK: CommerceSettings
+
+extension Clerk.Environment.CommerceSettings {
+  public static var mock: Self {
+    .default
   }
 }
 

--- a/Tests/Domains/Environment/EnvironmentTests.swift
+++ b/Tests/Domains/Environment/EnvironmentTests.swift
@@ -112,3 +112,119 @@ struct EnvironmentTests {
     }
   }
 }
+
+struct EnvironmentCommerceSettingsDecodingTests {
+  private let decoder = JSONDecoder.clerkDecoder
+  private let encoder = JSONEncoder.clerkEncoder
+
+  private enum TestError: Error {
+    case invalidUTF8
+  }
+
+  private func environmentJSON(commerceSettings: String? = nil) throws -> Data {
+    let authConfig = try encoder.encode(Clerk.Environment.AuthConfig.mock)
+    let userSettings = try encoder.encode(Clerk.Environment.UserSettings.mock)
+    let displayConfig = try encoder.encode(Clerk.Environment.DisplayConfig.mock)
+    guard
+      let authConfigString = String(data: authConfig, encoding: .utf8),
+      let userSettingsString = String(data: userSettings, encoding: .utf8),
+      let displayConfigString = String(data: displayConfig, encoding: .utf8)
+    else {
+      throw TestError.invalidUTF8
+    }
+
+    var parts = [
+      "\"auth_config\": \(authConfigString)",
+      "\"user_settings\": \(userSettingsString)",
+      "\"display_config\": \(displayConfigString)",
+    ]
+    if let commerceSettings {
+      parts.append("\"commerce_settings\": \(commerceSettings)")
+    }
+
+    return Data("{ \(parts.joined(separator: ", ")) }".utf8)
+  }
+
+  @Test
+  func environmentDecodesWhenCommerceSettingsKeyIsMissing() throws {
+    let data = try environmentJSON(commerceSettings: nil)
+    let env = try decoder.decode(Clerk.Environment.self, from: data)
+    #expect(env.commerceSettings == .default)
+  }
+
+  @Test
+  func environmentDecodesEnabledUserBilling() throws {
+    let json = """
+    {
+      "billing": {
+        "stripe_publishable_key": "pk_test_123",
+        "user": { "enabled": true, "has_paid_plans": true },
+        "organization": { "enabled": false, "has_paid_plans": false }
+      }
+    }
+    """
+    let env = try decoder.decode(Clerk.Environment.self, from: environmentJSON(commerceSettings: json))
+
+    #expect(env.commerceSettings.billing.user.enabled == true)
+    #expect(env.commerceSettings.billing.user.hasPaidPlans == true)
+    #expect(env.commerceSettings.billing.organization.enabled == false)
+    #expect(env.commerceSettings.billing.stripePublishableKey == "pk_test_123")
+  }
+
+  @Test
+  func environmentDecodesEnabledOrganizationBilling() throws {
+    let json = """
+    {
+      "billing": {
+        "stripe_publishable_key": "pk_live_abc",
+        "user": { "enabled": false, "has_paid_plans": false },
+        "organization": { "enabled": true, "has_paid_plans": true }
+      }
+    }
+    """
+    let env = try decoder.decode(Clerk.Environment.self, from: environmentJSON(commerceSettings: json))
+
+    #expect(env.commerceSettings.billing.organization.enabled == true)
+    #expect(env.commerceSettings.billing.organization.hasPaidPlans == true)
+    #expect(env.commerceSettings.billing.user.enabled == false)
+    #expect(env.commerceSettings.billing.stripePublishableKey == "pk_live_abc")
+  }
+
+  @Test
+  func environmentDecodesNullStripePublishableKey() throws {
+    let json = """
+    {
+      "billing": {
+        "stripe_publishable_key": null,
+        "user": { "enabled": true, "has_paid_plans": false },
+        "organization": { "enabled": false, "has_paid_plans": false }
+      }
+    }
+    """
+    let env = try decoder.decode(Clerk.Environment.self, from: environmentJSON(commerceSettings: json))
+
+    #expect(env.commerceSettings.billing.stripePublishableKey == nil)
+    #expect(env.commerceSettings.billing.user.enabled == true)
+  }
+
+  @Test
+  func environmentDecodesUnknownCommerceSettingsKeys() throws {
+    let json = """
+    {
+      "id": "commerce_settings_1",
+      "object": "commerce_settings",
+      "billing": {
+        "stripe_publishable_key": "pk_test_leftover",
+        "user": { "enabled": true, "has_paid_plans": false },
+        "organization": { "enabled": true, "has_paid_plans": false },
+        "future_flag": true
+      }
+    }
+    """
+    let env = try decoder.decode(Clerk.Environment.self, from: environmentJSON(commerceSettings: json))
+
+    #expect(env.commerceSettings.billing.user.enabled == true)
+    #expect(env.commerceSettings.billing.organization.enabled == true)
+    #expect(env.commerceSettings.billing.stripePublishableKey == "pk_test_leftover")
+  }
+}


### PR DESCRIPTION
`/v1/environment` already returns `commerce_settings`, but ClerkKit dropped the key. Apps had no way to know whether Billing is on for users or orgs.

This adds `Clerk.Environment.commerceSettings` with the same shape as clerk-js (`stripePublishableKey`, `user.enabled`, `user.hasPaidPlans`, `organization.enabled`, `organization.hasPaidPlans`). Missing or partial payloads decode as disabled so cached environment JSON from older SDK versions still loads.

First PR in the native Billing read stack. No checkout or write APIs.

## What to focus on

- Defaulting when `commerce_settings` is absent, so environment refresh does not throw.
- Snake_case decode of `stripe_publishable_key` and leftover `id` / `object` keys from FAPI.

## Verification

- `make test` (includes decode cases for enabled user billing, enabled org billing, missing key, null Stripe key, unknown keys)

Live lanes still need a Billing-enabled instance. This PR does not change UI. No screenshots or video.
