### PR TITLE
Add UserDefaults privacy manifests

### DIFF
--- a/Sources/ClerkKit/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/ClerkKit/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array>
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>CA92.1</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/Sources/ClerkKitUI/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/ClerkKitUI/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array>
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>CA92.1</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/Tests/Utils/PrivacyManifestTests.swift
+++ b/Tests/Utils/PrivacyManifestTests.swift
@@ -1,0 +1,29 @@
+//
+//  PrivacyManifestTests.swift
+//
+
+import Foundation
+import Testing
+
+struct PrivacyManifestTests {
+  @Test(arguments: ["ClerkKit", "ClerkKitUI"])
+  func bundledManifestDeclaresUserDefaults(target: String) throws {
+    // SwiftPM places the SDK resource bundles alongside the test resource bundle.
+    let bundleURL = Bundle.module.bundleURL
+      .deletingLastPathComponent()
+      .appendingPathComponent("Clerk_\(target).bundle")
+    let bundle = try #require(Bundle(url: bundleURL))
+    let manifestURL = try #require(bundle.url(forResource: "PrivacyInfo", withExtension: "xcprivacy"))
+    let data = try Data(contentsOf: manifestURL)
+    let manifest = try #require(
+      PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+    )
+    let accessedAPIs = try #require(manifest["NSPrivacyAccessedAPITypes"] as? [[String: Any]])
+    let userDefaults = try #require(accessedAPIs.first {
+      $0["NSPrivacyAccessedAPIType"] as? String == "NSPrivacyAccessedAPICategoryUserDefaults"
+    })
+    let reasons = try #require(userDefaults["NSPrivacyAccessedAPITypeReasons"] as? [String])
+
+    #expect(reasons == ["CA92.1"])
+  }
+}


### PR DESCRIPTION
Declare UserDefaults access with reason CA92.1 in ClerkKit and ClerkKitUI. Add tests verifying both resource bundles include the expected privacy declaration.