### PR TITLE
feat(billing): add GET APIs for plans, subscriptions, and credits

### DIFF
--- a/Sources/ClerkKit/Core/Clerk.swift
+++ b/Sources/ClerkKit/Core/Clerk.swift
@@ -272,6 +272,15 @@ public final class Clerk {
     Organizations(organizationService: dependencies.organizationService)
   }
 
+  /// The main entry point for Billing GET APIs.
+  ///
+  /// Use this to read plans, subscriptions, statements, payments, and credits.
+  /// Payment methods live on ``User/getPaymentMethods(params:)`` and
+  /// ``Organization/getPaymentMethods(params:)``.
+  public var billing: Billing {
+    Billing(billingService: dependencies.billingService)
+  }
+
   /// The main entry point for biometric credential operations.
   public var biometricCredentials: BiometricCredentials {
     BiometricCredentials(

--- a/Sources/ClerkKit/Dependencies/Dependencies.swift
+++ b/Sources/ClerkKit/Dependencies/Dependencies.swift
@@ -83,6 +83,9 @@ protocol Dependencies: AnyObject {
   /// Service for organization-related operations.
   var organizationService: OrganizationServiceProtocol { get }
 
+  /// Service for billing-related operations.
+  var billingService: BillingServiceProtocol { get }
+
   /// Service for environment-related operations.
   var environmentService: EnvironmentServiceProtocol { get }
 

--- a/Sources/ClerkKit/Dependencies/DependencyContainer.swift
+++ b/Sources/ClerkKit/Dependencies/DependencyContainer.swift
@@ -50,6 +50,7 @@ final class DependencyContainer: Dependencies {
   let passkeyService: PasskeyServiceProtocol
   let biometricCredentialService: BiometricCredentialServiceProtocol
   let organizationService: OrganizationServiceProtocol
+  let billingService: BillingServiceProtocol
   let environmentService: EnvironmentServiceProtocol
   let emailAddressService: EmailAddressServiceProtocol
   let phoneNumberService: PhoneNumberServiceProtocol
@@ -183,6 +184,7 @@ final class DependencyContainer: Dependencies {
     passkeyService = PasskeyService(apiClient: apiClient)
     biometricCredentialService = BiometricCredentialService(apiClient: apiClient)
     organizationService = OrganizationService(apiClient: apiClient)
+    billingService = BillingService(apiClient: apiClient)
     environmentService = EnvironmentService(apiClient: apiClient)
     emailAddressService = EmailAddressService(apiClient: apiClient)
     phoneNumberService = PhoneNumberService(apiClient: apiClient)

--- a/Sources/ClerkKit/Domains/Billing/Billing.swift
+++ b/Sources/ClerkKit/Domains/Billing/Billing.swift
@@ -1,0 +1,51 @@
+//
+//  Billing.swift
+//  Clerk
+//
+
+import Foundation
+
+@MainActor
+public struct Billing {
+  private let billingService: BillingServiceProtocol
+
+  init(billingService: BillingServiceProtocol) {
+    self.billingService = billingService
+  }
+
+  public func getPaymentAttempts(params: GetPaymentAttemptsParams) async throws -> ClerkPaginatedResponse<BillingPayment> {
+    try await billingService.getPaymentAttempts(params: params)
+  }
+
+  public func getPaymentAttempt(params: GetPaymentAttemptParams) async throws -> BillingPayment {
+    try await billingService.getPaymentAttempt(params: params)
+  }
+
+  public func getPlans(params: GetPlansParams? = nil) async throws -> ClerkPaginatedResponse<BillingPlan> {
+    try await billingService.getPlans(params: params)
+  }
+
+  public func getPlan(params: GetPlanParams) async throws -> BillingPlan {
+    try await billingService.getPlan(params: params)
+  }
+
+  public func getSubscription(params: GetSubscriptionParams) async throws -> BillingSubscription {
+    try await billingService.getSubscription(params: params)
+  }
+
+  public func getStatements(params: GetStatementsParams) async throws -> ClerkPaginatedResponse<BillingStatement> {
+    try await billingService.getStatements(params: params)
+  }
+
+  public func getStatement(params: GetStatementParams) async throws -> BillingStatement {
+    try await billingService.getStatement(params: params)
+  }
+
+  public func getCreditBalance(params: GetCreditBalanceParams) async throws -> BillingCreditBalance {
+    try await billingService.getCreditBalance(params: params)
+  }
+
+  public func getCreditHistory(params: GetCreditHistoryParams) async throws -> ClerkPaginatedResponse<BillingCreditLedger> {
+    try await billingService.getCreditHistory(params: params)
+  }
+}

--- a/Sources/ClerkKit/Domains/Billing/BillingCreditBalance.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingCreditBalance.swift
@@ -1,0 +1,14 @@
+//
+//  BillingCreditBalance.swift
+//  Clerk
+//
+
+import Foundation
+
+public struct BillingCreditBalance: Codable, Equatable, Sendable {
+  public var balance: BillingMoneyAmount?
+
+  public init(balance: BillingMoneyAmount? = nil) {
+    self.balance = balance
+  }
+}

--- a/Sources/ClerkKit/Domains/Billing/BillingCreditLedger.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingCreditLedger.swift
@@ -1,0 +1,28 @@
+//
+//  BillingCreditLedger.swift
+//  Clerk
+//
+
+import Foundation
+
+public struct BillingCreditLedger: Codable, Equatable, Sendable, Identifiable {
+  public var id: String
+  public var amount: BillingMoneyAmount
+  public var sourceType: String
+  public var sourceId: String
+  public var createdAt: Date
+
+  public init(
+    id: String,
+    amount: BillingMoneyAmount,
+    sourceType: String,
+    sourceId: String,
+    createdAt: Date
+  ) {
+    self.id = id
+    self.amount = amount
+    self.sourceType = sourceType
+    self.sourceId = sourceId
+    self.createdAt = createdAt
+  }
+}

--- a/Sources/ClerkKit/Domains/Billing/BillingMoneyAmount.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingMoneyAmount.swift
@@ -1,0 +1,57 @@
+//
+//  BillingMoneyAmount.swift
+//  Clerk
+//
+
+import Foundation
+
+public struct BillingMoneyAmount: Codable, Equatable, Sendable {
+  public var amount: Int
+  public var amountFormatted: String
+  public var currency: String
+  public var currencySymbol: String
+
+  public init(
+    amount: Int,
+    amountFormatted: String,
+    currency: String,
+    currencySymbol: String
+  ) {
+    self.amount = amount
+    self.amountFormatted = amountFormatted
+    self.currency = currency
+    self.currencySymbol = currencySymbol
+  }
+}
+
+public struct BillingPerUnitTotalTier: Codable, Equatable, Sendable {
+  public var quantity: Int?
+  public var feePerBlock: BillingMoneyAmount
+  public var total: BillingMoneyAmount
+
+  public init(
+    quantity: Int?,
+    feePerBlock: BillingMoneyAmount,
+    total: BillingMoneyAmount
+  ) {
+    self.quantity = quantity
+    self.feePerBlock = feePerBlock
+    self.total = total
+  }
+}
+
+public struct BillingPerUnitTotal: Codable, Equatable, Sendable {
+  public var name: String
+  public var blockSize: Int
+  public var tiers: [BillingPerUnitTotalTier]
+
+  public init(
+    name: String,
+    blockSize: Int,
+    tiers: [BillingPerUnitTotalTier]
+  ) {
+    self.name = name
+    self.blockSize = blockSize
+    self.tiers = tiers
+  }
+}

--- a/Sources/ClerkKit/Domains/Billing/BillingParams.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingParams.swift
@@ -1,0 +1,148 @@
+//
+//  BillingParams.swift
+//  Clerk
+//
+
+import Foundation
+
+public enum ForPayerType: String, Codable, Equatable, Sendable {
+  case organization
+  case user
+}
+
+public struct GetPlansParams: Equatable, Sendable {
+  public var `for`: ForPayerType?
+  public var orgId: String?
+  public var minSeats: Int?
+  public var initialPage: Int?
+  public var pageSize: Int?
+
+  public init(
+    for: ForPayerType? = nil,
+    orgId: String? = nil,
+    minSeats: Int? = nil,
+    initialPage: Int? = nil,
+    pageSize: Int? = nil
+  ) {
+    self.for = `for`
+    self.orgId = orgId
+    self.minSeats = minSeats
+    self.initialPage = initialPage
+    self.pageSize = pageSize
+  }
+}
+
+public struct GetPlanParams: Equatable, Sendable {
+  public var id: String
+
+  public init(id: String) {
+    self.id = id
+  }
+}
+
+public struct GetSubscriptionParams: Equatable, Sendable {
+  public var orgId: String?
+
+  public init(orgId: String? = nil) {
+    self.orgId = orgId
+  }
+}
+
+public struct GetStatementsParams: Equatable, Sendable {
+  public var orgId: String?
+  public var initialPage: Int?
+  public var pageSize: Int?
+
+  public init(
+    orgId: String? = nil,
+    initialPage: Int? = nil,
+    pageSize: Int? = nil
+  ) {
+    self.orgId = orgId
+    self.initialPage = initialPage
+    self.pageSize = pageSize
+  }
+}
+
+public struct GetStatementParams: Equatable, Sendable {
+  public var id: String
+  public var orgId: String?
+  public var initialPage: Int?
+  public var pageSize: Int?
+
+  public init(
+    id: String,
+    orgId: String? = nil,
+    initialPage: Int? = nil,
+    pageSize: Int? = nil
+  ) {
+    self.id = id
+    self.orgId = orgId
+    self.initialPage = initialPage
+    self.pageSize = pageSize
+  }
+}
+
+public struct GetPaymentAttemptsParams: Equatable, Sendable {
+  public var orgId: String?
+  public var initialPage: Int?
+  public var pageSize: Int?
+
+  public init(
+    orgId: String? = nil,
+    initialPage: Int? = nil,
+    pageSize: Int? = nil
+  ) {
+    self.orgId = orgId
+    self.initialPage = initialPage
+    self.pageSize = pageSize
+  }
+}
+
+public struct GetPaymentAttemptParams: Equatable, Sendable {
+  public var id: String
+  public var orgId: String?
+  public var initialPage: Int?
+  public var pageSize: Int?
+
+  public init(
+    id: String,
+    orgId: String? = nil,
+    initialPage: Int? = nil,
+    pageSize: Int? = nil
+  ) {
+    self.id = id
+    self.orgId = orgId
+    self.initialPage = initialPage
+    self.pageSize = pageSize
+  }
+}
+
+public struct GetCreditBalanceParams: Equatable, Sendable {
+  public var orgId: String?
+
+  public init(orgId: String? = nil) {
+    self.orgId = orgId
+  }
+}
+
+public struct GetCreditHistoryParams: Equatable, Sendable {
+  public var orgId: String?
+
+  public init(orgId: String? = nil) {
+    self.orgId = orgId
+  }
+}
+
+public struct GetPaymentMethodsParams: Equatable, Sendable {
+  public var initialPage: Int?
+  public var pageSize: Int?
+
+  public init(
+    initialPage: Int? = nil,
+    pageSize: Int? = nil
+  ) {
+    self.initialPage = initialPage
+    self.pageSize = pageSize
+  }
+}

--- a/Sources/ClerkKit/Domains/Billing/BillingPayment.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingPayment.swift
@@ -5,15 +5,86 @@
 
 import Foundation
 
-public enum BillingPaymentChargeType: String, Codable, Equatable, Sendable {
+public enum BillingPaymentChargeType: Codable, Equatable, Sendable {
   case checkout
   case recurring
+  case priceTransition
+  case unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .checkout:
+      "checkout"
+    case .recurring:
+      "recurring"
+    case .priceTransition:
+      "price_transition"
+    case .unknown(let value):
+      value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "checkout":
+      self = .checkout
+    case "recurring":
+      self = .recurring
+    case "price_transition":
+      self = .priceTransition
+    default:
+      self = .unknown(rawValue)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    try self.init(rawValue: BillingUnknownString.decode(from: decoder))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try BillingUnknownString.encode(rawValue, to: encoder)
+  }
 }
 
-public enum BillingPaymentStatus: String, Codable, Equatable, Sendable {
+public enum BillingPaymentStatus: Codable, Equatable, Sendable {
   case pending
   case paid
   case failed
+  case unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .pending:
+      "pending"
+    case .paid:
+      "paid"
+    case .failed:
+      "failed"
+    case .unknown(let value):
+      value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "pending":
+      self = .pending
+    case "paid":
+      self = .paid
+    case "failed":
+      self = .failed
+    default:
+      self = .unknown(rawValue)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    try self.init(rawValue: BillingUnknownString.decode(from: decoder))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try BillingUnknownString.encode(rawValue, to: encoder)
+  }
 }
 
 public struct BillingPaymentTotals: Codable, Equatable, Sendable {

--- a/Sources/ClerkKit/Domains/Billing/BillingPayment.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingPayment.swift
@@ -1,0 +1,106 @@
+//
+//  BillingPayment.swift
+//  Clerk
+//
+
+import Foundation
+
+public enum BillingPaymentChargeType: String, Codable, Equatable, Sendable {
+  case checkout
+  case recurring
+}
+
+public enum BillingPaymentStatus: String, Codable, Equatable, Sendable {
+  case pending
+  case paid
+  case failed
+}
+
+public struct BillingPaymentTotals: Codable, Equatable, Sendable {
+  public var subtotal: BillingMoneyAmount
+  public var grandTotal: BillingMoneyAmount
+  public var taxTotal: BillingMoneyAmount
+  public var baseFee: BillingMoneyAmount?
+  public var perUnitTotals: [BillingPerUnitTotal]?
+  public var discounts: BillingDiscounts?
+
+  public init(
+    subtotal: BillingMoneyAmount,
+    grandTotal: BillingMoneyAmount,
+    taxTotal: BillingMoneyAmount,
+    baseFee: BillingMoneyAmount? = nil,
+    perUnitTotals: [BillingPerUnitTotal]? = nil,
+    discounts: BillingDiscounts? = nil
+  ) {
+    self.subtotal = subtotal
+    self.grandTotal = grandTotal
+    self.taxTotal = taxTotal
+    self.baseFee = baseFee
+    self.perUnitTotals = perUnitTotals
+    self.discounts = discounts
+  }
+}
+
+public struct BillingPayment: Codable, Equatable, Sendable, Identifiable {
+  public var id: String
+  public var amount: BillingMoneyAmount
+  public var paidAt: Date?
+  public var failedAt: Date?
+  public var updatedAt: Date
+  public var paymentMethod: BillingPaymentMethod?
+  public var subscriptionItem: BillingSubscriptionItem
+  public var chargeType: BillingPaymentChargeType
+  public var status: BillingPaymentStatus
+  public var totals: BillingPaymentTotals?
+
+  public init(
+    id: String,
+    amount: BillingMoneyAmount,
+    paidAt: Date? = nil,
+    failedAt: Date? = nil,
+    updatedAt: Date,
+    paymentMethod: BillingPaymentMethod? = nil,
+    subscriptionItem: BillingSubscriptionItem,
+    chargeType: BillingPaymentChargeType,
+    status: BillingPaymentStatus,
+    totals: BillingPaymentTotals? = nil
+  ) {
+    self.id = id
+    self.amount = amount
+    self.paidAt = paidAt
+    self.failedAt = failedAt
+    self.updatedAt = updatedAt
+    self.paymentMethod = paymentMethod
+    self.subscriptionItem = subscriptionItem
+    self.chargeType = chargeType
+    self.status = status
+    self.totals = totals
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    amount = try container.decode(BillingMoneyAmount.self, forKey: .amount)
+    paidAt = try container.decodeIfPresent(Date.self, forKey: .paidAt)
+    failedAt = try container.decodeIfPresent(Date.self, forKey: .failedAt)
+    updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+    paymentMethod = try container.decodeIfPresent(BillingPaymentMethod.self, forKey: .paymentMethod)
+    subscriptionItem = try container.decode(BillingSubscriptionItem.self, forKey: .subscriptionItem)
+    chargeType = try container.decode(BillingPaymentChargeType.self, forKey: .chargeType)
+    status = try container.decode(BillingPaymentStatus.self, forKey: .status)
+    totals = try container.decodeIfPresent(BillingPaymentTotals.self, forKey: .totals)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case amount
+    case paidAt
+    case failedAt
+    case updatedAt
+    case paymentMethod
+    case subscriptionItem
+    case chargeType
+    case status
+    case totals
+  }
+}

--- a/Sources/ClerkKit/Domains/Billing/BillingPaymentMethod.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingPaymentMethod.swift
@@ -5,10 +5,45 @@
 
 import Foundation
 
-public enum BillingPaymentMethodStatus: String, Codable, Equatable, Sendable {
+public enum BillingPaymentMethodStatus: Codable, Equatable, Sendable {
   case active
   case expired
   case disconnected
+  case unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .active:
+      "active"
+    case .expired:
+      "expired"
+    case .disconnected:
+      "disconnected"
+    case .unknown(let value):
+      value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "active":
+      self = .active
+    case "expired":
+      self = .expired
+    case "disconnected":
+      self = .disconnected
+    default:
+      self = .unknown(rawValue)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    try self.init(rawValue: BillingUnknownString.decode(from: decoder))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try BillingUnknownString.encode(rawValue, to: encoder)
+  }
 }
 
 public struct BillingPaymentMethod: Codable, Equatable, Sendable, Identifiable {

--- a/Sources/ClerkKit/Domains/Billing/BillingPaymentMethod.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingPaymentMethod.swift
@@ -1,0 +1,55 @@
+//
+//  BillingPaymentMethod.swift
+//  Clerk
+//
+
+import Foundation
+
+public enum BillingPaymentMethodStatus: String, Codable, Equatable, Sendable {
+  case active
+  case expired
+  case disconnected
+}
+
+public struct BillingPaymentMethod: Codable, Equatable, Sendable, Identifiable {
+  public var id: String
+  public var last4: String?
+  public var paymentType: String?
+  public var cardType: String?
+  public var isDefault: Bool?
+  public var isRemovable: Bool?
+  public var status: BillingPaymentMethodStatus
+  public var walletType: String?
+  public var expiryYear: Int?
+  public var expiryMonth: Int?
+  public var createdAt: Date?
+  public var updatedAt: Date?
+
+  public init(
+    id: String,
+    last4: String? = nil,
+    paymentType: String? = nil,
+    cardType: String? = nil,
+    isDefault: Bool? = nil,
+    isRemovable: Bool? = nil,
+    status: BillingPaymentMethodStatus,
+    walletType: String? = nil,
+    expiryYear: Int? = nil,
+    expiryMonth: Int? = nil,
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil
+  ) {
+    self.id = id
+    self.last4 = last4
+    self.paymentType = paymentType
+    self.cardType = cardType
+    self.isDefault = isDefault
+    self.isRemovable = isRemovable
+    self.status = status
+    self.walletType = walletType
+    self.expiryYear = expiryYear
+    self.expiryMonth = expiryMonth
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+  }
+}

--- a/Sources/ClerkKit/Domains/Billing/BillingPlan.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingPlan.swift
@@ -41,14 +41,14 @@ public enum BillingPayerResourceType: Codable, Equatable, Sendable {
   }
 }
 
-public struct BillingPlanUnitPriceTier: Codable, Equatable, Sendable, Identifiable {
-  public var id: String
+public struct BillingPlanUnitPriceTier: Codable, Equatable, Sendable {
+  public var id: String?
   public var startsAtBlock: Int
   public var endsAfterBlock: Int?
   public var feePerBlock: BillingMoneyAmount
 
   public init(
-    id: String,
+    id: String? = nil,
     startsAtBlock: Int,
     endsAfterBlock: Int? = nil,
     feePerBlock: BillingMoneyAmount

--- a/Sources/ClerkKit/Domains/Billing/BillingPlan.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingPlan.swift
@@ -5,9 +5,40 @@
 
 import Foundation
 
-public enum BillingPayerResourceType: String, Codable, Equatable, Sendable {
+public enum BillingPayerResourceType: Codable, Equatable, Sendable {
   case org
   case user
+  case unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .org:
+      "org"
+    case .user:
+      "user"
+    case .unknown(let value):
+      value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "org":
+      self = .org
+    case "user":
+      self = .user
+    default:
+      self = .unknown(rawValue)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    try self.init(rawValue: BillingUnknownString.decode(from: decoder))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try BillingUnknownString.encode(rawValue, to: encoder)
+  }
 }
 
 public struct BillingPlanUnitPriceTier: Codable, Equatable, Sendable, Identifiable {

--- a/Sources/ClerkKit/Domains/Billing/BillingPlan.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingPlan.swift
@@ -1,0 +1,172 @@
+//
+//  BillingPlan.swift
+//  Clerk
+//
+
+import Foundation
+
+public enum BillingPayerResourceType: String, Codable, Equatable, Sendable {
+  case org
+  case user
+}
+
+public struct BillingPlanUnitPriceTier: Codable, Equatable, Sendable, Identifiable {
+  public var id: String
+  public var startsAtBlock: Int
+  public var endsAfterBlock: Int?
+  public var feePerBlock: BillingMoneyAmount
+
+  public init(
+    id: String,
+    startsAtBlock: Int,
+    endsAfterBlock: Int? = nil,
+    feePerBlock: BillingMoneyAmount
+  ) {
+    self.id = id
+    self.startsAtBlock = startsAtBlock
+    self.endsAfterBlock = endsAfterBlock
+    self.feePerBlock = feePerBlock
+  }
+}
+
+public struct BillingPlanUnitPrice: Codable, Equatable, Sendable {
+  public var name: String
+  public var blockSize: Int
+  public var tiers: [BillingPlanUnitPriceTier]
+
+  public init(
+    name: String,
+    blockSize: Int,
+    tiers: [BillingPlanUnitPriceTier]
+  ) {
+    self.name = name
+    self.blockSize = blockSize
+    self.tiers = tiers
+  }
+}
+
+public struct BillingPlanPrice: Codable, Equatable, Sendable, Identifiable {
+  public var id: String
+  public var fee: BillingMoneyAmount?
+  public var annualMonthlyFee: BillingMoneyAmount?
+  public var isDefault: Bool
+  public var unitPrices: [BillingPlanUnitPrice]?
+
+  public init(
+    id: String,
+    fee: BillingMoneyAmount? = nil,
+    annualMonthlyFee: BillingMoneyAmount? = nil,
+    isDefault: Bool,
+    unitPrices: [BillingPlanUnitPrice]? = nil
+  ) {
+    self.id = id
+    self.fee = fee
+    self.annualMonthlyFee = annualMonthlyFee
+    self.isDefault = isDefault
+    self.unitPrices = unitPrices
+  }
+}
+
+public struct BillingPlan: Codable, Equatable, Sendable, Identifiable {
+  public var id: String
+  public var name: String
+  public var fee: BillingMoneyAmount?
+  public var annualFee: BillingMoneyAmount?
+  public var annualMonthlyFee: BillingMoneyAmount?
+  public var description: String?
+  public var isDefault: Bool
+  public var isRecurring: Bool
+  public var hasBaseFee: Bool
+  public var forPayerType: BillingPayerResourceType
+  public var publiclyVisible: Bool
+  public var slug: String
+  public var avatarUrl: String?
+  public var features: [Feature]
+  public var unitPrices: [BillingPlanUnitPrice]?
+  public var availablePrices: [BillingPlanPrice]?
+  public var freeTrialDays: Int?
+  public var freeTrialEnabled: Bool
+
+  public init(
+    id: String,
+    name: String,
+    fee: BillingMoneyAmount? = nil,
+    annualFee: BillingMoneyAmount? = nil,
+    annualMonthlyFee: BillingMoneyAmount? = nil,
+    description: String? = nil,
+    isDefault: Bool,
+    isRecurring: Bool,
+    hasBaseFee: Bool,
+    forPayerType: BillingPayerResourceType,
+    publiclyVisible: Bool,
+    slug: String,
+    avatarUrl: String? = nil,
+    features: [Feature] = [],
+    unitPrices: [BillingPlanUnitPrice]? = nil,
+    availablePrices: [BillingPlanPrice]? = nil,
+    freeTrialDays: Int? = nil,
+    freeTrialEnabled: Bool = false
+  ) {
+    self.id = id
+    self.name = name
+    self.fee = fee
+    self.annualFee = annualFee
+    self.annualMonthlyFee = annualMonthlyFee
+    self.description = description
+    self.isDefault = isDefault
+    self.isRecurring = isRecurring
+    self.hasBaseFee = hasBaseFee
+    self.forPayerType = forPayerType
+    self.publiclyVisible = publiclyVisible
+    self.slug = slug
+    self.avatarUrl = avatarUrl
+    self.features = features
+    self.unitPrices = unitPrices
+    self.availablePrices = availablePrices
+    self.freeTrialDays = freeTrialDays
+    self.freeTrialEnabled = freeTrialEnabled
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    name = try container.decode(String.self, forKey: .name)
+    fee = try container.decodeIfPresent(BillingMoneyAmount.self, forKey: .fee)
+    annualFee = try container.decodeIfPresent(BillingMoneyAmount.self, forKey: .annualFee)
+    annualMonthlyFee = try container.decodeIfPresent(BillingMoneyAmount.self, forKey: .annualMonthlyFee)
+    description = try container.decodeIfPresent(String.self, forKey: .description)
+    isDefault = try container.decode(Bool.self, forKey: .isDefault)
+    isRecurring = try container.decode(Bool.self, forKey: .isRecurring)
+    hasBaseFee = try container.decode(Bool.self, forKey: .hasBaseFee)
+    forPayerType = try container.decode(BillingPayerResourceType.self, forKey: .forPayerType)
+    publiclyVisible = try container.decode(Bool.self, forKey: .publiclyVisible)
+    slug = try container.decode(String.self, forKey: .slug)
+    avatarUrl = try container.decodeIfPresent(String.self, forKey: .avatarUrl)
+    features = try container.decodeIfPresent([Feature].self, forKey: .features) ?? []
+    unitPrices = try container.decodeIfPresent([BillingPlanUnitPrice].self, forKey: .unitPrices)
+    availablePrices = try container.decodeIfPresent([BillingPlanPrice].self, forKey: .availablePrices)
+    freeTrialDays = try container.decodeIfPresent(Int.self, forKey: .freeTrialDays)
+    freeTrialEnabled = try container.decodeIfPresent(Bool.self, forKey: .freeTrialEnabled) ?? false
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case fee
+    case annualFee
+    case annualMonthlyFee
+    case description
+    case isDefault
+    case isRecurring
+    case hasBaseFee
+    case forPayerType
+    case publiclyVisible
+    case slug
+    case avatarUrl
+    case features
+    case unitPrices
+    case availablePrices
+    case freeTrialDays
+    case freeTrialEnabled
+  }
+}

--- a/Sources/ClerkKit/Domains/Billing/BillingService.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingService.swift
@@ -1,0 +1,170 @@
+//
+//  BillingService.swift
+//  Clerk
+//
+
+import Foundation
+
+protocol BillingServiceProtocol: Sendable {
+  @MainActor func getPaymentAttempts(params: GetPaymentAttemptsParams) async throws -> ClerkPaginatedResponse<BillingPayment>
+  @MainActor func getPaymentAttempt(params: GetPaymentAttemptParams) async throws -> BillingPayment
+  @MainActor func getPlans(params: GetPlansParams?) async throws -> ClerkPaginatedResponse<BillingPlan>
+  @MainActor func getPlan(params: GetPlanParams) async throws -> BillingPlan
+  @MainActor func getSubscription(params: GetSubscriptionParams) async throws -> BillingSubscription
+  @MainActor func getStatements(params: GetStatementsParams) async throws -> ClerkPaginatedResponse<BillingStatement>
+  @MainActor func getStatement(params: GetStatementParams) async throws -> BillingStatement
+  @MainActor func getCreditBalance(params: GetCreditBalanceParams) async throws -> BillingCreditBalance
+  @MainActor func getCreditHistory(params: GetCreditHistoryParams) async throws -> ClerkPaginatedResponse<BillingCreditLedger>
+  @MainActor func getPaymentMethods(params: GetPaymentMethodsParams?, orgId: String?) async throws -> ClerkPaginatedResponse<BillingPaymentMethod>
+}
+
+final class BillingService: BillingServiceProtocol {
+  private let apiClient: APIClient
+
+  init(apiClient: APIClient) {
+    self.apiClient = apiClient
+  }
+
+  @MainActor
+  func getPaymentAttempts(params: GetPaymentAttemptsParams) async throws -> ClerkPaginatedResponse<BillingPayment> {
+    let request = Request<ClerkPaginatedResponse<BillingPayment>>(
+      path: Self.path("/payment_attempts", orgId: params.orgId),
+      method: .get,
+      query: sessionQuery() + paginationQuery(initialPage: params.initialPage, pageSize: params.pageSize)
+    )
+
+    return try await apiClient.send(request).value
+  }
+
+  @MainActor
+  func getPaymentAttempt(params: GetPaymentAttemptParams) async throws -> BillingPayment {
+    let request = Request<BillingPayment>(
+      path: Self.path("/payment_attempts/\(params.id)", orgId: params.orgId),
+      method: .get,
+      query: sessionQuery()
+    )
+
+    return try await apiClient.send(request).value
+  }
+
+  @MainActor
+  func getPlans(params: GetPlansParams?) async throws -> ClerkPaginatedResponse<BillingPlan> {
+    var query = sessionQuery()
+    query.append(("payer_type", value: params?.for == .organization ? "org" : "user"))
+    if let orgId = params?.orgId {
+      query.append(("org_id", value: orgId))
+    }
+    if let minSeats = params?.minSeats {
+      query.append(("min_seats", value: String(minSeats)))
+    }
+    query += paginationQuery(initialPage: params?.initialPage, pageSize: params?.pageSize)
+
+    let request = Request<ClerkPaginatedResponse<BillingPlan>>(
+      path: "/v1/billing/plans",
+      method: .get,
+      query: query
+    )
+
+    return try await apiClient.send(request).value
+  }
+
+  @MainActor
+  func getPlan(params: GetPlanParams) async throws -> BillingPlan {
+    let request = Request<BillingPlan>(
+      path: "/v1/billing/plans/\(params.id)",
+      method: .get,
+      query: sessionQuery()
+    )
+
+    return try await apiClient.send(request).value
+  }
+
+  @MainActor
+  func getSubscription(params: GetSubscriptionParams) async throws -> BillingSubscription {
+    let request = Request<ClientResponse<BillingSubscription>>(
+      path: Self.path("/subscription", orgId: params.orgId),
+      method: .get,
+      query: sessionQuery()
+    )
+
+    return try await apiClient.send(request).value.response
+  }
+
+  @MainActor
+  func getStatements(params: GetStatementsParams) async throws -> ClerkPaginatedResponse<BillingStatement> {
+    let request = Request<ClientResponse<ClerkPaginatedResponse<BillingStatement>>>(
+      path: Self.path("/statements", orgId: params.orgId),
+      method: .get,
+      query: sessionQuery() + paginationQuery(initialPage: params.initialPage, pageSize: params.pageSize)
+    )
+
+    return try await apiClient.send(request).value.response
+  }
+
+  @MainActor
+  func getStatement(params: GetStatementParams) async throws -> BillingStatement {
+    let request = Request<ClientResponse<BillingStatement>>(
+      path: Self.path("/statements/\(params.id)", orgId: params.orgId),
+      method: .get,
+      query: sessionQuery()
+    )
+
+    return try await apiClient.send(request).value.response
+  }
+
+  @MainActor
+  func getCreditBalance(params: GetCreditBalanceParams) async throws -> BillingCreditBalance {
+    let request = Request<ClientResponse<BillingCreditBalance>>(
+      path: Self.path("/credits", orgId: params.orgId),
+      method: .get,
+      query: sessionQuery()
+    )
+
+    return try await apiClient.send(request).value.response
+  }
+
+  @MainActor
+  func getCreditHistory(params: GetCreditHistoryParams) async throws -> ClerkPaginatedResponse<BillingCreditLedger> {
+    let request = Request<ClientResponse<ClerkPaginatedResponse<BillingCreditLedger>>>(
+      path: Self.path("/credits/history", orgId: params.orgId),
+      method: .get,
+      query: sessionQuery()
+    )
+
+    return try await apiClient.send(request).value.response
+  }
+
+  @MainActor
+  func getPaymentMethods(params: GetPaymentMethodsParams?, orgId: String?) async throws -> ClerkPaginatedResponse<BillingPaymentMethod> {
+    let request = Request<ClientResponse<ClerkPaginatedResponse<BillingPaymentMethod>>>(
+      path: Self.path("/payment_methods", orgId: orgId),
+      method: .get,
+      query: sessionQuery() + paginationQuery(initialPage: params?.initialPage, pageSize: params?.pageSize)
+    )
+
+    return try await apiClient.send(request).value.response
+  }
+
+  static func path(_ subPath: String, orgId: String?) -> String {
+    let prefix = if let orgId, !orgId.isEmpty {
+      "/v1/organizations/\(orgId)"
+    } else {
+      "/v1/me"
+    }
+    return "\(prefix)/billing\(subPath)"
+  }
+
+  @MainActor
+  private func sessionQuery() -> [(String, String?)] {
+    [("_clerk_session_id", value: Clerk.shared.session?.id)]
+  }
+
+  private func paginationQuery(initialPage: Int?, pageSize: Int?) -> [(String, String?)] {
+    let resolvedPageSize = pageSize ?? 10
+    let resolvedInitialPage = initialPage ?? 1
+    return [
+      ("limit", value: String(resolvedPageSize)),
+      ("offset", value: String((resolvedInitialPage - 1) * resolvedPageSize)),
+    ]
+  }
+}

--- a/Sources/ClerkKit/Domains/Billing/BillingStatement.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingStatement.swift
@@ -57,13 +57,13 @@ public struct BillingStatementTotals: Codable, Equatable, Sendable {
   }
 }
 
-public struct BillingStatementGroup: Codable, Equatable, Sendable, Identifiable {
-  public var id: String
+public struct BillingStatementGroup: Codable, Equatable, Sendable {
+  public var id: String?
   public var timestamp: Date
   public var items: [BillingPayment]
 
   public init(
-    id: String,
+    id: String? = nil,
     timestamp: Date,
     items: [BillingPayment]
   ) {

--- a/Sources/ClerkKit/Domains/Billing/BillingStatement.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingStatement.swift
@@ -1,0 +1,65 @@
+//
+//  BillingStatement.swift
+//  Clerk
+//
+
+import Foundation
+
+public enum BillingStatementStatus: String, Codable, Equatable, Sendable {
+  case open
+  case closed
+}
+
+public struct BillingStatementTotals: Codable, Equatable, Sendable {
+  public var subtotal: BillingMoneyAmount
+  public var grandTotal: BillingMoneyAmount
+  public var taxTotal: BillingMoneyAmount
+
+  public init(
+    subtotal: BillingMoneyAmount,
+    grandTotal: BillingMoneyAmount,
+    taxTotal: BillingMoneyAmount
+  ) {
+    self.subtotal = subtotal
+    self.grandTotal = grandTotal
+    self.taxTotal = taxTotal
+  }
+}
+
+public struct BillingStatementGroup: Codable, Equatable, Sendable, Identifiable {
+  public var id: String
+  public var timestamp: Date
+  public var items: [BillingPayment]
+
+  public init(
+    id: String,
+    timestamp: Date,
+    items: [BillingPayment]
+  ) {
+    self.id = id
+    self.timestamp = timestamp
+    self.items = items
+  }
+}
+
+public struct BillingStatement: Codable, Equatable, Sendable, Identifiable {
+  public var id: String
+  public var totals: BillingStatementTotals
+  public var status: BillingStatementStatus
+  public var timestamp: Date
+  public var groups: [BillingStatementGroup]
+
+  public init(
+    id: String,
+    totals: BillingStatementTotals,
+    status: BillingStatementStatus,
+    timestamp: Date,
+    groups: [BillingStatementGroup]
+  ) {
+    self.id = id
+    self.totals = totals
+    self.status = status
+    self.timestamp = timestamp
+    self.groups = groups
+  }
+}

--- a/Sources/ClerkKit/Domains/Billing/BillingStatement.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingStatement.swift
@@ -5,9 +5,40 @@
 
 import Foundation
 
-public enum BillingStatementStatus: String, Codable, Equatable, Sendable {
+public enum BillingStatementStatus: Codable, Equatable, Sendable {
   case open
   case closed
+  case unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .open:
+      "open"
+    case .closed:
+      "closed"
+    case .unknown(let value):
+      value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "open":
+      self = .open
+    case "closed":
+      self = .closed
+    default:
+      self = .unknown(rawValue)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    try self.init(rawValue: BillingUnknownString.decode(from: decoder))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try BillingUnknownString.encode(rawValue, to: encoder)
+  }
 }
 
 public struct BillingStatementTotals: Codable, Equatable, Sendable {

--- a/Sources/ClerkKit/Domains/Billing/BillingSubscription.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingSubscription.swift
@@ -1,0 +1,489 @@
+//
+//  BillingSubscription.swift
+//  Clerk
+//
+
+import Foundation
+
+public enum BillingSubscriptionStatus: String, Codable, Equatable, Sendable {
+  case active
+  case ended
+  case upcoming
+  case pastDue = "past_due"
+}
+
+public enum BillingSubscriptionPlanPeriod: String, Codable, Equatable, Sendable {
+  case month
+  case annual
+}
+
+public enum BillingDiscountEffect: String, Codable, Equatable, Sendable {
+  case percentage
+  case fixedAmount = "fixed_amount"
+}
+
+public enum BillingDiscountSource: String, Codable, Equatable, Sendable {
+  case promotion
+  case manual
+  case promoCode = "promo_code"
+}
+
+public enum BillingDiscountRedemptionStatus: String, Codable, Equatable, Sendable {
+  case active
+  case exhausted
+  case removed
+}
+
+public struct BillingProrationCreditDetail: Codable, Equatable, Sendable {
+  public var amount: BillingMoneyAmount
+  public var cycleDaysRemaining: Int
+  public var cycleDaysTotal: Int
+  public var cycleRemainingPercent: Double
+
+  public init(
+    amount: BillingMoneyAmount,
+    cycleDaysRemaining: Int,
+    cycleDaysTotal: Int,
+    cycleRemainingPercent: Double
+  ) {
+    self.amount = amount
+    self.cycleDaysRemaining = cycleDaysRemaining
+    self.cycleDaysTotal = cycleDaysTotal
+    self.cycleRemainingPercent = cycleRemainingPercent
+  }
+}
+
+public struct BillingPayerCredit: Codable, Equatable, Sendable {
+  public var remainingBalance: BillingMoneyAmount
+  public var appliedAmount: BillingMoneyAmount
+
+  public init(
+    remainingBalance: BillingMoneyAmount,
+    appliedAmount: BillingMoneyAmount
+  ) {
+    self.remainingBalance = remainingBalance
+    self.appliedAmount = appliedAmount
+  }
+}
+
+public struct BillingCredits: Codable, Equatable, Sendable {
+  public var proration: BillingProrationCreditDetail?
+  public var payer: BillingPayerCredit?
+  public var total: BillingMoneyAmount
+
+  public init(
+    proration: BillingProrationCreditDetail? = nil,
+    payer: BillingPayerCredit? = nil,
+    total: BillingMoneyAmount
+  ) {
+    self.proration = proration
+    self.payer = payer
+    self.total = total
+  }
+}
+
+public struct BillingProrationDiscount: Codable, Equatable, Sendable {
+  public var amount: BillingMoneyAmount
+  public var cycleDaysPassed: Int
+  public var cycleDaysTotal: Int
+  public var cyclePassedPercent: Double
+
+  public init(
+    amount: BillingMoneyAmount,
+    cycleDaysPassed: Int,
+    cycleDaysTotal: Int,
+    cyclePassedPercent: Double
+  ) {
+    self.amount = amount
+    self.cycleDaysPassed = cycleDaysPassed
+    self.cycleDaysTotal = cycleDaysTotal
+    self.cyclePassedPercent = cyclePassedPercent
+  }
+}
+
+public struct BillingAppliedDiscount: Codable, Equatable, Sendable {
+  public var amount: BillingMoneyAmount
+  public var discountId: String
+  public var name: String
+  public var effect: BillingDiscountEffect
+  public var percentOff: Double?
+  public var amountOff: BillingMoneyAmount?
+  public var promoCode: String?
+  public var cyclesRemaining: Int?
+  public var durationInCycles: Int?
+
+  public init(
+    amount: BillingMoneyAmount,
+    discountId: String,
+    name: String,
+    effect: BillingDiscountEffect,
+    percentOff: Double? = nil,
+    amountOff: BillingMoneyAmount? = nil,
+    promoCode: String? = nil,
+    cyclesRemaining: Int? = nil,
+    durationInCycles: Int? = nil
+  ) {
+    self.amount = amount
+    self.discountId = discountId
+    self.name = name
+    self.effect = effect
+    self.percentOff = percentOff
+    self.amountOff = amountOff
+    self.promoCode = promoCode
+    self.cyclesRemaining = cyclesRemaining
+    self.durationInCycles = durationInCycles
+  }
+}
+
+public struct BillingDiscountRedemption: Codable, Equatable, Sendable, Identifiable {
+  public var id: String
+  public var subscriptionItemId: String
+  public var discountId: String
+  public var name: String
+  public var source: BillingDiscountSource
+  public var promoCode: String?
+  public var effect: BillingDiscountEffect?
+  public var percentOff: Double?
+  public var amountOff: BillingMoneyAmount?
+  public var amount: BillingMoneyAmount?
+  public var cyclesRemaining: Int?
+  public var cyclesApplied: Int
+  public var status: BillingDiscountRedemptionStatus?
+  public var redeemedAt: Date
+  public var redeemedBy: String?
+
+  public init(
+    id: String,
+    subscriptionItemId: String,
+    discountId: String,
+    name: String,
+    source: BillingDiscountSource,
+    promoCode: String? = nil,
+    effect: BillingDiscountEffect? = nil,
+    percentOff: Double? = nil,
+    amountOff: BillingMoneyAmount? = nil,
+    amount: BillingMoneyAmount? = nil,
+    cyclesRemaining: Int? = nil,
+    cyclesApplied: Int,
+    status: BillingDiscountRedemptionStatus? = nil,
+    redeemedAt: Date,
+    redeemedBy: String? = nil
+  ) {
+    self.id = id
+    self.subscriptionItemId = subscriptionItemId
+    self.discountId = discountId
+    self.name = name
+    self.source = source
+    self.promoCode = promoCode
+    self.effect = effect
+    self.percentOff = percentOff
+    self.amountOff = amountOff
+    self.amount = amount
+    self.cyclesRemaining = cyclesRemaining
+    self.cyclesApplied = cyclesApplied
+    self.status = status
+    self.redeemedAt = redeemedAt
+    self.redeemedBy = redeemedBy
+  }
+}
+
+public struct BillingDiscounts: Codable, Equatable, Sendable {
+  public var proration: BillingProrationDiscount?
+  public var discount: BillingAppliedDiscount?
+  public var total: BillingMoneyAmount
+
+  public init(
+    proration: BillingProrationDiscount? = nil,
+    discount: BillingAppliedDiscount? = nil,
+    total: BillingMoneyAmount
+  ) {
+    self.proration = proration
+    self.discount = discount
+    self.total = total
+  }
+}
+
+public struct BillingPeriodTotals: Codable, Equatable, Sendable {
+  public var subtotal: BillingMoneyAmount
+  public var baseFee: BillingMoneyAmount
+  public var taxTotal: BillingMoneyAmount
+  public var grandTotal: BillingMoneyAmount
+  public var perUnitTotals: [BillingPerUnitTotal]?
+
+  public init(
+    subtotal: BillingMoneyAmount,
+    baseFee: BillingMoneyAmount,
+    taxTotal: BillingMoneyAmount,
+    grandTotal: BillingMoneyAmount,
+    perUnitTotals: [BillingPerUnitTotal]? = nil
+  ) {
+    self.subtotal = subtotal
+    self.baseFee = baseFee
+    self.taxTotal = taxTotal
+    self.grandTotal = grandTotal
+    self.perUnitTotals = perUnitTotals
+  }
+}
+
+public struct BillingTotals: Codable, Equatable, Sendable {
+  public var subtotal: BillingMoneyAmount
+  public var baseFee: BillingMoneyAmount?
+  public var taxTotal: BillingMoneyAmount
+  public var grandTotal: BillingMoneyAmount
+  public var totalDueAfterFreeTrial: BillingMoneyAmount?
+  public var credit: BillingMoneyAmount?
+  public var credits: BillingCredits?
+  public var discounts: BillingDiscounts?
+  public var pastDue: BillingMoneyAmount?
+  public var totalDueNow: BillingMoneyAmount?
+  public var perUnitTotals: [BillingPerUnitTotal]?
+  public var totalsDuePerPeriod: BillingPeriodTotals?
+  public var totalDuePerPeriod: BillingMoneyAmount?
+
+  public init(
+    subtotal: BillingMoneyAmount,
+    baseFee: BillingMoneyAmount? = nil,
+    taxTotal: BillingMoneyAmount,
+    grandTotal: BillingMoneyAmount,
+    totalDueAfterFreeTrial: BillingMoneyAmount? = nil,
+    credit: BillingMoneyAmount? = nil,
+    credits: BillingCredits? = nil,
+    discounts: BillingDiscounts? = nil,
+    pastDue: BillingMoneyAmount? = nil,
+    totalDueNow: BillingMoneyAmount? = nil,
+    perUnitTotals: [BillingPerUnitTotal]? = nil,
+    totalsDuePerPeriod: BillingPeriodTotals? = nil,
+    totalDuePerPeriod: BillingMoneyAmount? = nil
+  ) {
+    self.subtotal = subtotal
+    self.baseFee = baseFee
+    self.taxTotal = taxTotal
+    self.grandTotal = grandTotal
+    self.totalDueAfterFreeTrial = totalDueAfterFreeTrial
+    self.credit = credit
+    self.credits = credits
+    self.discounts = discounts
+    self.pastDue = pastDue
+    self.totalDueNow = totalDueNow
+    self.perUnitTotals = perUnitTotals
+    self.totalsDuePerPeriod = totalsDuePerPeriod
+    self.totalDuePerPeriod = totalDuePerPeriod
+  }
+}
+
+public struct BillingSubscriptionItemSeats: Codable, Equatable, Sendable {
+  public var quantity: Int?
+  public var tiers: [BillingPerUnitTotalTier]?
+
+  public init(
+    quantity: Int?,
+    tiers: [BillingPerUnitTotalTier]? = nil
+  ) {
+    self.quantity = quantity
+    self.tiers = tiers
+  }
+}
+
+public struct BillingSubscriptionNextPayment: Codable, Equatable, Sendable {
+  public var amount: BillingMoneyAmount
+  public var date: Date
+  public var perUnitTotals: [BillingPerUnitTotal]?
+  public var totals: BillingTotals?
+
+  public init(
+    amount: BillingMoneyAmount,
+    date: Date,
+    perUnitTotals: [BillingPerUnitTotal]? = nil,
+    totals: BillingTotals? = nil
+  ) {
+    self.amount = amount
+    self.date = date
+    self.perUnitTotals = perUnitTotals
+    self.totals = totals
+  }
+}
+
+public struct BillingSubscriptionItemNextPayment: Codable, Equatable, Sendable {
+  public var amount: BillingMoneyAmount
+  public var date: Date
+  public var perUnitTotals: [BillingPerUnitTotal]?
+  public var totals: BillingTotals?
+
+  public init(
+    amount: BillingMoneyAmount,
+    date: Date,
+    perUnitTotals: [BillingPerUnitTotal]? = nil,
+    totals: BillingTotals? = nil
+  ) {
+    self.amount = amount
+    self.date = date
+    self.perUnitTotals = perUnitTotals
+    self.totals = totals
+  }
+}
+
+public struct BillingSubscriptionItemCredit: Codable, Equatable, Sendable {
+  public var amount: BillingMoneyAmount
+
+  public init(amount: BillingMoneyAmount) {
+    self.amount = amount
+  }
+}
+
+public struct BillingSubscriptionItem: Codable, Equatable, Sendable, Identifiable {
+  public var id: String
+  public var plan: BillingPlan
+  public var planPeriod: BillingSubscriptionPlanPeriod
+  public var priceId: String
+  public var status: BillingSubscriptionStatus
+  public var createdAt: Date
+  public var pastDueAt: Date?
+  public var periodStart: Date
+  public var periodEnd: Date?
+  public var canceledAt: Date?
+  public var amount: BillingMoneyAmount?
+  public var nextPayment: BillingSubscriptionItemNextPayment?
+  public var credit: BillingSubscriptionItemCredit?
+  public var credits: BillingCredits?
+  public var appliedDiscount: BillingDiscountRedemption?
+  public var seats: BillingSubscriptionItemSeats?
+  public var isFreeTrial: Bool
+
+  public init(
+    id: String,
+    plan: BillingPlan,
+    planPeriod: BillingSubscriptionPlanPeriod,
+    priceId: String,
+    status: BillingSubscriptionStatus,
+    createdAt: Date,
+    pastDueAt: Date? = nil,
+    periodStart: Date,
+    periodEnd: Date? = nil,
+    canceledAt: Date? = nil,
+    amount: BillingMoneyAmount? = nil,
+    nextPayment: BillingSubscriptionItemNextPayment? = nil,
+    credit: BillingSubscriptionItemCredit? = nil,
+    credits: BillingCredits? = nil,
+    appliedDiscount: BillingDiscountRedemption? = nil,
+    seats: BillingSubscriptionItemSeats? = nil,
+    isFreeTrial: Bool = false
+  ) {
+    self.id = id
+    self.plan = plan
+    self.planPeriod = planPeriod
+    self.priceId = priceId
+    self.status = status
+    self.createdAt = createdAt
+    self.pastDueAt = pastDueAt
+    self.periodStart = periodStart
+    self.periodEnd = periodEnd
+    self.canceledAt = canceledAt
+    self.amount = amount
+    self.nextPayment = nextPayment
+    self.credit = credit
+    self.credits = credits
+    self.appliedDiscount = appliedDiscount
+    self.seats = seats
+    self.isFreeTrial = isFreeTrial
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    plan = try container.decode(BillingPlan.self, forKey: .plan)
+    planPeriod = try container.decode(BillingSubscriptionPlanPeriod.self, forKey: .planPeriod)
+    priceId = try container.decode(String.self, forKey: .priceId)
+    status = try container.decode(BillingSubscriptionStatus.self, forKey: .status)
+    createdAt = try container.decode(Date.self, forKey: .createdAt)
+    pastDueAt = try container.decodeIfPresent(Date.self, forKey: .pastDueAt)
+    periodStart = try container.decode(Date.self, forKey: .periodStart)
+    periodEnd = try container.decodeIfPresent(Date.self, forKey: .periodEnd)
+    canceledAt = try container.decodeIfPresent(Date.self, forKey: .canceledAt)
+    amount = try container.decodeIfPresent(BillingMoneyAmount.self, forKey: .amount)
+    nextPayment = try container.decodeIfPresent(BillingSubscriptionItemNextPayment.self, forKey: .nextPayment)
+    credit = try container.decodeIfPresent(BillingSubscriptionItemCredit.self, forKey: .credit)
+    credits = try container.decodeIfPresent(BillingCredits.self, forKey: .credits)
+    appliedDiscount = try container.decodeIfPresent(BillingDiscountRedemption.self, forKey: .appliedDiscount)
+    seats = try container.decodeIfPresent(BillingSubscriptionItemSeats.self, forKey: .seats)
+    isFreeTrial = try container.decodeIfPresent(Bool.self, forKey: .isFreeTrial) ?? false
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case plan
+    case planPeriod
+    case priceId
+    case status
+    case createdAt
+    case pastDueAt
+    case periodStart
+    case periodEnd
+    case canceledAt
+    case amount
+    case nextPayment
+    case credit
+    case credits
+    case appliedDiscount
+    case seats
+    case isFreeTrial
+  }
+}
+
+public struct BillingSubscription: Codable, Equatable, Sendable, Identifiable {
+  public var id: String
+  public var activeAt: Date
+  public var createdAt: Date
+  public var nextPayment: BillingSubscriptionNextPayment?
+  public var pastDueAt: Date?
+  public var status: BillingSubscriptionStatus
+  public var subscriptionItems: [BillingSubscriptionItem]
+  public var updatedAt: Date?
+  public var eligibleForFreeTrial: Bool
+
+  public init(
+    id: String,
+    activeAt: Date,
+    createdAt: Date,
+    nextPayment: BillingSubscriptionNextPayment? = nil,
+    pastDueAt: Date? = nil,
+    status: BillingSubscriptionStatus,
+    subscriptionItems: [BillingSubscriptionItem] = [],
+    updatedAt: Date? = nil,
+    eligibleForFreeTrial: Bool = false
+  ) {
+    self.id = id
+    self.activeAt = activeAt
+    self.createdAt = createdAt
+    self.nextPayment = nextPayment
+    self.pastDueAt = pastDueAt
+    self.status = status
+    self.subscriptionItems = subscriptionItems
+    self.updatedAt = updatedAt
+    self.eligibleForFreeTrial = eligibleForFreeTrial
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    activeAt = try container.decode(Date.self, forKey: .activeAt)
+    createdAt = try container.decode(Date.self, forKey: .createdAt)
+    nextPayment = try container.decodeIfPresent(BillingSubscriptionNextPayment.self, forKey: .nextPayment)
+    pastDueAt = try container.decodeIfPresent(Date.self, forKey: .pastDueAt)
+    status = try container.decode(BillingSubscriptionStatus.self, forKey: .status)
+    subscriptionItems = try container.decodeIfPresent([BillingSubscriptionItem].self, forKey: .subscriptionItems) ?? []
+    updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
+    eligibleForFreeTrial = try container.decodeIfPresent(Bool.self, forKey: .eligibleForFreeTrial) ?? false
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case activeAt
+    case createdAt
+    case nextPayment
+    case pastDueAt
+    case status
+    case subscriptionItems
+    case updatedAt
+    case eligibleForFreeTrial
+  }
+}

--- a/Sources/ClerkKit/Domains/Billing/BillingSubscription.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingSubscription.swift
@@ -565,9 +565,9 @@ public struct BillingSubscriptionItem: Codable, Equatable, Sendable, Identifiabl
     planPeriod = try container.decode(BillingSubscriptionPlanPeriod.self, forKey: .planPeriod)
     priceId = try container.decode(String.self, forKey: .priceId)
     status = try container.decode(BillingSubscriptionStatus.self, forKey: .status)
-    createdAt = try container.decode(Date.self, forKey: .createdAt)
+    createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date(timeIntervalSince1970: 0)
     pastDueAt = try container.decodeIfPresent(Date.self, forKey: .pastDueAt)
-    periodStart = try container.decode(Date.self, forKey: .periodStart)
+    periodStart = try container.decodeIfPresent(Date.self, forKey: .periodStart) ?? createdAt
     periodEnd = try container.decodeIfPresent(Date.self, forKey: .periodEnd)
     canceledAt = try container.decodeIfPresent(Date.self, forKey: .canceledAt)
     amount = try container.decodeIfPresent(BillingMoneyAmount.self, forKey: .amount)

--- a/Sources/ClerkKit/Domains/Billing/BillingSubscription.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingSubscription.swift
@@ -505,7 +505,7 @@ public struct BillingSubscriptionItem: Codable, Equatable, Sendable, Identifiabl
   public var id: String
   public var plan: BillingPlan
   public var planPeriod: BillingSubscriptionPlanPeriod
-  public var priceId: String
+  public var priceId: String?
   public var status: BillingSubscriptionStatus
   public var createdAt: Date?
   public var pastDueAt: Date?
@@ -524,7 +524,7 @@ public struct BillingSubscriptionItem: Codable, Equatable, Sendable, Identifiabl
     id: String,
     plan: BillingPlan,
     planPeriod: BillingSubscriptionPlanPeriod,
-    priceId: String,
+    priceId: String? = nil,
     status: BillingSubscriptionStatus,
     createdAt: Date? = nil,
     pastDueAt: Date? = nil,
@@ -563,11 +563,11 @@ public struct BillingSubscriptionItem: Codable, Equatable, Sendable, Identifiabl
     id = try container.decode(String.self, forKey: .id)
     plan = try container.decode(BillingPlan.self, forKey: .plan)
     planPeriod = try container.decode(BillingSubscriptionPlanPeriod.self, forKey: .planPeriod)
-    priceId = try container.decode(String.self, forKey: .priceId)
+    priceId = try container.decodeIfPresent(String.self, forKey: .priceId)
     status = try container.decode(BillingSubscriptionStatus.self, forKey: .status)
-    createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+    createdAt = try Self.nonEpochDate(container.decodeIfPresent(Date.self, forKey: .createdAt))
     pastDueAt = try container.decodeIfPresent(Date.self, forKey: .pastDueAt)
-    periodStart = try container.decodeIfPresent(Date.self, forKey: .periodStart)
+    periodStart = try Self.nonEpochDate(container.decodeIfPresent(Date.self, forKey: .periodStart))
     periodEnd = try container.decodeIfPresent(Date.self, forKey: .periodEnd)
     canceledAt = try container.decodeIfPresent(Date.self, forKey: .canceledAt)
     amount = try container.decodeIfPresent(BillingMoneyAmount.self, forKey: .amount)
@@ -577,6 +577,13 @@ public struct BillingSubscriptionItem: Codable, Equatable, Sendable, Identifiabl
     appliedDiscount = try container.decodeIfPresent(BillingDiscountRedemption.self, forKey: .appliedDiscount)
     seats = try container.decodeIfPresent(BillingSubscriptionItemSeats.self, forKey: .seats)
     isFreeTrial = try container.decodeIfPresent(Bool.self, forKey: .isFreeTrial) ?? false
+  }
+
+  private static func nonEpochDate(_ date: Date?) -> Date? {
+    guard let date, date.timeIntervalSince1970 != 0 else {
+      return nil
+    }
+    return date
   }
 
   private enum CodingKeys: String, CodingKey {

--- a/Sources/ClerkKit/Domains/Billing/BillingSubscription.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingSubscription.swift
@@ -609,7 +609,7 @@ public struct BillingSubscriptionItem: Codable, Equatable, Sendable, Identifiabl
 
 public struct BillingSubscription: Codable, Equatable, Sendable, Identifiable {
   public var id: String
-  public var activeAt: Date
+  public var activeAt: Date?
   public var createdAt: Date
   public var nextPayment: BillingSubscriptionNextPayment?
   public var pastDueAt: Date?
@@ -620,7 +620,7 @@ public struct BillingSubscription: Codable, Equatable, Sendable, Identifiable {
 
   public init(
     id: String,
-    activeAt: Date,
+    activeAt: Date? = nil,
     createdAt: Date,
     nextPayment: BillingSubscriptionNextPayment? = nil,
     pastDueAt: Date? = nil,
@@ -643,7 +643,7 @@ public struct BillingSubscription: Codable, Equatable, Sendable, Identifiable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     id = try container.decode(String.self, forKey: .id)
-    activeAt = try container.decode(Date.self, forKey: .activeAt)
+    activeAt = try container.decodeIfPresent(Date.self, forKey: .activeAt)
     createdAt = try container.decode(Date.self, forKey: .createdAt)
     nextPayment = try container.decodeIfPresent(BillingSubscriptionNextPayment.self, forKey: .nextPayment)
     pastDueAt = try container.decodeIfPresent(Date.self, forKey: .pastDueAt)

--- a/Sources/ClerkKit/Domains/Billing/BillingSubscription.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingSubscription.swift
@@ -5,33 +5,204 @@
 
 import Foundation
 
-public enum BillingSubscriptionStatus: String, Codable, Equatable, Sendable {
+public enum BillingSubscriptionStatus: Codable, Equatable, Sendable {
   case active
   case ended
   case upcoming
-  case pastDue = "past_due"
+  case pastDue
+  case unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .active:
+      "active"
+    case .ended:
+      "ended"
+    case .upcoming:
+      "upcoming"
+    case .pastDue:
+      "past_due"
+    case .unknown(let value):
+      value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "active":
+      self = .active
+    case "ended":
+      self = .ended
+    case "upcoming":
+      self = .upcoming
+    case "past_due":
+      self = .pastDue
+    default:
+      self = .unknown(rawValue)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    try self.init(rawValue: BillingUnknownString.decode(from: decoder))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try BillingUnknownString.encode(rawValue, to: encoder)
+  }
 }
 
-public enum BillingSubscriptionPlanPeriod: String, Codable, Equatable, Sendable {
+public enum BillingSubscriptionPlanPeriod: Codable, Equatable, Sendable {
   case month
   case annual
+  case unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .month:
+      "month"
+    case .annual:
+      "annual"
+    case .unknown(let value):
+      value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "month":
+      self = .month
+    case "annual":
+      self = .annual
+    default:
+      self = .unknown(rawValue)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    try self.init(rawValue: BillingUnknownString.decode(from: decoder))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try BillingUnknownString.encode(rawValue, to: encoder)
+  }
 }
 
-public enum BillingDiscountEffect: String, Codable, Equatable, Sendable {
+public enum BillingDiscountEffect: Codable, Equatable, Sendable {
   case percentage
-  case fixedAmount = "fixed_amount"
+  case fixedAmount
+  case unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .percentage:
+      "percentage"
+    case .fixedAmount:
+      "fixed_amount"
+    case .unknown(let value):
+      value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "percentage":
+      self = .percentage
+    case "fixed_amount":
+      self = .fixedAmount
+    default:
+      self = .unknown(rawValue)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    try self.init(rawValue: BillingUnknownString.decode(from: decoder))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try BillingUnknownString.encode(rawValue, to: encoder)
+  }
 }
 
-public enum BillingDiscountSource: String, Codable, Equatable, Sendable {
+public enum BillingDiscountSource: Codable, Equatable, Sendable {
   case promotion
   case manual
-  case promoCode = "promo_code"
+  case promoCode
+  case unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .promotion:
+      "promotion"
+    case .manual:
+      "manual"
+    case .promoCode:
+      "promo_code"
+    case .unknown(let value):
+      value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "promotion":
+      self = .promotion
+    case "manual":
+      self = .manual
+    case "promo_code":
+      self = .promoCode
+    default:
+      self = .unknown(rawValue)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    try self.init(rawValue: BillingUnknownString.decode(from: decoder))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try BillingUnknownString.encode(rawValue, to: encoder)
+  }
 }
 
-public enum BillingDiscountRedemptionStatus: String, Codable, Equatable, Sendable {
+public enum BillingDiscountRedemptionStatus: Codable, Equatable, Sendable {
   case active
   case exhausted
   case removed
+  case unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .active:
+      "active"
+    case .exhausted:
+      "exhausted"
+    case .removed:
+      "removed"
+    case .unknown(let value):
+      value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "active":
+      self = .active
+    case "exhausted":
+      self = .exhausted
+    case "removed":
+      self = .removed
+    default:
+      self = .unknown(rawValue)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    try self.init(rawValue: BillingUnknownString.decode(from: decoder))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try BillingUnknownString.encode(rawValue, to: encoder)
+  }
 }
 
 public struct BillingProrationCreditDetail: Codable, Equatable, Sendable {

--- a/Sources/ClerkKit/Domains/Billing/BillingSubscription.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingSubscription.swift
@@ -507,9 +507,9 @@ public struct BillingSubscriptionItem: Codable, Equatable, Sendable, Identifiabl
   public var planPeriod: BillingSubscriptionPlanPeriod
   public var priceId: String
   public var status: BillingSubscriptionStatus
-  public var createdAt: Date
+  public var createdAt: Date?
   public var pastDueAt: Date?
-  public var periodStart: Date
+  public var periodStart: Date?
   public var periodEnd: Date?
   public var canceledAt: Date?
   public var amount: BillingMoneyAmount?
@@ -526,9 +526,9 @@ public struct BillingSubscriptionItem: Codable, Equatable, Sendable, Identifiabl
     planPeriod: BillingSubscriptionPlanPeriod,
     priceId: String,
     status: BillingSubscriptionStatus,
-    createdAt: Date,
+    createdAt: Date? = nil,
     pastDueAt: Date? = nil,
-    periodStart: Date,
+    periodStart: Date? = nil,
     periodEnd: Date? = nil,
     canceledAt: Date? = nil,
     amount: BillingMoneyAmount? = nil,
@@ -565,9 +565,9 @@ public struct BillingSubscriptionItem: Codable, Equatable, Sendable, Identifiabl
     planPeriod = try container.decode(BillingSubscriptionPlanPeriod.self, forKey: .planPeriod)
     priceId = try container.decode(String.self, forKey: .priceId)
     status = try container.decode(BillingSubscriptionStatus.self, forKey: .status)
-    createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date(timeIntervalSince1970: 0)
+    createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
     pastDueAt = try container.decodeIfPresent(Date.self, forKey: .pastDueAt)
-    periodStart = try container.decodeIfPresent(Date.self, forKey: .periodStart) ?? createdAt
+    periodStart = try container.decodeIfPresent(Date.self, forKey: .periodStart)
     periodEnd = try container.decodeIfPresent(Date.self, forKey: .periodEnd)
     canceledAt = try container.decodeIfPresent(Date.self, forKey: .canceledAt)
     amount = try container.decodeIfPresent(BillingMoneyAmount.self, forKey: .amount)

--- a/Sources/ClerkKit/Domains/Billing/BillingUnknownString.swift
+++ b/Sources/ClerkKit/Domains/Billing/BillingUnknownString.swift
@@ -1,0 +1,18 @@
+//
+//  BillingUnknownString.swift
+//  Clerk
+//
+
+import Foundation
+
+enum BillingUnknownString {
+  static func decode(from decoder: Decoder) throws -> String {
+    let container = try decoder.singleValueContainer()
+    return try container.decode(String.self)
+  }
+
+  static func encode(_ rawValue: String, to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}

--- a/Sources/ClerkKit/Domains/Billing/Feature.swift
+++ b/Sources/ClerkKit/Domains/Billing/Feature.swift
@@ -1,0 +1,28 @@
+//
+//  Feature.swift
+//  Clerk
+//
+
+import Foundation
+
+public struct Feature: Codable, Equatable, Sendable, Identifiable {
+  public var id: String
+  public var name: String
+  public var description: String?
+  public var slug: String
+  public var avatarUrl: String?
+
+  public init(
+    id: String,
+    name: String,
+    description: String? = nil,
+    slug: String,
+    avatarUrl: String? = nil
+  ) {
+    self.id = id
+    self.name = name
+    self.description = description
+    self.slug = slug
+    self.avatarUrl = avatarUrl
+  }
+}

--- a/Sources/ClerkKit/Domains/Organization/Organization.swift
+++ b/Sources/ClerkKit/Domains/Organization/Organization.swift
@@ -112,6 +112,11 @@ extension Organization {
     Clerk.shared.dependencies.organizationService
   }
 
+  @MainActor
+  private var billingService: any BillingServiceProtocol {
+    Clerk.shared.dependencies.billingService
+  }
+
   /// Updates an organization's attributes. Returns an Organization object.
   ///
   /// - Parameters:
@@ -454,6 +459,11 @@ extension Organization {
       pageSize: pageSize,
       status: status
     )
+  }
+
+  @MainActor
+  public func getPaymentMethods(params: GetPaymentMethodsParams? = nil) async throws -> ClerkPaginatedResponse<BillingPaymentMethod> {
+    try await billingService.getPaymentMethods(params: params, orgId: id)
   }
 }
 

--- a/Sources/ClerkKit/Domains/User/User.swift
+++ b/Sources/ClerkKit/Domains/User/User.swift
@@ -210,6 +210,11 @@ extension User {
     Clerk.shared.dependencies.userService
   }
 
+  @MainActor
+  private var billingService: any BillingServiceProtocol {
+    Clerk.shared.dependencies.billingService
+  }
+
   /// Reloads the user from the Clerk API.
   @discardableResult @MainActor
   public func reload() async throws -> User {
@@ -508,6 +513,11 @@ extension User {
   @discardableResult @MainActor
   public func getSessions() async throws -> [Session] {
     try await userService.getSessions(user: self)
+  }
+
+  @discardableResult @MainActor
+  public func getPaymentMethods(params: GetPaymentMethodsParams? = nil) async throws -> ClerkPaginatedResponse<BillingPaymentMethod> {
+    try await billingService.getPaymentMethods(params: params, orgId: nil)
   }
 
   /// Updates the user's password. Passwords must be at least 8 characters long.

--- a/Sources/ClerkKit/Mocks/Clerk+Mocks.swift
+++ b/Sources/ClerkKit/Mocks/Clerk+Mocks.swift
@@ -63,6 +63,10 @@ package final class MockServicesBuilder {
   /// You can modify handler properties directly or replace the entire service.
   package var organizationService: MockOrganizationService = .init()
 
+  /// Mock billing service for customizing billing behavior.
+  /// You can modify handler properties directly or replace the entire service.
+  package var billingService: MockBillingService = .init()
+
   /// Mock environment service for customizing `clerk.refreshEnvironment()` behavior.
   /// You can modify handler properties directly or replace the entire service.
   package var environmentService: MockEnvironmentService = .init()

--- a/Sources/ClerkKit/Mocks/Clerk+Preview.swift
+++ b/Sources/ClerkKit/Mocks/Clerk+Preview.swift
@@ -174,6 +174,7 @@ extension Clerk {
       sessionService: services.sessionService,
       passkeyService: services.passkeyService,
       organizationService: services.organizationService,
+      billingService: services.billingService,
       environmentService: services.environmentService,
       emailAddressService: services.emailAddressService,
       phoneNumberService: services.phoneNumberService,

--- a/Sources/ClerkKit/Mocks/MockDependencyContainer.swift
+++ b/Sources/ClerkKit/Mocks/MockDependencyContainer.swift
@@ -39,6 +39,7 @@ final class MockDependencyContainer: Dependencies {
   let passkeyService: PasskeyServiceProtocol
   let biometricCredentialService: BiometricCredentialServiceProtocol
   let organizationService: OrganizationServiceProtocol
+  let billingService: BillingServiceProtocol
   let environmentService: EnvironmentServiceProtocol
   let emailAddressService: EmailAddressServiceProtocol
   let phoneNumberService: PhoneNumberServiceProtocol
@@ -65,6 +66,7 @@ final class MockDependencyContainer: Dependencies {
   ///   - passkeyService: Optional custom passkey service (defaults to MockPasskeyService).
   ///   - biometricCredentialService: Optional custom biometric-credential service (defaults to MockBiometricCredentialService).
   ///   - organizationService: Optional custom organization service (defaults to MockOrganizationService).
+  ///   - billingService: Optional custom billing service (defaults to MockBillingService).
   ///   - environmentService: Optional custom environment service (defaults to MockEnvironmentService with Clerk.Environment.mock).
   ///   - emailAddressService: Optional custom email address service (defaults to MockEmailAddressService).
   ///   - phoneNumberService: Optional custom phone number service (defaults to MockPhoneNumberService).
@@ -92,6 +94,7 @@ final class MockDependencyContainer: Dependencies {
     passkeyService: (any PasskeyServiceProtocol)? = nil,
     biometricCredentialService: (any BiometricCredentialServiceProtocol)? = nil,
     organizationService: (any OrganizationServiceProtocol)? = nil,
+    billingService: (any BillingServiceProtocol)? = nil,
     environmentService: (any EnvironmentServiceProtocol)? = nil,
     emailAddressService: (any EmailAddressServiceProtocol)? = nil,
     phoneNumberService: (any PhoneNumberServiceProtocol)? = nil,
@@ -131,6 +134,7 @@ final class MockDependencyContainer: Dependencies {
     self.passkeyService = passkeyService ?? MockPasskeyService()
     self.biometricCredentialService = biometricCredentialService ?? MockBiometricCredentialService()
     self.organizationService = organizationService ?? MockOrganizationService()
+    self.billingService = billingService ?? MockBillingService()
     self.environmentService = environmentService ?? MockEnvironmentService()
     self.emailAddressService = emailAddressService ?? MockEmailAddressService()
     self.phoneNumberService = phoneNumberService ?? MockPhoneNumberService()

--- a/Sources/ClerkKit/Mocks/MockModels.swift
+++ b/Sources/ClerkKit/Mocks/MockModels.swift
@@ -1142,3 +1142,201 @@ extension ClerkAPIError {
     )
   }
 }
+
+// MARK: Billing
+
+extension BillingMoneyAmount {
+  public static var mock: Self {
+    .init(amount: 1000, amountFormatted: "10.00", currency: "USD", currencySymbol: "$")
+  }
+}
+
+extension Feature {
+  public static var mock: Self {
+    .init(id: "feat_1", name: "SSO", description: "Single sign-on", slug: "sso", avatarUrl: nil)
+  }
+}
+
+extension BillingPlan {
+  public static var mock: Self {
+    .init(
+      id: "plan_1",
+      name: "Pro",
+      fee: .mock,
+      annualFee: .mock,
+      annualMonthlyFee: .mock,
+      description: "Pro plan",
+      isDefault: false,
+      isRecurring: true,
+      hasBaseFee: true,
+      forPayerType: .org,
+      publiclyVisible: true,
+      slug: "pro",
+      avatarUrl: nil,
+      features: [.mock],
+      unitPrices: [
+        .init(
+          name: "seats",
+          blockSize: 1,
+          tiers: [
+            .init(id: "tier_1", startsAtBlock: 1, endsAfterBlock: nil, feePerBlock: .mock),
+          ]
+        ),
+      ],
+      availablePrices: [
+        .init(id: "price_1", fee: .mock, annualMonthlyFee: .mock, isDefault: true, unitPrices: nil),
+      ],
+      freeTrialDays: 14,
+      freeTrialEnabled: true
+    )
+  }
+}
+
+extension BillingPaymentMethod {
+  public static var mock: Self {
+    .init(
+      id: "pm_1",
+      last4: "4242",
+      paymentType: "card",
+      cardType: "visa",
+      isDefault: true,
+      isRemovable: true,
+      status: .active,
+      walletType: nil,
+      expiryYear: 2030,
+      expiryMonth: 12,
+      createdAt: Date.distantPast,
+      updatedAt: Date.distantPast
+    )
+  }
+}
+
+extension BillingSubscriptionItem {
+  public static var mock: Self {
+    .init(
+      id: "si_1",
+      plan: .mock,
+      planPeriod: .month,
+      priceId: "price_1",
+      status: .active,
+      createdAt: Date.distantPast,
+      pastDueAt: nil,
+      periodStart: Date.distantPast,
+      periodEnd: Date.distantFuture,
+      canceledAt: nil,
+      amount: .mock,
+      nextPayment: .init(amount: .mock, date: Date.distantFuture),
+      credit: .init(amount: .mock),
+      credits: .init(
+        proration: .init(amount: .mock, cycleDaysRemaining: 10, cycleDaysTotal: 30, cycleRemainingPercent: 0.33),
+        payer: .init(remainingBalance: .mock, appliedAmount: .mock),
+        total: .mock
+      ),
+      appliedDiscount: .init(
+        id: "red_1",
+        subscriptionItemId: "si_1",
+        discountId: "disc_1",
+        name: "Launch",
+        source: .promoCode,
+        promoCode: "LAUNCH",
+        effect: .percentage,
+        percentOff: 20,
+        amount: .mock,
+        cyclesRemaining: 2,
+        cyclesApplied: 1,
+        status: .active,
+        redeemedAt: Date.distantPast,
+        redeemedBy: "user_1"
+      ),
+      seats: .init(
+        quantity: 5,
+        tiers: [.init(quantity: 5, feePerBlock: .mock, total: .mock)]
+      ),
+      isFreeTrial: false
+    )
+  }
+}
+
+extension BillingSubscription {
+  public static var mock: Self {
+    .init(
+      id: "sub_1",
+      activeAt: Date.distantPast,
+      createdAt: Date.distantPast,
+      nextPayment: .init(amount: .mock, date: Date.distantFuture, totals: .init(subtotal: .mock, taxTotal: .mock, grandTotal: .mock)),
+      pastDueAt: nil,
+      status: .active,
+      subscriptionItems: [.mock],
+      updatedAt: Date.distantPast,
+      eligibleForFreeTrial: false
+    )
+  }
+}
+
+extension BillingPayment {
+  public static var mock: Self {
+    .init(
+      id: "pay_1",
+      amount: .mock,
+      paidAt: Date.distantPast,
+      failedAt: nil,
+      updatedAt: Date.distantPast,
+      paymentMethod: .mock,
+      subscriptionItem: .mock,
+      chargeType: .recurring,
+      status: .paid,
+      totals: .init(
+        subtotal: .mock,
+        grandTotal: .mock,
+        taxTotal: .mock,
+        baseFee: .mock,
+        perUnitTotals: [.init(name: "seats", blockSize: 1, tiers: [.init(quantity: 5, feePerBlock: .mock, total: .mock)])],
+        discounts: .init(
+          proration: .init(amount: .mock, cycleDaysPassed: 10, cycleDaysTotal: 30, cyclePassedPercent: 0.33),
+          discount: .init(
+            amount: .mock,
+            discountId: "disc_1",
+            name: "Launch",
+            effect: .percentage,
+            percentOff: 20,
+            promoCode: "LAUNCH",
+            cyclesRemaining: 2
+          ),
+          total: .mock
+        )
+      )
+    )
+  }
+}
+
+extension BillingStatement {
+  public static var mock: Self {
+    .init(
+      id: "stmt_1",
+      totals: .init(subtotal: .mock, grandTotal: .mock, taxTotal: .mock),
+      status: .open,
+      timestamp: Date.distantPast,
+      groups: [
+        .init(id: "grp_1", timestamp: Date.distantPast, items: [.mock]),
+      ]
+    )
+  }
+}
+
+extension BillingCreditBalance {
+  public static var mock: Self {
+    .init(balance: .mock)
+  }
+}
+
+extension BillingCreditLedger {
+  public static var mock: Self {
+    .init(
+      id: "led_1",
+      amount: .mock,
+      sourceType: "payment",
+      sourceId: "pay_1",
+      createdAt: Date.distantPast
+    )
+  }
+}

--- a/Sources/ClerkKit/Mocks/MockServices/MockBillingService.swift
+++ b/Sources/ClerkKit/Mocks/MockServices/MockBillingService.swift
@@ -1,0 +1,123 @@
+//
+//  MockBillingService.swift
+//  Clerk
+//
+
+import Foundation
+
+package final class MockBillingService: BillingServiceProtocol {
+  package nonisolated(unsafe) var getPaymentAttemptsHandler: ((GetPaymentAttemptsParams) async throws -> ClerkPaginatedResponse<BillingPayment>)?
+  package nonisolated(unsafe) var getPaymentAttemptHandler: ((GetPaymentAttemptParams) async throws -> BillingPayment)?
+  package nonisolated(unsafe) var getPlansHandler: ((GetPlansParams?) async throws -> ClerkPaginatedResponse<BillingPlan>)?
+  package nonisolated(unsafe) var getPlanHandler: ((GetPlanParams) async throws -> BillingPlan)?
+  package nonisolated(unsafe) var getSubscriptionHandler: ((GetSubscriptionParams) async throws -> BillingSubscription)?
+  package nonisolated(unsafe) var getStatementsHandler: ((GetStatementsParams) async throws -> ClerkPaginatedResponse<BillingStatement>)?
+  package nonisolated(unsafe) var getStatementHandler: ((GetStatementParams) async throws -> BillingStatement)?
+  package nonisolated(unsafe) var getCreditBalanceHandler: ((GetCreditBalanceParams) async throws -> BillingCreditBalance)?
+  package nonisolated(unsafe) var getCreditHistoryHandler: ((GetCreditHistoryParams) async throws -> ClerkPaginatedResponse<BillingCreditLedger>)?
+  package nonisolated(unsafe) var getPaymentMethodsHandler: ((GetPaymentMethodsParams?, String?) async throws -> ClerkPaginatedResponse<BillingPaymentMethod>)?
+
+  package init(
+    getPaymentAttempts: ((GetPaymentAttemptsParams) async throws -> ClerkPaginatedResponse<BillingPayment>)? = nil,
+    getPaymentAttempt: ((GetPaymentAttemptParams) async throws -> BillingPayment)? = nil,
+    getPlans: ((GetPlansParams?) async throws -> ClerkPaginatedResponse<BillingPlan>)? = nil,
+    getPlan: ((GetPlanParams) async throws -> BillingPlan)? = nil,
+    getSubscription: ((GetSubscriptionParams) async throws -> BillingSubscription)? = nil,
+    getStatements: ((GetStatementsParams) async throws -> ClerkPaginatedResponse<BillingStatement>)? = nil,
+    getStatement: ((GetStatementParams) async throws -> BillingStatement)? = nil,
+    getCreditBalance: ((GetCreditBalanceParams) async throws -> BillingCreditBalance)? = nil,
+    getCreditHistory: ((GetCreditHistoryParams) async throws -> ClerkPaginatedResponse<BillingCreditLedger>)? = nil,
+    getPaymentMethods: ((GetPaymentMethodsParams?, String?) async throws -> ClerkPaginatedResponse<BillingPaymentMethod>)? = nil
+  ) {
+    getPaymentAttemptsHandler = getPaymentAttempts
+    getPaymentAttemptHandler = getPaymentAttempt
+    getPlansHandler = getPlans
+    getPlanHandler = getPlan
+    getSubscriptionHandler = getSubscription
+    getStatementsHandler = getStatements
+    getStatementHandler = getStatement
+    getCreditBalanceHandler = getCreditBalance
+    getCreditHistoryHandler = getCreditHistory
+    getPaymentMethodsHandler = getPaymentMethods
+  }
+
+  @MainActor
+  package func getPaymentAttempts(params: GetPaymentAttemptsParams) async throws -> ClerkPaginatedResponse<BillingPayment> {
+    if let getPaymentAttemptsHandler {
+      return try await getPaymentAttemptsHandler(params)
+    }
+    return ClerkPaginatedResponse(data: [.mock], totalCount: 1)
+  }
+
+  @MainActor
+  package func getPaymentAttempt(params: GetPaymentAttemptParams) async throws -> BillingPayment {
+    if let getPaymentAttemptHandler {
+      return try await getPaymentAttemptHandler(params)
+    }
+    return .mock
+  }
+
+  @MainActor
+  package func getPlans(params: GetPlansParams?) async throws -> ClerkPaginatedResponse<BillingPlan> {
+    if let getPlansHandler {
+      return try await getPlansHandler(params)
+    }
+    return ClerkPaginatedResponse(data: [.mock], totalCount: 1)
+  }
+
+  @MainActor
+  package func getPlan(params: GetPlanParams) async throws -> BillingPlan {
+    if let getPlanHandler {
+      return try await getPlanHandler(params)
+    }
+    return .mock
+  }
+
+  @MainActor
+  package func getSubscription(params: GetSubscriptionParams) async throws -> BillingSubscription {
+    if let getSubscriptionHandler {
+      return try await getSubscriptionHandler(params)
+    }
+    return .mock
+  }
+
+  @MainActor
+  package func getStatements(params: GetStatementsParams) async throws -> ClerkPaginatedResponse<BillingStatement> {
+    if let getStatementsHandler {
+      return try await getStatementsHandler(params)
+    }
+    return ClerkPaginatedResponse(data: [.mock], totalCount: 1)
+  }
+
+  @MainActor
+  package func getStatement(params: GetStatementParams) async throws -> BillingStatement {
+    if let getStatementHandler {
+      return try await getStatementHandler(params)
+    }
+    return .mock
+  }
+
+  @MainActor
+  package func getCreditBalance(params: GetCreditBalanceParams) async throws -> BillingCreditBalance {
+    if let getCreditBalanceHandler {
+      return try await getCreditBalanceHandler(params)
+    }
+    return .mock
+  }
+
+  @MainActor
+  package func getCreditHistory(params: GetCreditHistoryParams) async throws -> ClerkPaginatedResponse<BillingCreditLedger> {
+    if let getCreditHistoryHandler {
+      return try await getCreditHistoryHandler(params)
+    }
+    return ClerkPaginatedResponse(data: [.mock], totalCount: 1)
+  }
+
+  @MainActor
+  package func getPaymentMethods(params: GetPaymentMethodsParams?, orgId: String?) async throws -> ClerkPaginatedResponse<BillingPaymentMethod> {
+    if let getPaymentMethodsHandler {
+      return try await getPaymentMethodsHandler(params, orgId)
+    }
+    return ClerkPaginatedResponse(data: [.mock], totalCount: 1)
+  }
+}

--- a/Tests/Domains/Billing/BillingTests.swift
+++ b/Tests/Domains/Billing/BillingTests.swift
@@ -1,0 +1,704 @@
+@testable import ClerkKit
+import ConcurrencyExtras
+import Foundation
+import Mocker
+import Testing
+
+@MainActor
+@Suite(.serialized)
+struct BillingTests {
+  init() {
+    configureClerkForTesting()
+  }
+
+  private let decoder = JSONDecoder.clerkDecoder
+
+  @Test
+  func billingGetMethodsAreCallable() async throws {
+    // Omitted write APIs from clerk-js BillingNamespace / BillingPayerMethods:
+    // startCheckout, updateCheckout, initializePaymentMethod, addPaymentMethod,
+    // cancel, remove, makeDefault
+    let service = MockBillingService()
+    Clerk.shared.dependencies = MockDependencyContainer(
+      apiClient: createMockAPIClient(),
+      billingService: service
+    )
+
+    _ = try await Clerk.shared.billing.getPaymentAttempts(params: .init())
+    _ = try await Clerk.shared.billing.getPaymentAttempt(params: .init(id: "pay_1"))
+    _ = try await Clerk.shared.billing.getPlans()
+    _ = try await Clerk.shared.billing.getPlan(params: .init(id: "plan_1"))
+    _ = try await Clerk.shared.billing.getSubscription(params: .init())
+    _ = try await Clerk.shared.billing.getStatements(params: .init())
+    _ = try await Clerk.shared.billing.getStatement(params: .init(id: "stmt_1"))
+    _ = try await Clerk.shared.billing.getCreditBalance(params: .init())
+    _ = try await Clerk.shared.billing.getCreditHistory(params: .init())
+    _ = try await User.mock.getPaymentMethods()
+    _ = try await Organization.mock.getPaymentMethods()
+  }
+
+  @Test
+  func getPlansMapsOrganizationPayerTypeAndPagination() async throws {
+    let requestHandled = LockIsolated(false)
+    var mock = try Mock(
+      url: URL(string: mockBaseUrl.absoluteString + "/v1/billing/plans")!,
+      ignoreQuery: true,
+      contentType: .json,
+      statusCode: 200,
+      data: [
+        .get: JSONEncoder.clerkEncoder.encode(ClerkPaginatedResponse(data: [BillingPlan.mock], totalCount: 1)),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { @Sendable request in
+      #expect(request.httpMethod == "GET")
+      #expect(request.url?.query?.contains("_clerk_session_id") == true)
+      #expect(request.url?.queryParam(named: "payer_type") == "org")
+      #expect(request.url?.queryParam(named: "org_id") == "org_123")
+      #expect(request.url?.queryParam(named: "min_seats") == "5")
+      #expect(request.url?.queryParam(named: "limit") == "10")
+      #expect(request.url?.queryParam(named: "offset") == "20")
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    _ = try await Clerk.shared.billing.getPlans(
+      params: .init(
+        for: .organization,
+        orgId: "org_123",
+        minSeats: 5,
+        initialPage: 3,
+        pageSize: 10
+      )
+    )
+    #expect(requestHandled.value)
+  }
+
+  @Test
+  func getPlansDefaultsToUserPayerTypeAndFirstPage() async throws {
+    let requestHandled = LockIsolated(false)
+    var mock = try Mock(
+      url: URL(string: mockBaseUrl.absoluteString + "/v1/billing/plans")!,
+      ignoreQuery: true,
+      contentType: .json,
+      statusCode: 200,
+      data: [
+        .get: JSONEncoder.clerkEncoder.encode(ClerkPaginatedResponse(data: [BillingPlan.mock], totalCount: 1)),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { @Sendable request in
+      #expect(request.url?.queryParam(named: "payer_type") == "user")
+      #expect(request.url?.queryParam(named: "org_id") == nil)
+      #expect(request.url?.queryParam(named: "min_seats") == nil)
+      #expect(request.url?.queryParam(named: "limit") == "10")
+      #expect(request.url?.queryParam(named: "offset") == "0")
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    _ = try await Clerk.shared.billing.getPlans()
+    #expect(requestHandled.value)
+  }
+
+  @Test
+  func userAndOrganizationUseDistinctBillingPathPrefixes() async throws {
+    try await assertGET(
+      path: "/v1/me/billing/subscription",
+      body: encodeClientResponse(BillingSubscription.mock)
+    ) {
+      _ = try await Clerk.shared.billing.getSubscription(params: .init())
+    }
+
+    try await assertGET(
+      path: "/v1/organizations/org_123/billing/subscription",
+      body: encodeClientResponse(BillingSubscription.mock)
+    ) {
+      _ = try await Clerk.shared.billing.getSubscription(params: .init(orgId: "org_123"))
+    }
+
+    try await assertGET(
+      path: "/v1/me/billing/statements",
+      body: encodeClientResponse(ClerkPaginatedResponse(data: [BillingStatement.mock], totalCount: 1))
+    ) {
+      _ = try await Clerk.shared.billing.getStatements(params: .init())
+    }
+
+    try await assertGET(
+      path: "/v1/organizations/org_123/billing/statements",
+      body: encodeClientResponse(ClerkPaginatedResponse(data: [BillingStatement.mock], totalCount: 1))
+    ) {
+      _ = try await Clerk.shared.billing.getStatements(params: .init(orgId: "org_123"))
+    }
+
+    try await assertGET(
+      path: "/v1/me/billing/payment_attempts",
+      body: JSONEncoder.clerkEncoder.encode(ClerkPaginatedResponse(data: [BillingPayment.mock], totalCount: 1))
+    ) {
+      _ = try await Clerk.shared.billing.getPaymentAttempts(params: .init())
+    }
+
+    try await assertGET(
+      path: "/v1/organizations/org_123/billing/payment_attempts",
+      body: JSONEncoder.clerkEncoder.encode(ClerkPaginatedResponse(data: [BillingPayment.mock], totalCount: 1))
+    ) {
+      _ = try await Clerk.shared.billing.getPaymentAttempts(params: .init(orgId: "org_123"))
+    }
+
+    try await assertGET(
+      path: "/v1/me/billing/credits",
+      body: encodeClientResponse(BillingCreditBalance.mock)
+    ) {
+      _ = try await Clerk.shared.billing.getCreditBalance(params: .init())
+    }
+
+    try await assertGET(
+      path: "/v1/organizations/org_123/billing/credits",
+      body: encodeClientResponse(BillingCreditBalance.mock)
+    ) {
+      _ = try await Clerk.shared.billing.getCreditBalance(params: .init(orgId: "org_123"))
+    }
+
+    try await assertGET(
+      path: "/v1/me/billing/payment_methods",
+      body: encodeClientResponse(ClerkPaginatedResponse(data: [BillingPaymentMethod.mock], totalCount: 1))
+    ) {
+      _ = try await User.mock.getPaymentMethods()
+    }
+
+    try await assertGET(
+      path: "/v1/organizations/\(Organization.mock.id)/billing/payment_methods",
+      body: encodeClientResponse(ClerkPaginatedResponse(data: [BillingPaymentMethod.mock], totalCount: 1))
+    ) {
+      _ = try await Organization.mock.getPaymentMethods()
+    }
+  }
+
+  @Test
+  func getCreditHistoryOmitsPagination() async throws {
+    let requestHandled = LockIsolated(false)
+    var mock = try Mock(
+      url: URL(string: mockBaseUrl.absoluteString + "/v1/me/billing/credits/history")!,
+      ignoreQuery: true,
+      contentType: .json,
+      statusCode: 200,
+      data: [
+        .get: encodeClientResponse(ClerkPaginatedResponse(data: [BillingCreditLedger.mock], totalCount: 1)),
+      ]
+    )
+
+    mock.onRequestHandler = OnRequestHandler { @Sendable request in
+      #expect(request.url?.queryParam(named: "limit") == nil)
+      #expect(request.url?.queryParam(named: "offset") == nil)
+      #expect(request.url?.query?.contains("_clerk_session_id") == true)
+      requestHandled.setValue(true)
+    }
+    mock.register()
+
+    _ = try await Clerk.shared.billing.getCreditHistory(params: .init())
+    #expect(requestHandled.value)
+  }
+
+  @Test
+  func decodesFeature() throws {
+    let feature = try decoder.decode(Feature.self, from: Data(featureJSON.utf8))
+    #expect(feature.id == "feat_1")
+    #expect(feature.name == "SSO")
+    #expect(feature.description == "Single sign-on")
+    #expect(feature.slug == "sso")
+    #expect(feature.avatarUrl == nil)
+  }
+
+  @Test
+  func decodesBillingMoneyAmount() throws {
+    let money = try decoder.decode(BillingMoneyAmount.self, from: Data(moneyJSON.utf8))
+    #expect(money.amount == 1000)
+    #expect(money.amountFormatted == "10.00")
+    #expect(money.currency == "USD")
+    #expect(money.currencySymbol == "$")
+  }
+
+  @Test
+  func decodesBillingPlanWithFeaturesUnitPricesAndAvailablePrices() throws {
+    let plan = try decoder.decode(BillingPlan.self, from: Data(planJSON.utf8))
+    #expect(plan.id == "plan_1")
+    #expect(plan.fee?.amount == 1000)
+    #expect(plan.annualFee?.amountFormatted == "10.00")
+    #expect(plan.features.map(\.slug) == ["sso"])
+    #expect(plan.unitPrices?.first?.name == "seats")
+    #expect(plan.unitPrices?.first?.tiers.first?.startsAtBlock == 1)
+    #expect(plan.availablePrices?.first?.id == "price_1")
+    #expect(plan.freeTrialDays == 14)
+    #expect(plan.freeTrialEnabled)
+  }
+
+  @Test
+  func decodesBillingPlanDefaultsMissingFeaturesAndTrial() throws {
+    let json = Data(
+      """
+      {
+        "id": "plan_free",
+        "name": "Free",
+        "fee": null,
+        "annual_fee": null,
+        "annual_monthly_fee": null,
+        "description": null,
+        "is_default": true,
+        "is_recurring": true,
+        "has_base_fee": false,
+        "for_payer_type": "user",
+        "publicly_visible": true,
+        "slug": "free",
+        "avatar_url": null
+      }
+      """.utf8
+    )
+
+    let plan = try decoder.decode(BillingPlan.self, from: json)
+    #expect(plan.features.isEmpty)
+    #expect(plan.freeTrialDays == nil)
+    #expect(!plan.freeTrialEnabled)
+  }
+
+  @Test
+  func decodesBillingSubscriptionWithSeatsCreditsAndDiscounts() throws {
+    let subscription = try decoder.decode(BillingSubscription.self, from: Data(subscriptionJSON.utf8))
+    let item = try #require(subscription.subscriptionItems.first)
+    #expect(subscription.status == .active)
+    #expect(item.seats?.quantity == 5)
+    #expect(item.seats?.tiers?.first?.total.amount == 1000)
+    #expect(item.credits?.proration?.cycleDaysRemaining == 10)
+    #expect(item.appliedDiscount?.source == .promoCode)
+    #expect(item.appliedDiscount?.percentOff == 20)
+    #expect(item.credit?.amount.currencySymbol == "$")
+    #expect(item.isFreeTrial == false)
+  }
+
+  @Test
+  func decodesBillingStatementWithTotals() throws {
+    let statement = try decoder.decode(BillingStatement.self, from: Data(statementJSON.utf8))
+    #expect(statement.status == .open)
+    #expect(statement.totals.subtotal.amount == 1000)
+    #expect(statement.totals.grandTotal.amountFormatted == "10.00")
+    #expect(statement.totals.taxTotal.currency == "USD")
+    #expect(statement.groups.first?.items.first?.id == "pay_1")
+  }
+
+  @Test
+  func decodesBillingPaymentWithTotals() throws {
+    let payment = try decoder.decode(BillingPayment.self, from: Data(paymentJSON.utf8))
+    #expect(payment.status == .paid)
+    #expect(payment.chargeType == .recurring)
+    #expect(payment.totals?.grandTotal.amount == 1000)
+    #expect(payment.totals?.discounts?.proration?.cycleDaysPassed == 10)
+    #expect(payment.totals?.perUnitTotals?.first?.name == "seats")
+    #expect(payment.paymentMethod?.last4 == "4242")
+  }
+
+  @Test
+  func decodesBillingPaymentMethod() throws {
+    let method = try decoder.decode(BillingPaymentMethod.self, from: Data(paymentMethodJSON.utf8))
+    #expect(method.id == "pm_1")
+    #expect(method.last4 == "4242")
+    #expect(method.cardType == "visa")
+    #expect(method.status == .active)
+    #expect(method.expiryMonth == 12)
+  }
+
+  @Test
+  func decodesBillingCreditBalance() throws {
+    let balance = try decoder.decode(BillingCreditBalance.self, from: Data(creditBalanceJSON.utf8))
+    #expect(balance.balance?.amount == 1000)
+  }
+
+  @Test
+  func decodesBillingCreditLedger() throws {
+    let ledger = try decoder.decode(BillingCreditLedger.self, from: Data(creditLedgerJSON.utf8))
+    #expect(ledger.id == "led_1")
+    #expect(ledger.sourceType == "payment")
+    #expect(ledger.sourceId == "pay_1")
+    #expect(ledger.amount.currencySymbol == "$")
+  }
+
+  @Test
+  func rawEnvelopesDecodePlansAndPaymentAttempts() async throws {
+    try await assertGET(
+      path: "/v1/billing/plans",
+      body: JSONEncoder.clerkEncoder.encode(ClerkPaginatedResponse(data: [BillingPlan.mock], totalCount: 2))
+    ) {
+      let plans = try await Clerk.shared.billing.getPlans()
+      #expect(plans.data.count == 1)
+      #expect(plans.totalCount == 2)
+    }
+
+    try await assertGET(
+      path: "/v1/billing/plans/plan_1",
+      body: JSONEncoder.clerkEncoder.encode(BillingPlan.mock)
+    ) {
+      let plan = try await Clerk.shared.billing.getPlan(params: .init(id: "plan_1"))
+      #expect(plan.id == BillingPlan.mock.id)
+    }
+
+    try await assertGET(
+      path: "/v1/me/billing/payment_attempts",
+      body: JSONEncoder.clerkEncoder.encode(ClerkPaginatedResponse(data: [BillingPayment.mock], totalCount: 1))
+    ) {
+      let payments = try await Clerk.shared.billing.getPaymentAttempts(params: .init())
+      #expect(payments.data.first?.id == BillingPayment.mock.id)
+    }
+
+    try await assertGET(
+      path: "/v1/me/billing/payment_attempts/pay_1",
+      body: JSONEncoder.clerkEncoder.encode(BillingPayment.mock)
+    ) {
+      let payment = try await Clerk.shared.billing.getPaymentAttempt(params: .init(id: "pay_1"))
+      #expect(payment.id == "pay_1")
+    }
+  }
+
+  @Test
+  func clientResponseEnvelopesDecodeSubscriptionStatementsCreditsAndPaymentMethods() async throws {
+    try await assertGET(
+      path: "/v1/me/billing/subscription",
+      body: encodeClientResponse(BillingSubscription.mock)
+    ) {
+      let subscription = try await Clerk.shared.billing.getSubscription(params: .init())
+      #expect(subscription.id == BillingSubscription.mock.id)
+    }
+
+    try await assertGET(
+      path: "/v1/me/billing/statements",
+      body: encodeClientResponse(ClerkPaginatedResponse(data: [BillingStatement.mock], totalCount: 1))
+    ) {
+      let statements = try await Clerk.shared.billing.getStatements(params: .init())
+      #expect(statements.data.first?.totals.grandTotal.amount == 1000)
+    }
+
+    try await assertGET(
+      path: "/v1/me/billing/statements/stmt_1",
+      body: encodeClientResponse(BillingStatement.mock)
+    ) {
+      let statement = try await Clerk.shared.billing.getStatement(params: .init(id: "stmt_1"))
+      #expect(statement.id == "stmt_1")
+    }
+
+    try await assertGET(
+      path: "/v1/me/billing/credits",
+      body: encodeClientResponse(BillingCreditBalance.mock)
+    ) {
+      let credits = try await Clerk.shared.billing.getCreditBalance(params: .init())
+      #expect(credits.balance?.amount == 1000)
+    }
+
+    try await assertGET(
+      path: "/v1/me/billing/credits/history",
+      body: encodeClientResponse(ClerkPaginatedResponse(data: [BillingCreditLedger.mock], totalCount: 1))
+    ) {
+      let history = try await Clerk.shared.billing.getCreditHistory(params: .init())
+      #expect(history.data.first?.id == "led_1")
+    }
+
+    try await assertGET(
+      path: "/v1/me/billing/payment_methods",
+      body: encodeClientResponse(ClerkPaginatedResponse(data: [BillingPaymentMethod.mock], totalCount: 1))
+    ) {
+      let methods = try await User.mock.getPaymentMethods()
+      #expect(methods.data.first?.last4 == "4242")
+    }
+  }
+
+  @Test
+  func rawPlanBodyDoesNotDecodeClientResponseWrapper() throws {
+    let wrapped = try? decoder.decode(
+      BillingPlan.self,
+      from: try encodeClientResponse(BillingPlan.mock)
+    )
+    #expect(wrapped == nil)
+  }
+
+  @Test
+  func wrappedSubscriptionBodyDoesNotDecodeRawResource() throws {
+    let raw = try? decoder.decode(
+      ClientResponse<BillingSubscription>.self,
+      from: try JSONEncoder.clerkEncoder.encode(BillingSubscription.mock)
+    )
+    #expect(raw == nil)
+  }
+
+  private func assertGET(
+    path: String,
+    body: Data,
+    perform: () async throws -> Void
+  ) async throws {
+    let requestHandled = LockIsolated(false)
+    var mock = Mock(
+      url: URL(string: mockBaseUrl.absoluteString + path)!,
+      ignoreQuery: true,
+      contentType: .json,
+      statusCode: 200,
+      data: [
+        .get: body,
+      ]
+    )
+    mock.onRequestHandler = OnRequestHandler { @Sendable request in
+      #expect(request.httpMethod == "GET")
+      #expect(request.url?.query?.contains("_clerk_session_id") == true)
+      requestHandled.setValue(true)
+    }
+    mock.register()
+    try await perform()
+    #expect(requestHandled.value)
+  }
+
+  private func encodeClientResponse(_ response: some Codable & Sendable) throws -> Data {
+    try JSONEncoder.clerkEncoder.encode(ClientResponse(response: response, client: .mock))
+  }
+}
+
+private let moneyJSON = """
+{
+  "amount": 1000,
+  "amount_formatted": "10.00",
+  "currency": "USD",
+  "currency_symbol": "$"
+}
+"""
+
+private let featureJSON = """
+{
+  "object": "feature",
+  "id": "feat_1",
+  "name": "SSO",
+  "description": "Single sign-on",
+  "slug": "sso",
+  "avatar_url": null
+}
+"""
+
+private let planJSON = """
+{
+  "object": "commerce_plan",
+  "id": "plan_1",
+  "name": "Pro",
+  "fee": \(moneyJSON),
+  "annual_fee": \(moneyJSON),
+  "annual_monthly_fee": \(moneyJSON),
+  "description": "Pro plan",
+  "is_default": false,
+  "is_recurring": true,
+  "has_base_fee": true,
+  "for_payer_type": "org",
+  "publicly_visible": true,
+  "slug": "pro",
+  "avatar_url": null,
+  "features": [\(featureJSON)],
+  "unit_prices": [
+    {
+      "name": "seats",
+      "block_size": 1,
+      "tiers": [
+        {
+          "id": "tier_1",
+          "starts_at_block": 1,
+          "ends_after_block": null,
+          "fee_per_block": \(moneyJSON)
+        }
+      ]
+    }
+  ],
+  "available_prices": [
+    {
+      "id": "price_1",
+      "fee": \(moneyJSON),
+      "annual_monthly_fee": \(moneyJSON),
+      "is_default": true
+    }
+  ],
+  "free_trial_days": 14,
+  "free_trial_enabled": true
+}
+"""
+
+private let paymentMethodJSON = """
+{
+  "object": "commerce_payment_method",
+  "id": "pm_1",
+  "last4": "4242",
+  "payment_type": "card",
+  "card_type": "visa",
+  "is_default": true,
+  "is_removable": true,
+  "status": "active",
+  "wallet_type": null,
+  "expiry_year": 2030,
+  "expiry_month": 12,
+  "created_at": 1700000000000,
+  "updated_at": 1700000000000
+}
+"""
+
+private let subscriptionItemJSON = """
+{
+  "object": "commerce_subscription_item",
+  "id": "si_1",
+  "plan": \(planJSON),
+  "plan_period": "month",
+  "price_id": "price_1",
+  "status": "active",
+  "created_at": 1700000000000,
+  "period_start": 1700000000000,
+  "period_end": 1702592000000,
+  "canceled_at": null,
+  "past_due_at": null,
+  "amount": \(moneyJSON),
+  "credit": { "amount": \(moneyJSON) },
+  "credits": {
+    "proration": {
+      "amount": \(moneyJSON),
+      "cycle_days_remaining": 10,
+      "cycle_days_total": 30,
+      "cycle_remaining_percent": 0.33
+    },
+    "payer": {
+      "remaining_balance": \(moneyJSON),
+      "applied_amount": \(moneyJSON)
+    },
+    "total": \(moneyJSON)
+  },
+  "applied_discount": {
+    "id": "red_1",
+    "subscription_item_id": "si_1",
+    "discount_id": "disc_1",
+    "name": "Launch",
+    "source": "promo_code",
+    "promo_code": "LAUNCH",
+    "effect": "percentage",
+    "percent_off": 20,
+    "cycles_remaining": 2,
+    "cycles_applied": 1,
+    "status": "active",
+    "redeemed_at": 1700000000000,
+    "redeemed_by": "user_1"
+  },
+  "seats": {
+    "quantity": 5,
+    "tiers": [
+      {
+        "quantity": 5,
+        "fee_per_block": \(moneyJSON),
+        "total": \(moneyJSON)
+      }
+    ]
+  },
+  "is_free_trial": false
+}
+"""
+
+private let subscriptionJSON = """
+{
+  "object": "commerce_subscription",
+  "id": "sub_1",
+  "status": "active",
+  "created_at": 1700000000000,
+  "active_at": 1700000000000,
+  "updated_at": 1700000000000,
+  "past_due_at": null,
+  "eligible_for_free_trial": false,
+  "subscription_items": [\(subscriptionItemJSON)],
+  "next_payment": {
+    "amount": \(moneyJSON),
+    "date": 1702592000000
+  }
+}
+"""
+
+private let paymentJSON = """
+{
+  "object": "commerce_payment",
+  "id": "pay_1",
+  "amount": \(moneyJSON),
+  "paid_at": 1700000000000,
+  "failed_at": null,
+  "updated_at": 1700000000000,
+  "payment_method": \(paymentMethodJSON),
+  "subscription_item": \(subscriptionItemJSON),
+  "charge_type": "recurring",
+  "status": "paid",
+  "totals": {
+    "subtotal": \(moneyJSON),
+    "grand_total": \(moneyJSON),
+    "tax_total": \(moneyJSON),
+    "base_fee": \(moneyJSON),
+    "per_unit_totals": [
+      {
+        "name": "seats",
+        "block_size": 1,
+        "tiers": [
+          {
+            "quantity": 5,
+            "fee_per_block": \(moneyJSON),
+            "total": \(moneyJSON)
+          }
+        ]
+      }
+    ],
+    "discounts": {
+      "proration": {
+        "amount": \(moneyJSON),
+        "cycle_days_passed": 10,
+        "cycle_days_total": 30,
+        "cycle_passed_percent": 0.33
+      },
+      "discount": {
+        "amount": \(moneyJSON),
+        "discount_id": "disc_1",
+        "name": "Launch",
+        "effect": "percentage",
+        "percent_off": 20,
+        "promo_code": "LAUNCH",
+        "cycles_remaining": 2
+      },
+      "total": \(moneyJSON)
+    }
+  }
+}
+"""
+
+private let statementJSON = """
+{
+  "object": "commerce_statement",
+  "id": "stmt_1",
+  "status": "open",
+  "timestamp": 1700000000000,
+  "totals": {
+    "subtotal": \(moneyJSON),
+    "grand_total": \(moneyJSON),
+    "tax_total": \(moneyJSON)
+  },
+  "groups": [
+    {
+      "id": "grp_1",
+      "timestamp": 1700000000000,
+      "items": [\(paymentJSON)]
+    }
+  ]
+}
+"""
+
+private let creditBalanceJSON = """
+{
+  "object": "commerce_credit_balance",
+  "balance": \(moneyJSON)
+}
+"""
+
+private let creditLedgerJSON = """
+{
+  "object": "commerce_credit_ledger",
+  "id": "led_1",
+  "amount": \(moneyJSON),
+  "source_type": "payment",
+  "source_id": "pay_1",
+  "created_at": 1700000000000
+}
+"""

--- a/Tests/Domains/Billing/BillingTests.swift
+++ b/Tests/Domains/Billing/BillingTests.swift
@@ -328,6 +328,8 @@ struct BillingTests {
     let payment = try decoder.decode(BillingPayment.self, from: Data(stripped.utf8))
     #expect(payment.id == "pay_1")
     #expect(payment.subscriptionItem.id == "si_1")
+    #expect(payment.subscriptionItem.createdAt == nil)
+    #expect(payment.subscriptionItem.periodStart == nil)
     #expect(payment.status == .paid)
   }
 

--- a/Tests/Domains/Billing/BillingTests.swift
+++ b/Tests/Domains/Billing/BillingTests.swift
@@ -282,6 +282,45 @@ struct BillingTests {
     #expect(statement.totals.grandTotal.amountFormatted == "10.00")
     #expect(statement.totals.taxTotal.currency == "USD")
     #expect(statement.groups.first?.items.first?.id == "pay_1")
+    #expect(statement.groups.first?.id == "grp_1")
+  }
+
+  @Test
+  func decodesBillingStatementGroupWhenIdIsMissing() throws {
+    let json = """
+    {
+      "object": "commerce_statement",
+      "id": "stmt_1",
+      "status": "open",
+      "timestamp": 1700000000000,
+      "totals": {
+        "subtotal": \(moneyJSON),
+        "grand_total": \(moneyJSON),
+        "tax_total": \(moneyJSON)
+      },
+      "groups": [
+        {
+          "timestamp": 1700000000000,
+          "items": [\(paymentJSON)]
+        }
+      ]
+    }
+    """
+    let statement = try decoder.decode(BillingStatement.self, from: Data(json.utf8))
+    #expect(statement.groups.count == 1)
+    #expect(statement.groups.first?.id == nil)
+    #expect(statement.groups.first?.items.first?.id == "pay_1")
+  }
+
+  @Test
+  func decodesBillingPaymentWhenNestedSubscriptionItemOmitsCreatedAt() throws {
+    let stripped = paymentJSON
+      .replacingOccurrences(of: "\"created_at\": 1700000000000,", with: "")
+      .replacingOccurrences(of: "\"period_start\": 1700000000000,", with: "")
+    let payment = try decoder.decode(BillingPayment.self, from: Data(stripped.utf8))
+    #expect(payment.id == "pay_1")
+    #expect(payment.subscriptionItem.id == "si_1")
+    #expect(payment.status == .paid)
   }
 
   @Test

--- a/Tests/Domains/Billing/BillingTests.swift
+++ b/Tests/Domains/Billing/BillingTests.swift
@@ -323,14 +323,26 @@ struct BillingTests {
   @Test
   func decodesBillingPaymentWhenNestedSubscriptionItemOmitsCreatedAt() throws {
     let stripped = paymentJSON
+      .replacingOccurrences(of: "\"price_id\": \"price_1\",", with: "")
       .replacingOccurrences(of: "\"created_at\": 1700000000000,", with: "")
       .replacingOccurrences(of: "\"period_start\": 1700000000000,", with: "")
     let payment = try decoder.decode(BillingPayment.self, from: Data(stripped.utf8))
     #expect(payment.id == "pay_1")
     #expect(payment.subscriptionItem.id == "si_1")
+    #expect(payment.subscriptionItem.priceId == nil)
     #expect(payment.subscriptionItem.createdAt == nil)
     #expect(payment.subscriptionItem.periodStart == nil)
     #expect(payment.status == .paid)
+  }
+
+  @Test
+  func decodesBillingPaymentWhenNestedSubscriptionItemSendsEpochTimestamps() throws {
+    let epoch = paymentJSON
+      .replacingOccurrences(of: "\"created_at\": 1700000000000,", with: "\"created_at\": 0,")
+      .replacingOccurrences(of: "\"period_start\": 1700000000000,", with: "\"period_start\": 0,")
+    let payment = try decoder.decode(BillingPayment.self, from: Data(epoch.utf8))
+    #expect(payment.subscriptionItem.createdAt == nil)
+    #expect(payment.subscriptionItem.periodStart == nil)
   }
 
   @Test

--- a/Tests/Domains/Billing/BillingTests.swift
+++ b/Tests/Domains/Billing/BillingTests.swift
@@ -283,6 +283,14 @@ struct BillingTests {
   }
 
   @Test
+  func decodesBillingSubscriptionWhenActiveAtIsNull() throws {
+    let json = subscriptionJSON.replacingOccurrences(of: "\"active_at\": 1700000000000", with: "\"active_at\": null")
+    let subscription = try decoder.decode(BillingSubscription.self, from: Data(json.utf8))
+    #expect(subscription.activeAt == nil)
+    #expect(subscription.status == .active)
+  }
+
+  @Test
   func decodesBillingStatementWithTotals() throws {
     let statement = try decoder.decode(BillingStatement.self, from: Data(statementJSON.utf8))
     #expect(statement.status == .open)

--- a/Tests/Domains/Billing/BillingTests.swift
+++ b/Tests/Domains/Billing/BillingTests.swift
@@ -233,6 +233,14 @@ struct BillingTests {
   }
 
   @Test
+  func decodesBillingPlanUnitPriceTierWhenIdIsMissing() throws {
+    let stripped = planJSON.replacingOccurrences(of: "\"id\": \"tier_1\",", with: "")
+    let plan = try decoder.decode(BillingPlan.self, from: Data(stripped.utf8))
+    #expect(plan.unitPrices?.first?.tiers.first?.id == nil)
+    #expect(plan.unitPrices?.first?.tiers.first?.startsAtBlock == 1)
+  }
+
+  @Test
   func decodesBillingPlanDefaultsMissingFeaturesAndTrial() throws {
     let json = Data(
       """

--- a/Tests/Domains/Billing/BillingTests.swift
+++ b/Tests/Domains/Billing/BillingTests.swift
@@ -296,6 +296,22 @@ struct BillingTests {
   }
 
   @Test
+  func decodesUnknownBillingEnumValuesWithoutFailingTheResource() throws {
+    #expect(BillingSubscriptionStatus(rawValue: "canceled") == .unknown("canceled"))
+    #expect(BillingSubscriptionStatus(rawValue: "canceled").rawValue == "canceled")
+    #expect(BillingPaymentChargeType(rawValue: "price_transition") == .priceTransition)
+    #expect(BillingPaymentChargeType(rawValue: "future_charge").rawValue == "future_charge")
+
+    let unknownPaymentJSON = paymentJSON
+      .replacingOccurrences(of: "\"charge_type\": \"recurring\"", with: "\"charge_type\": \"price_transition\"")
+      .replacingOccurrences(of: "\"status\": \"paid\"", with: "\"status\": \"settled\"")
+    let payment = try decoder.decode(BillingPayment.self, from: Data(unknownPaymentJSON.utf8))
+    #expect(payment.chargeType == .priceTransition)
+    #expect(payment.status == .unknown("settled"))
+    #expect(payment.id == "pay_1")
+  }
+
+  @Test
   func decodesBillingPaymentMethod() throws {
     let method = try decoder.decode(BillingPaymentMethod.self, from: Data(paymentMethodJSON.utf8))
     #expect(method.id == "pm_1")

--- a/Tests/TestSupport/TestHelpers.swift
+++ b/Tests/TestSupport/TestHelpers.swift
@@ -63,6 +63,7 @@ func setupMockAPIClient() {
     passkeyService: PasskeyService(apiClient: mockAPIClient),
     biometricCredentialService: BiometricCredentialService(apiClient: mockAPIClient),
     organizationService: OrganizationService(apiClient: mockAPIClient),
+    billingService: BillingService(apiClient: mockAPIClient),
     environmentService: EnvironmentService(apiClient: mockAPIClient),
     emailAddressService: EmailAddressService(apiClient: mockAPIClient),
     phoneNumberService: PhoneNumberService(apiClient: mockAPIClient),


### PR DESCRIPTION
Apps can read Billing data from native iOS the same way they do from clerk-js `Clerk.billing`. Checkout and other writes stay out because of App Store rules.

`Clerk.shared.billing` ports every BillingNamespace GET. `User.getPaymentMethods` and `Organization.getPaymentMethods` cover the payer reads. Pagination is `initialPage` / `pageSize`, converted to FAPI `offset` / `limit` the way clerk-js does.

Stacked on #562 because environment `commerce_settings` is the feature flag for this API.

## What to focus on

- Envelope split. Plans and payment attempts decode the raw body. Subscription, statements, credits, and payment methods unwrap `ClientResponse`.
- Path prefixes. `/v1/billing/plans` is unscoped. Everything else is `/v1/me/billing/...` or `/v1/organizations/{id}/billing/...`.
- Missing write symbols. No `startCheckout`, `cancel`, `remove`, or `makeDefault`.

## Verification

- `make test` (BillingTests covers every GET, payer paths, pagination, Feature decode, and both envelope styles)

This PR is a read API. No screenshots or video.
