### PR TITLE
fix(session): fail closed on mismatched has() tokens

### DIFF
--- a/Sources/ClerkKit/Domains/Auth/Session/SessionAuthorization.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionAuthorization.swift
@@ -47,9 +47,10 @@ extension Session {
   /// Checks whether this session is authorized for the requested role, permission, feature, plan,
   /// and/or reverification.
   ///
-  /// Shares one implementation with ``has(_:)``. Returns `false` when the user is missing or any
-  /// requested dimension fails. Org role and permission come from the active organization
-  /// membership. Feature and plan come from the last active session token `fea` / `pla` claims.
+  /// Returns `false` when the user is missing or any requested dimension fails. Org role and
+  /// permission come from the active organization membership. Feature and plan come from a token
+  /// whose session and organization match this session. Reverification uses that token's `fva`
+  /// claim when present.
   public func checkAuthorization(_ params: CheckAuthorizationParams) -> Bool {
     SessionAuthorization.evaluate(session: self, params: params)
   }
@@ -75,14 +76,16 @@ enum SessionAuthorization {
     let membership = session.user?.organizationMemberships?.first {
       $0.organization.id == session.lastActiveOrganizationId
     }
+    let token = authorizationToken(for: session)
     return evaluate(
       userId: session.user?.id,
       orgId: membership?.organization.id,
       orgRole: membership?.role,
       orgPermissions: membership?.permissions,
-      factorVerificationAge: session.factorVerificationAge,
-      features: session.lastActiveToken?.featuresClaim ?? "",
-      plans: session.lastActiveToken?.plansClaim ?? "",
+      factorVerificationAge: token.flatMap { agedFactorVerificationAge(for: $0) }
+        ?? session.factorVerificationAge,
+      features: token?.featuresClaim ?? "",
+      plans: token?.plansClaim ?? "",
       params: params
     )
   }
@@ -341,6 +344,52 @@ enum SessionAuthorization {
 
   private static func isValidFactorAge(_ value: Int) -> Bool {
     value == -1 || value >= 0
+  }
+
+  private static func authorizationToken(for session: Session) -> TokenResource? {
+    guard let token = session.lastActiveToken else {
+      return nil
+    }
+    guard matchesAuthorizationContext(
+      token,
+      sessionId: session.id,
+      organizationId: session.lastActiveOrganizationId
+    ) else {
+      return nil
+    }
+    return token
+  }
+
+  private static func matchesAuthorizationContext(
+    _ token: TokenResource,
+    sessionId: String,
+    organizationId: String?
+  ) -> Bool {
+    guard let jwt = try? DecodedJWT(jwt: token.jwt), let tokenSessionId = jwt.sessionId else {
+      return false
+    }
+    return tokenSessionId == sessionId
+      && TokenFreshness.normalizedOrganizationId(jwt.organizationId)
+      == TokenFreshness.normalizedOrganizationId(organizationId)
+  }
+
+  private static func agedFactorVerificationAge(
+    for token: TokenResource,
+    now: Date = Date()
+  ) -> [Int]? {
+    guard let factorVerificationAge = token.factorVerificationAgeClaim else {
+      return nil
+    }
+    guard let issuedAt = token.decodedJWT?.issuedAt else {
+      return factorVerificationAge
+    }
+    let elapsedMinutes = Int(max(0, now.timeIntervalSince(issuedAt)) / 60)
+    guard elapsedMinutes > 0 else {
+      return factorVerificationAge
+    }
+    return factorVerificationAge.map { age in
+      age >= 0 ? age + elapsedMinutes : age
+    }
   }
 }
 

--- a/Sources/ClerkKit/Domains/Auth/Session/SessionAuthorization.swift
+++ b/Sources/ClerkKit/Domains/Auth/Session/SessionAuthorization.swift
@@ -82,8 +82,10 @@ enum SessionAuthorization {
       orgId: membership?.organization.id,
       orgRole: membership?.role,
       orgPermissions: membership?.permissions,
-      factorVerificationAge: token.flatMap { agedFactorVerificationAge(for: $0) }
-        ?? session.factorVerificationAge,
+      factorVerificationAge: agedFactorVerificationAge(
+        for: token,
+        snapshot: session.factorVerificationAge
+      ),
       features: token?.featuresClaim ?? "",
       plans: token?.plansClaim ?? "",
       params: params
@@ -374,13 +376,14 @@ enum SessionAuthorization {
   }
 
   private static func agedFactorVerificationAge(
-    for token: TokenResource,
+    for token: TokenResource?,
+    snapshot: [Int]?,
     now: Date = Date()
   ) -> [Int]? {
-    guard let factorVerificationAge = token.factorVerificationAgeClaim else {
-      return nil
+    guard let factorVerificationAge = token?.factorVerificationAgeClaim ?? snapshot else {
+      return snapshot
     }
-    guard let issuedAt = token.decodedJWT?.issuedAt else {
+    guard let issuedAt = token?.decodedJWT?.issuedAt else {
       return factorVerificationAge
     }
     let elapsedMinutes = Int(max(0, now.timeIntervalSince(issuedAt)) / 60)

--- a/Sources/ClerkKit/Domains/Auth/TokenResource.swift
+++ b/Sources/ClerkKit/Domains/Auth/TokenResource.swift
@@ -38,4 +38,17 @@ extension TokenResource {
   var plansClaim: String {
     decodedJWT?.claim(name: "pla").string ?? ""
   }
+
+  var factorVerificationAgeClaim: [Int]? {
+    guard let raw = decodedJWT?.body["fva"] else {
+      return nil
+    }
+    if let values = raw as? [Int], values.count == 2 {
+      return values
+    }
+    if let values = raw as? [NSNumber], values.count == 2 {
+      return values.map(\.intValue)
+    }
+    return nil
+  }
 }

--- a/Tests/Domains/Auth/Session/SessionAuthorizationTests.swift
+++ b/Tests/Domains/Auth/Session/SessionAuthorizationTests.swift
@@ -353,6 +353,25 @@ struct SessionAuthorizationTests {
   }
 
   @Test
+  func failsStrictWhenMatchingTokenWithoutFvaAgesTheSessionSnapshot() {
+    var session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_memberships:read"],
+      factorVerificationAge: [0, 0]
+    )
+    session.lastActiveToken = TokenResource(
+      jwt: jwtWithClaims(
+        sid: session.id,
+        orgId: "org_123",
+        issuedAt: Int(Date().timeIntervalSince1970) - 11 * 60
+      )
+    )
+
+    #expect(!session.has(.init(reverification: .strict)))
+  }
+
+  @Test
   func failsStrictWhenMatchingTokenFvaAgesPastTenMinutesWithoutClientRefresh() {
     var session = makeSession(
       orgId: "org_123",

--- a/Tests/Domains/Auth/Session/SessionAuthorizationTests.swift
+++ b/Tests/Domains/Auth/Session/SessionAuthorizationTests.swift
@@ -335,6 +335,42 @@ struct SessionAuthorizationTests {
     let p95 = samples[949]
     #expect(p95 < 1.0)
   }
+
+  @Test
+  func failsOrgScopedFeatureWhenSnapshotTokenBelongsToAnotherOrganization() {
+    var session = makeSession(
+      orgId: "org_b",
+      orgRole: "org:admin",
+      orgPermissions: ["org:read"],
+      features: "o:feature_b"
+    )
+    session.lastActiveToken = TokenResource(
+      jwt: jwtWithClaims(sid: session.id, orgId: "org_a", fea: "o:feature_a")
+    )
+
+    #expect(!session.has(.init(feature: "o:feature_a")))
+    #expect(!session.has(.init(feature: "o:feature_b")))
+  }
+
+  @Test
+  func failsStrictWhenMatchingTokenFvaAgesPastTenMinutesWithoutClientRefresh() {
+    var session = makeSession(
+      orgId: "org_123",
+      orgRole: "org:admin",
+      orgPermissions: ["org:sys_memberships:read"],
+      factorVerificationAge: [0, 0]
+    )
+    session.lastActiveToken = TokenResource(
+      jwt: jwtWithClaims(
+        sid: session.id,
+        orgId: "org_123",
+        fva: [0, 0],
+        issuedAt: Int(Date().timeIntervalSince1970) - 11 * 60
+      )
+    )
+
+    #expect(!session.has(.init(reverification: .strict)))
+  }
 }
 
 private func makeSession(
@@ -351,7 +387,9 @@ private func makeSession(
   session.lastActiveOrganizationId = orgId
   session.factorVerificationAge = factorVerificationAge
   if features != nil || plans != nil {
-    session.lastActiveToken = TokenResource(jwt: jwtWithClaims(fea: features, pla: plans))
+    session.lastActiveToken = TokenResource(
+      jwt: jwtWithClaims(sid: session.id, orgId: orgId, fea: features, pla: plans)
+    )
   }
   return session
 }
@@ -378,24 +416,29 @@ private func user(
   return user
 }
 
-private func jwtWithClaims(fea: String?, pla: String?) -> String {
-  var payload: [String: String] = [:]
+private func jwtWithClaims(
+  sid: String,
+  orgId: String? = nil,
+  fea: String? = nil,
+  pla: String? = nil,
+  fva: [Int]? = nil,
+  issuedAt: Int? = nil
+) -> String {
+  var claims: [String: Any] = ["sid": sid]
+  if let orgId {
+    claims["org_id"] = orgId
+  }
   if let fea {
-    payload["fea"] = fea
+    claims["fea"] = fea
   }
   if let pla {
-    payload["pla"] = pla
+    claims["pla"] = pla
   }
-  return encodeJWT(payload: payload)
-}
-
-private func encodeJWT(payload: [String: String]) -> String {
-  func encode(_ object: [String: String]) -> String {
-    let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
-    return data.base64EncodedString()
-      .replacingOccurrences(of: "+", with: "-")
-      .replacingOccurrences(of: "/", with: "_")
-      .trimmingCharacters(in: CharacterSet(charactersIn: "="))
+  if let fva {
+    claims["fva"] = fva
   }
-  return "\(encode(["alg": "none", "typ": "JWT"])).\(encode(payload)).sig"
+  if let issuedAt {
+    claims["iat"] = issuedAt
+  }
+  return try! testJWT(claims: claims)
 }

--- a/Tests/Integration/SessionAuthorizationIntegrationTests.swift
+++ b/Tests/Integration/SessionAuthorizationIntegrationTests.swift
@@ -1,0 +1,159 @@
+//
+//  SessionAuthorizationIntegrationTests.swift
+//  Clerk
+//
+
+@testable import ClerkKit
+import Foundation
+import Testing
+
+/// Live `has()` coverage against the with-billing instance.
+///
+/// Lane 4 (`o:<slug>`) asserts true only when `free_org` has a feature. Until that
+/// plan carries a feature, the test still signs in, creates an org, and prints
+/// `LIVE_HAS orgFeature` so the restamp can see the miss.
+@MainActor
+@Suite(.serialized)
+struct SessionAuthorizationIntegrationTests {
+  private static let testPassword = "Clerk_iOS_Test_2025_XyZ9#mK2$pL7"
+  private static let testVerificationCode = "424242"
+
+  @Test
+  func signedInHasMatchesSubscriptionAndPlans() async throws {
+    let keyName = "with-billing"
+    guard try configureClerkForIntegrationTesting(keyName: keyName) else {
+      return
+    }
+
+    let testEmail = Self.makeUniqueTestEmail()
+    var capturedError: Error?
+    var didCreateSignUp = false
+    var createdOrg: Organization?
+
+    do {
+      let signUp = try await Clerk.shared.auth.signUp(emailAddress: testEmail, password: Self.testPassword)
+      didCreateSignUp = true
+      let prepared = try await signUp.sendEmailCode()
+      try await prepared.verifyEmailCode(Self.testVerificationCode)
+
+      guard let session = Clerk.shared.session else {
+        throw IntegrationSessionAuthorizationError.missingSession("after sign up")
+      }
+
+      let plans = try await Clerk.shared.billing.getPlans(params: .init(for: .user))
+      let subscription = try await Clerk.shared.billing.getSubscription(params: .init())
+      let subscribedSlugs = Set(subscription.subscriptionItems.map(\.plan.slug))
+
+      print("LIVE_HAS session=\(session.id)")
+      print("LIVE_HAS subscriptionStatus=\(subscription.status)")
+      print("LIVE_HAS subscribedSlugs=\(subscribedSlugs.sorted())")
+      print("LIVE_HAS planSlugs=\(plans.data.map(\.slug))")
+
+      #expect(session.has(.init()) == false)
+      #expect(session.has(.init(plan: "plus")) == session.checkAuthorization(.init(plan: "plus")))
+
+      for plan in plans.data {
+        let hasPlan = session.has(.init(plan: plan.slug))
+        let subscribed = subscribedSlugs.contains(plan.slug)
+        print("LIVE_HAS plan=\(plan.slug) has=\(hasPlan) subscribed=\(subscribed)")
+        if subscribed {
+          #expect(hasPlan)
+        }
+        for feature in plan.features {
+          let hasFeature = session.has(.init(feature: feature.slug))
+          print("LIVE_HAS feature=\(feature.slug) has=\(hasFeature) plan=\(plan.slug)")
+        }
+      }
+
+      #expect(session.has(.init(plan: "missing-plan-slug-for-live")) == false)
+      #expect(session.has(.init(feature: "lol:dashboard")) == false)
+
+      let noOrgFeature = session.has(.init(feature: "o:feature_one"))
+      print("LIVE_HAS noActiveOrg o:feature_one=\(noOrgFeature)")
+      #expect(noOrgFeature == false)
+
+      _ = try await Clerk.shared.auth.getToken(.init(skipCache: true))
+      guard let refreshed = Clerk.shared.session else {
+        throw IntegrationSessionAuthorizationError.missingSession("after getToken")
+      }
+      let hasFreeAfterRefresh = refreshed.has(.init(plan: "free_user"))
+      print("LIVE_HAS afterGetToken plan=free_user has=\(hasFreeAfterRefresh)")
+      #expect(hasFreeAfterRefresh)
+
+      let orgPlans = try await Clerk.shared.billing.getPlans(params: .init(for: .organization))
+      let freeOrgFeatures = orgPlans.data.first { $0.slug == "free_org" }?.features.map(\.slug) ?? []
+      print("LIVE_HAS orgPlanSlugs=\(orgPlans.data.map(\.slug))")
+      print("LIVE_HAS freeOrgFeatures=\(freeOrgFeatures)")
+
+      let org = try await Clerk.shared.organizations.create(
+        name: "Has Org \(UUID().uuidString.prefix(8))"
+      )
+      createdOrg = org
+      try await Clerk.shared.auth.setActive(sessionId: session.id, organizationId: org.id)
+      _ = try await Clerk.shared.auth.getToken(.init(skipCache: true))
+      guard let orgSession = Clerk.shared.session else {
+        throw IntegrationSessionAuthorizationError.missingSession("after setActive")
+      }
+
+      let hasAdmin = orgSession.has(.init(role: "org:admin"))
+      let hasMembershipRead = orgSession.has(.init(permission: "org:sys_memberships:read"))
+      let orgFeatureSlug = freeOrgFeatures.first ?? "feature_one"
+      let hasOrgFeature = orgSession.has(.init(feature: "o:\(orgFeatureSlug)"))
+      print("LIVE_HAS orgRole admin=\(hasAdmin)")
+      print("LIVE_HAS orgPermission membershipsRead=\(hasMembershipRead)")
+      print("LIVE_HAS orgFeature o:\(orgFeatureSlug)=\(hasOrgFeature)")
+      if !freeOrgFeatures.isEmpty {
+        #expect(hasOrgFeature)
+      }
+
+      try await org.destroy()
+      createdOrg = nil
+    } catch {
+      capturedError = error
+    }
+
+    if let createdOrg {
+      _ = try? await createdOrg.destroy()
+    }
+    await deleteTestAccountIfExists(email: testEmail, allowPasswordCleanup: didCreateSignUp)
+
+    if let capturedError {
+      if try shouldSkipIntegrationTest(capturedError, keyName: keyName) {
+        return
+      }
+      throw capturedError
+    }
+  }
+
+  private static func makeUniqueTestEmail() -> String {
+    let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
+    return "test+clerk_test_\(suffix)@example.com"
+  }
+
+  private func deleteTestAccountIfExists(email: String, allowPasswordCleanup: Bool) async {
+    do {
+      if let currentUser = Clerk.shared.user {
+        try await currentUser.delete()
+        return
+      }
+      guard allowPasswordCleanup else {
+        return
+      }
+      _ = try await Clerk.shared.auth.signInWithPassword(identifier: email, password: Self.testPassword)
+      try await Clerk.shared.user?.delete()
+    } catch {
+      // Best-effort cleanup. Some failure paths may not produce a deletable account.
+    }
+  }
+}
+
+private enum IntegrationSessionAuthorizationError: LocalizedError {
+  case missingSession(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .missingSession(let when):
+      "session missing \(when)"
+    }
+  }
+}


### PR DESCRIPTION
## Why

`Session.has` trusted any snapshot JWT. A token for another organization could authorize `fea`/`pla`, and `factorVerificationAge` stayed the Client snapshot after later token mints.

`has()` now reads feature, plan, and `fva` only from a snapshot token whose `sid` and org match this session. Token `fva` ages by `iat` so Strict fails after ten minutes without a Client refresh.

This is the iOS follow-up to the review on [clerk-android#921](https://github.com/clerk/clerk-android/pull/921). iOS `setActive` does not keep the previous `lastActiveToken`. It replaces the session from the network and clears the cache. The snapshot-match and `fva` aging holes still existed.

## Scope

- `SessionAuthorization.evaluate(session:)` picks a matching snapshot token or fails closed for `fea`/`pla`
- `TokenResource.factorVerificationAgeClaim` reads JWT `fva`
- Token `fva` ages by whole minutes since `iat`. Session `factorVerificationAge` remains the fallback when the claim is missing
- `SessionTokensCache` is an actor, so sync `has()` does not read it

## Tradeoffs

I did not inject a fake clock. The Strict regression uses `iat` eleven minutes in the past.

I did not change `TokenFreshness.matches`. That helper still fails open on a malformed JWT for cache hydration. Authorization uses a fail-closed check.

## Blast radius

`has(feature:)` and `has(plan:)` return false when the snapshot token's session or org does not match. Reverification-only calls without a matching token still use the session snapshot.

## Verification

`swift test --skip Integration --no-parallel --filter SessionAuthorizationTests`

30 tests passed, including org-mismatch fail-closed and Strict after an 11-minute `iat`.
