### PR TITLE
feat(session): add checkAuthorization and has for roles, features, and plans

### DIFF
--- a/Sources/ClerkKit/Domains/Auth/Session/Session.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/Session.swift
@@ -64,6 +64,11 @@ public struct Session: Codable, Identifiable, Equatable, Sendable {
   /// The last active token for the session.
   public var lastActiveToken: TokenResource?
 
+  /// Minutes since the last first- and second-factor verification: `[firstFactorAge, secondFactorAge]`.
+  ///
+  /// `-1` means that factor group is not enrolled. `nil` means the instance has not opted into factor verification age.
+  public var factorVerificationAge: [Int]?
+
   public init(
     id: String,
     status: SessionStatus,
@@ -78,7 +83,8 @@ public struct Session: Codable, Identifiable, Equatable, Sendable {
     createdAt: Date,
     updatedAt: Date,
     tasks: [Task]? = nil,
-    lastActiveToken: TokenResource? = nil
+    lastActiveToken: TokenResource? = nil,
+    factorVerificationAge: [Int]? = nil
   ) {
     self.id = id
     self.status = status
@@ -94,6 +100,7 @@ public struct Session: Codable, Identifiable, Equatable, Sendable {
     self.updatedAt = updatedAt
     self.tasks = tasks
     self.lastActiveToken = lastActiveToken
+    self.factorVerificationAge = factorVerificationAge
   }
 
   /// Represents the status of a session.

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionAuthorization.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionAuthorization.swift
@@ -1,0 +1,350 @@
+//
+//  SessionAuthorization.swift
+//
+
+import Foundation
+
+/// Parameters for ``Session/checkAuthorization(_:)`` and ``Session/has(_:)``.
+///
+/// Matches clerk-js `CheckAuthorizationParams`. The public TypeScript type treats role, permission,
+/// feature, and plan as mutually exclusive. The runtime combiner still ANDs every dimension that is
+/// present, including feature + plan.
+public struct CheckAuthorizationParams: Sendable, Equatable {
+  public var role: String?
+  public var permission: String?
+  public var feature: String?
+  public var plan: String?
+  public var reverification: ReverificationConfig?
+
+  public init(
+    role: String? = nil,
+    permission: String? = nil,
+    feature: String? = nil,
+    plan: String? = nil,
+    reverification: ReverificationConfig? = nil
+  ) {
+    self.role = role
+    self.permission = permission
+    self.feature = feature
+    self.plan = plan
+    self.reverification = reverification
+  }
+}
+
+/// Reverification requirement for ``Session/checkAuthorization(_:)``.
+///
+/// Matches clerk-js `ReverificationConfig`: presets `strict_mfa`, `strict`, `moderate`, `lax`, or a
+/// custom `{ level, afterMinutes }` object.
+public enum ReverificationConfig: Sendable, Equatable {
+  case strictMfa
+  case strict
+  case moderate
+  case lax
+  case custom(level: SessionVerification.Level, afterMinutes: Int)
+}
+
+extension Session {
+  /// Checks whether this session is authorized for the requested role, permission, feature, plan,
+  /// and/or reverification.
+  ///
+  /// Shares one implementation with ``has(_:)``. Returns `false` when the user is missing or any
+  /// requested dimension fails. Org role and permission come from the active organization
+  /// membership. Feature and plan come from the last active session token `fea` / `pla` claims.
+  public func checkAuthorization(_ params: CheckAuthorizationParams) -> Bool {
+    SessionAuthorization.evaluate(session: self, params: params)
+  }
+
+  /// Alias for ``checkAuthorization(_:)``. Matches the `useAuth().has` / `auth().has` name.
+  public func has(_ params: CheckAuthorizationParams) -> Bool {
+    checkAuthorization(params)
+  }
+}
+
+enum SessionAuthorization {
+  private enum CheckResult {
+    case pass
+    case fail
+    case skip
+  }
+
+  private static let orgScopes: Set<String> = ["o", "org", "organization"]
+  private static let userScopes: Set<String> = ["u", "user"]
+  private static let allowedLevels: Set<String> = ["first_factor", "second_factor", "multi_factor"]
+
+  static func evaluate(session: Session, params: CheckAuthorizationParams) -> Bool {
+    let membership = session.user?.organizationMemberships?.first {
+      $0.organization.id == session.lastActiveOrganizationId
+    }
+    return evaluate(
+      userId: session.user?.id,
+      orgId: membership?.organization.id,
+      orgRole: membership?.role,
+      orgPermissions: membership?.permissions,
+      factorVerificationAge: session.factorVerificationAge,
+      features: session.lastActiveToken?.featuresClaim ?? "",
+      plans: session.lastActiveToken?.plansClaim ?? "",
+      params: params
+    )
+  }
+
+  static func evaluate(
+    userId: String?,
+    orgId: String?,
+    orgRole: String?,
+    orgPermissions: [String]?,
+    factorVerificationAge: [Int]?,
+    features: String?,
+    plans: String?,
+    params: CheckAuthorizationParams
+  ) -> Bool {
+    guard let userId, !userId.isEmpty else {
+      return false
+    }
+
+    return combine([
+      checkOrgAuthorization(
+        role: params.role,
+        permission: params.permission,
+        orgId: orgId,
+        orgRole: orgRole,
+        orgPermissions: orgPermissions
+      ),
+      checkBillingAuthorization(
+        feature: params.feature,
+        plan: params.plan,
+        features: features,
+        plans: plans
+      ),
+      checkReverificationAuthorization(
+        reverification: params.reverification,
+        factorVerificationAge: factorVerificationAge
+      ),
+    ])
+  }
+
+  static func splitByScope(_ claim: String?) throws -> (org: [String], user: [String]) {
+    var org: [String] = []
+    var user: [String] = []
+
+    guard let claim, !claim.isEmpty else {
+      return (org, user)
+    }
+
+    for part in claim.split(separator: ",", omittingEmptySubsequences: false) {
+      let trimmed = part.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard let colonIndex = trimmed.firstIndex(of: ":") else {
+        throw SessionAuthorizationError.invalidClaimElement(trimmed)
+      }
+      let scope = String(trimmed[..<colonIndex])
+      let value = String(trimmed[trimmed.index(after: colonIndex)...])
+      switch scope {
+      case "o":
+        org.append(value)
+      case "u":
+        user.append(value)
+      case "ou", "uo":
+        org.append(value)
+        user.append(value)
+      default:
+        break
+      }
+    }
+
+    return (org, user)
+  }
+
+  private static func combine(_ results: [CheckResult]) -> Bool {
+    results.contains(.pass) && results.allSatisfy { $0 == .pass || $0 == .skip }
+  }
+
+  private static func prefixWithOrg(_ value: String) -> String {
+    let stripped = value.replacingOccurrences(of: "^(org:)*", with: "", options: .regularExpression)
+    return "org:\(stripped)"
+  }
+
+  private static func checkOrgAuthorization(
+    role: String?,
+    permission: String?,
+    orgId: String?,
+    orgRole: String?,
+    orgPermissions: [String]?
+  ) -> CheckResult {
+    let roleAsked = role != nil
+    let permissionAsked = permission != nil
+
+    if !roleAsked, !permissionAsked {
+      return .skip
+    }
+
+    guard let orgId, !orgId.isEmpty else {
+      return .fail
+    }
+
+    if roleAsked {
+      guard let role, let orgRole, !orgRole.isEmpty, prefixWithOrg(orgRole) == prefixWithOrg(role) else {
+        return .fail
+      }
+    }
+
+    if permissionAsked {
+      guard let permission, let orgPermissions, orgPermissions.contains(prefixWithOrg(permission)) else {
+        return .fail
+      }
+    }
+
+    return .pass
+  }
+
+  private static func checkBillingAuthorization(
+    feature: String?,
+    plan: String?,
+    features: String?,
+    plans: String?
+  ) -> CheckResult {
+    let featureAsked = feature != nil
+    let planAsked = plan != nil
+
+    if !featureAsked, !planAsked {
+      return .skip
+    }
+
+    if featureAsked {
+      guard let feature, let features, !features.isEmpty else {
+        return .fail
+      }
+      do {
+        if try !checkForFeatureOrPlan(claim: features, featureOrPlan: feature) {
+          return .fail
+        }
+      } catch {
+        return .fail
+      }
+    }
+
+    if planAsked {
+      guard let plan, let plans, !plans.isEmpty else {
+        return .fail
+      }
+      do {
+        if try !checkForFeatureOrPlan(claim: plans, featureOrPlan: plan) {
+          return .fail
+        }
+      } catch {
+        return .fail
+      }
+    }
+
+    return .pass
+  }
+
+  private static func checkForFeatureOrPlan(claim: String, featureOrPlan: String) throws -> Bool {
+    let split = try splitByScope(claim)
+    let parts = featureOrPlan.split(separator: ":", omittingEmptySubsequences: false)
+    let rawScope = String(parts[0])
+    let hasExplicitScope = parts.count > 1
+    let id = hasExplicitScope ? String(parts[1]) : rawScope
+
+    if hasExplicitScope, !orgScopes.contains(rawScope), !userScopes.contains(rawScope) {
+      throw SessionAuthorizationError.invalidScope(rawScope)
+    }
+
+    if hasExplicitScope {
+      if orgScopes.contains(rawScope) {
+        return split.org.contains(id)
+      }
+      if userScopes.contains(rawScope) {
+        return split.user.contains(id)
+      }
+    }
+
+    return (split.org + split.user).contains(id)
+  }
+
+  private static func checkReverificationAuthorization(
+    reverification: ReverificationConfig?,
+    factorVerificationAge: [Int]?
+  ) -> CheckResult {
+    guard let reverification else {
+      return .skip
+    }
+
+    guard let factorVerificationAge else {
+      return .fail
+    }
+
+    guard
+      factorVerificationAge.count == 2,
+      isValidFactorAge(factorVerificationAge[0]),
+      isValidFactorAge(factorVerificationAge[1])
+    else {
+      return .fail
+    }
+
+    guard let resolved = resolveReverification(reverification) else {
+      return .fail
+    }
+
+    let factor1Age = factorVerificationAge[0]
+    let factor2Age = factorVerificationAge[1]
+    let afterMinutes = resolved.afterMinutes
+
+    if factor1Age == -1, factor2Age == -1 {
+      return .fail
+    }
+
+    let factor1FreshEnough = factor1Age != -1 && afterMinutes > factor1Age
+    let factor2FreshEnough = factor2Age != -1 && afterMinutes > factor2Age
+
+    switch resolved.level {
+    case .firstFactor:
+      return factor1FreshEnough ? .pass : .fail
+    case .secondFactor:
+      if factor2Age == -1 {
+        return factor1FreshEnough ? .pass : .fail
+      }
+      if factor1Age == -1 {
+        return factor2FreshEnough ? .pass : .fail
+      }
+      return factor2FreshEnough ? .pass : .fail
+    case .multiFactor:
+      if factor2Age == -1 {
+        return factor1FreshEnough ? .pass : .fail
+      }
+      if factor1Age == -1 {
+        return .fail
+      }
+      return factor1FreshEnough && factor2FreshEnough ? .pass : .fail
+    case .unknown:
+      return .fail
+    }
+  }
+
+  private static func resolveReverification(
+    _ config: ReverificationConfig
+  ) -> (level: SessionVerification.Level, afterMinutes: Int)? {
+    switch config {
+    case .strictMfa:
+      return (.multiFactor, 10)
+    case .strict:
+      return (.secondFactor, 10)
+    case .moderate:
+      return (.secondFactor, 60)
+    case .lax:
+      return (.secondFactor, 1440)
+    case .custom(let level, let afterMinutes):
+      guard allowedLevels.contains(level.rawValue), afterMinutes > 0 else {
+        return nil
+      }
+      return (level, afterMinutes)
+    }
+  }
+
+  private static func isValidFactorAge(_ value: Int) -> Bool {
+    value == -1 || value >= 0
+  }
+}
+
+private enum SessionAuthorizationError: Error {
+  case invalidClaimElement(String)
+  case invalidScope(String)
+}

--- a/Sources/ClerkKit/Domains/Auth/TokenResource.swift
+++ b/Sources/ClerkKit/Domains/Auth/TokenResource.swift
@@ -28,4 +28,14 @@ extension TokenResource {
       return nil
     }
   }
+
+  /// Session token `fea` claim used by ``Session/has(_:)`` and ``Session/checkAuthorization(_:)``.
+  var featuresClaim: String {
+    decodedJWT?.claim(name: "fea").string ?? ""
+  }
+
+  /// Session token `pla` claim used by ``Session/has(_:)`` and ``Session/checkAuthorization(_:)``.
+  var plansClaim: String {
+    decodedJWT?.claim(name: "pla").string ?? ""
+  }
 }

--- a/Tests/Domains/Auth/Session/SessionAuthorizationTests.swift
+++ b/Tests/Domains/Auth/Session/SessionAuthorizationTests.swift
@@ -1,0 +1,377 @@
+@testable import ClerkKit
+import Foundation
+import Testing
+
+struct SessionAuthorizationTests {
+  @Test
+  func checkAuthorizationAndHasShareOneImplementation() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_memberships:read"],
+      features: "o:reservations,u:dashboard",
+      plans: "u:plus"
+    )
+
+    let params = CheckAuthorizationParams(plan: "plus")
+    #expect(session.has(params) == session.checkAuthorization(params))
+    #expect(session.has(params) == true)
+    #expect(session.has(.init(plan: "missing")) == session.checkAuthorization(.init(plan: "missing")))
+    #expect(session.has(.init(plan: "missing")) == false)
+  }
+
+  @Test
+  func decodesFactorVerificationAge() throws {
+    let json = """
+    {
+      "id": "sess_1",
+      "status": "active",
+      "expire_at": 1000,
+      "abandon_at": 1000,
+      "last_active_at": 1000,
+      "created_at": 1000,
+      "updated_at": 1000,
+      "factor_verification_age": [5, 10]
+    }
+    """
+    let session = try JSONDecoder.clerkDecoder.decode(Session.self, from: Data(json.utf8))
+    #expect(session.factorVerificationAge == [5, 10])
+  }
+
+  @Test
+  func missingFactorVerificationAgeDecodesAsNil() throws {
+    let json = """
+    {
+      "id": "sess_1",
+      "status": "active",
+      "expire_at": 1000,
+      "abandon_at": 1000,
+      "last_active_at": 1000,
+      "created_at": 1000,
+      "updated_at": 1000
+    }
+    """
+    let session = try JSONDecoder.clerkDecoder.decode(Session.self, from: Data(json.utf8))
+    #expect(session.factorVerificationAge == nil)
+  }
+
+  @Test
+  func parsesFeaturesByScope() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "admin",
+      orgPermissions: ["org:read"],
+      features: "o:reservations,u:dashboard"
+    )
+
+    #expect(session.has(.init(feature: "o:reservations")))
+    #expect(session.has(.init(feature: "org:reservations")))
+    #expect(session.has(.init(feature: "organization:reservations")))
+    #expect(session.has(.init(feature: "reservations")))
+    #expect(session.has(.init(feature: "u:dashboard")))
+    #expect(session.has(.init(feature: "user:dashboard")))
+    #expect(session.has(.init(feature: "dashboard")))
+    #expect(!session.has(.init(feature: "lol:dashboard")))
+  }
+
+  @Test
+  func failsWhenNoDimensionWasRequested() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_profile:delete"],
+      features: "o:premium",
+      plans: "plus"
+    )
+    #expect(!session.has(.init()))
+  }
+
+  @Test
+  func failsPermissionAndRoleWhenOrgContextIsMissing() {
+    let session = makeSession(orgId: nil, features: "", plans: "")
+    #expect(!session.has(.init(permission: "org:sys_profile:delete", reverification: .strict)))
+    #expect(!session.has(.init(role: "org:admin", reverification: .strict)))
+  }
+
+  @Test
+  func failsReverificationWhenFactorVerificationAgeIsNil() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_profile:delete"],
+      factorVerificationAge: nil
+    )
+    #expect(!session.has(.init(permission: "org:sys_profile:delete", reverification: .strict)))
+  }
+
+  @Test
+  func failsWhenFactorVerificationAgePayloadIsMalformed() {
+    let session = makeSession(factorVerificationAge: [0])
+    #expect(!session.has(.init(reverification: .strictMfa)))
+  }
+
+  @Test
+  func requiresAndAcrossBillingAndOrg() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_memberships:read"],
+      features: "o:reservations"
+    )
+    #expect(!session.has(.init(permission: "org:sys_profile:delete", feature: "org:reservations")))
+    #expect(session.has(.init(permission: "org:sys_memberships:read", feature: "org:reservations")))
+  }
+
+  @Test
+  func requiresAndWithinOrgWhenRoleAndPermissionAreRequested() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_memberships:read"]
+    )
+    #expect(!session.has(.init(role: "org:admin", permission: "org:sys_profile:delete")))
+    #expect(session.has(.init(role: "org:admin", permission: "org:sys_memberships:read")))
+    #expect(!session.has(.init(role: "org:member", permission: "org:sys_memberships:read")))
+  }
+
+  @Test
+  func requiresAndWithinBillingWhenFeatureAndPlanAreRequested() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:read"],
+      features: "o:reservations",
+      plans: "u:plus"
+    )
+    #expect(session.has(.init(feature: "org:reservations", plan: "u:plus")))
+    #expect(!session.has(.init(feature: "org:reservations", plan: "u:free")))
+    #expect(!session.has(.init(feature: "org:missing", plan: "u:plus")))
+  }
+
+  @Test
+  func failsFeatureCheckWhenFeaturesClaimIsMissingOrEmpty() {
+    let session = makeSession(orgId: "org_123", orgRole: "org:admin", orgPermissions: ["org:read"], features: "")
+    #expect(!session.has(.init(feature: "org:premium")))
+  }
+
+  @Test
+  func failsWhenTokenClaimsAreMissing() {
+    var session = Session.mock
+    session.user = user(id: "user_123", orgId: "org_123", role: "org:admin", permissions: ["org:read"])
+    session.lastActiveOrganizationId = "org_123"
+    session.lastActiveToken = nil
+    #expect(!session.has(.init(feature: "reservations")))
+    #expect(!session.has(.init(plan: "plus")))
+  }
+
+  @Test
+  func requiresAndAcrossOrgAndBillingCombos() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_memberships:read"],
+      features: "o:reservations",
+      plans: "u:plus"
+    )
+    #expect(!session.has(.init(role: "org:admin", feature: "org:missing")))
+    #expect(!session.has(.init(role: "org:admin", plan: "u:free")))
+    #expect(session.has(.init(role: "org:admin", feature: "org:reservations")))
+  }
+
+  @Test
+  func failsMissingFeaturesWhenReverificationWouldPass() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_profile:delete"],
+      features: ""
+    )
+    #expect(!session.has(.init(feature: "org:premium", reverification: .strict)))
+  }
+
+  @Test
+  func authorizesPermissionPlusReverificationWhenBothMatch() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_memberships:read"]
+    )
+    #expect(session.has(.init(permission: "org:sys_memberships:read", reverification: .strict)))
+  }
+
+  @Test
+  func authorizesEveryRequestedDimensionWhenAllThreeMatch() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_memberships:read"],
+      features: "o:reservations"
+    )
+    #expect(
+      session.has(
+        .init(
+          permission: "org:sys_memberships:read",
+          feature: "org:reservations",
+          reverification: .strict
+        )
+      )
+    )
+  }
+
+  @Test
+  func authorizesStrictMfaViaGracefulDowngradeWhenNoSecondFactorIsEnrolled() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_memberships:read"],
+      factorVerificationAge: [0, -1]
+    )
+    #expect(session.has(.init(permission: "org:sys_memberships:read", reverification: .strictMfa)))
+  }
+
+  @Test
+  func failsPermissionPlusReverificationWhenNoFactorsAreEnrolled() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_memberships:read"],
+      factorVerificationAge: [-1, -1]
+    )
+    #expect(!session.has(.init(permission: "org:sys_memberships:read", reverification: .strict)))
+  }
+
+  @Test
+  func failsReverificationWhenConfigObjectIsIncompleteOrOutOfRange() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_profile:delete"]
+    )
+    #expect(!session.has(.init(reverification: .custom(level: .multiFactor, afterMinutes: 0))))
+    #expect(!session.has(.init(reverification: .custom(level: .multiFactor, afterMinutes: -1))))
+    #expect(!session.has(.init(reverification: .custom(level: .unknown("nope"), afterMinutes: 10))))
+  }
+
+  @Test
+  func failsClosedWithoutUserId() {
+    var session = makeSession(features: "u:dashboard", plans: "u:plus")
+    session.user = nil
+    #expect(!session.has(.init(feature: "dashboard")))
+    #expect(!session.has(.init(plan: "plus")))
+    #expect(!session.has(.init(reverification: .strict)))
+  }
+
+  @Test
+  func splitsFeaturesByScopeIncludingMergedOuAndUo() throws {
+    let split = try SessionAuthorization.splitByScope("o:reservations,u:dashboard,ou:support-chat,uo:billing")
+    #expect(split.org == ["reservations", "support-chat", "billing"])
+    #expect(split.user == ["dashboard", "support-chat", "billing"])
+  }
+
+  @Test
+  func splitByScopeThrowsWhenClaimElementIsMissingAColon() {
+    #expect(throws: Error.self) {
+      try SessionAuthorization.splitByScope("reservations,dashboard")
+    }
+  }
+
+  @Test
+  func unscopedFeatureMatchesMergedUserAndOrgIds() {
+    let session = makeSession(orgId: "org_123", orgRole: "org:admin", features: "o:reservations,u:dashboard")
+    #expect(session.has(.init(feature: "reservations")))
+    #expect(session.has(.init(feature: "dashboard")))
+    #expect(!session.has(.init(feature: "missing")))
+  }
+
+  @Test
+  func orgScopedFeatureFailsWithoutActiveOrgClaim() {
+    let session = makeSession(orgId: nil, features: "u:dashboard")
+    #expect(!session.has(.init(feature: "o:dashboard")))
+    #expect(session.has(.init(feature: "u:dashboard")))
+  }
+
+  @Test
+  func roleCheckPrefixesOrg() {
+    let session = makeSession(orgId: "org_123", orgRole: "admin", orgPermissions: ["org:sys_memberships:read"])
+    #expect(session.has(.init(role: "org:admin")))
+    #expect(session.has(.init(role: "admin")))
+    #expect(!session.has(.init(role: "org:member")))
+  }
+
+  @Test
+  func readsFeaAndPlaFromLastActiveToken() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      features: "o:sso,u:dashboard",
+      plans: "u:pro"
+    )
+    #expect(session.has(.init(feature: "sso")))
+    #expect(session.has(.init(plan: "pro")))
+    #expect(!session.has(.init(feature: "missing")))
+    #expect(!session.has(.init(plan: "free")))
+  }
+}
+
+private func makeSession(
+  userId: String = "user_123",
+  orgId: String? = nil,
+  orgRole: String? = nil,
+  orgPermissions: [String]? = nil,
+  features: String? = nil,
+  plans: String? = nil,
+  factorVerificationAge: [Int]? = [0, 0]
+) -> Session {
+  var session = Session.mock
+  session.user = user(id: userId, orgId: orgId, role: orgRole, permissions: orgPermissions)
+  session.lastActiveOrganizationId = orgId
+  session.factorVerificationAge = factorVerificationAge
+  if features != nil || plans != nil {
+    session.lastActiveToken = TokenResource(jwt: jwtWithClaims(fea: features, pla: plans))
+  }
+  return session
+}
+
+private func user(
+  id: String,
+  orgId: String?,
+  role: String?,
+  permissions: [String]?
+) -> User {
+  var user = User.mock
+  user.id = id
+  if let orgId {
+    var membership = OrganizationMembership.mockWithUserData
+    membership.role = role ?? "org:member"
+    membership.permissions = permissions
+    var organization = membership.organization
+    organization.id = orgId
+    membership.organization = organization
+    user.organizationMemberships = [membership]
+  } else {
+    user.organizationMemberships = []
+  }
+  return user
+}
+
+private func jwtWithClaims(fea: String?, pla: String?) -> String {
+  var payload: [String: String] = [:]
+  if let fea {
+    payload["fea"] = fea
+  }
+  if let pla {
+    payload["pla"] = pla
+  }
+  return encodeJWT(payload: payload)
+}
+
+private func encodeJWT(payload: [String: String]) -> String {
+  func encode(_ object: [String: String]) -> String {
+    let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    return data.base64EncodedString()
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .trimmingCharacters(in: CharacterSet(charactersIn: "="))
+  }
+  return "\(encode(["alg": "none", "typ": "JWT"])).\(encode(payload)).sig"
+}

--- a/Tests/Domains/Auth/Session/SessionAuthorizationTests.swift
+++ b/Tests/Domains/Auth/Session/SessionAuthorizationTests.swift
@@ -311,6 +311,30 @@ struct SessionAuthorizationTests {
     #expect(!session.has(.init(feature: "missing")))
     #expect(!session.has(.init(plan: "free")))
   }
+
+  @Test
+  func hasOnCachedTokenStaysUnderOneMillisecond() {
+    let session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_memberships:read"],
+      features: "o:reservations,u:dashboard",
+      plans: "u:plus"
+    )
+    let params = CheckAuthorizationParams(plan: "plus")
+    _ = session.has(params)
+
+    var samples: [Double] = []
+    samples.reserveCapacity(1000)
+    for _ in 0 ..< 1000 {
+      let start = CFAbsoluteTimeGetCurrent()
+      _ = session.has(params)
+      samples.append((CFAbsoluteTimeGetCurrent() - start) * 1000)
+    }
+    samples.sort()
+    let p95 = samples[949]
+    #expect(p95 < 1.0)
+  }
 }
 
 private func makeSession(


### PR DESCRIPTION
A signed-in user on a paid plan can now ask the session whether they have that plan, the same way clerk-js does with `session.checkAuthorization` and `useAuth().has`.

`Session.checkAuthorization` and `Session.has` share one implementation. Role and permission come from the active organization membership. Feature and plan come from the last active token `fea` / `pla` claims. Reverification uses `factorVerificationAge`, which now decodes on Session.

Stacked on #563 because billing reads and session plan checks belong to the same Billing program.

## What to focus on

- Fail-closed combiner. Org, billing, and reverification AND together. Empty params return false. Missing userId returns false.
- Claim scopes. `o`/`org`/`organization`, `u`/`user`, unscoped merge, `ou`/`uo` in the claim. Invalid scope (`lol:dashboard`) is false.
- No static `Session.has`. Instance methods only.

## Verification

- `make test` (SessionAuthorizationTests covers role, permission, feature, plan, reverification, scopes, merged ids, invalid scope, missing claims)

## Proof

`session.has(plan:)` gates Priority support. The recording signs out, creates a free session, then taps Unlock plus. The row stays locked until that tap. Then `has(plus)` is true and Priority support is included.

Checkout is not in the SDK. The test-card call is a local harness only.

https://github.com/user-attachments/assets/4578c095-f4fa-43ac-99fa-a02b8ffd29f5
